### PR TITLE
fix(py): use user-facing client in tests instead of Rust-internal wrapper

### DIFF
--- a/sdks/py/alkahest_py/conftest.py
+++ b/sdks/py/alkahest_py/conftest.py
@@ -1,0 +1,57 @@
+"""
+Pytest fixtures for Alkahest Python SDK tests.
+
+These fixtures provide user-facing client instances that go through the same
+initialization path as what real users would experience, ensuring tests catch
+bugs in the actual SDK interface.
+"""
+
+import pytest
+from alkahest_py import AlkahestClient, EnvTestManager
+
+
+@pytest.fixture
+def env():
+    """
+    Create a test environment with Anvil chain, deployed contracts, and test accounts.
+
+    Returns:
+        EnvTestManager: Test environment with addresses, private keys, and mock tokens.
+    """
+    return EnvTestManager()
+
+
+@pytest.fixture
+def alice_client(env):
+    """
+    Create an AlkahestClient for Alice using the user-facing constructor.
+
+    This ensures tests exercise the same initialization path that real users hit,
+    catching any bugs in the Python SDK client construction.
+
+    Returns:
+        AlkahestClient: A fully initialized client for Alice's account.
+    """
+    return AlkahestClient(
+        private_key=env.alice_private_key,
+        rpc_url=env.rpc_url,
+        address_config=env.addresses,
+    )
+
+
+@pytest.fixture
+def bob_client(env):
+    """
+    Create an AlkahestClient for Bob using the user-facing constructor.
+
+    This ensures tests exercise the same initialization path that real users hit,
+    catching any bugs in the Python SDK client construction.
+
+    Returns:
+        AlkahestClient: A fully initialized client for Bob's account.
+    """
+    return AlkahestClient(
+        private_key=env.bob_private_key,
+        rpc_url=env.rpc_url,
+        address_config=env.addresses,
+    )

--- a/sdks/py/alkahest_py/erc1155/test_approve_all.py
+++ b/sdks/py/alkahest_py/erc1155/test_approve_all.py
@@ -2,7 +2,7 @@ import pytest
 from alkahest_py import EnvTestManager, MockERC1155
 
 @pytest.mark.asyncio
-async def test_approve_all():
+async def test_approve_all(env, alice_client):
     """
     Test ERC1155 approve_all functionality for both payment and escrow purposes.
     This corresponds to test_erc1155_approve_all() in main.rs
@@ -12,7 +12,6 @@ async def test_approve_all():
     2. Test approve_all for payment purpose and verify with isApprovedForAll
     3. Test approve_all for escrow purpose and verify with isApprovedForAll
     """
-    env = EnvTestManager()
     
     # Setup mock ERC1155 token
     mock_erc1155_a = MockERC1155(env.mock_addresses.erc1155_a, env.god_wallet_provider)
@@ -27,7 +26,7 @@ async def test_approve_all():
     
     # Test approve_all for payment
     print("Testing approve_all for payment purpose...")
-    await env.alice_client.erc1155.util.approve_all(env.mock_addresses.erc1155_a, "payment")
+    await alice_client.erc1155.util.approve_all(env.mock_addresses.erc1155_a, "payment")
     
     # Verify approval for payment obligation using isApprovedForAll
     payment_approved = mock_erc1155_a.is_approved_for_all(
@@ -41,7 +40,7 @@ async def test_approve_all():
     
     # Test approve_all for escrow
     print("Testing approve_all for escrow purpose...")
-    await env.alice_client.erc1155.util.approve_all(env.mock_addresses.erc1155_a, "escrow")
+    await alice_client.erc1155.util.approve_all(env.mock_addresses.erc1155_a, "escrow")
     
     # Verify approval for escrow obligation using isApprovedForAll
     escrow_approved = mock_erc1155_a.is_approved_for_all(

--- a/sdks/py/alkahest_py/erc1155/test_buy_bundle_with_erc1155.py
+++ b/sdks/py/alkahest_py/erc1155/test_buy_bundle_with_erc1155.py
@@ -2,7 +2,7 @@ import pytest
 from alkahest_py import EnvTestManager, MockERC1155
 
 @pytest.mark.asyncio
-async def test_buy_bundle_with_erc1155():
+async def test_buy_bundle_with_erc1155(env, alice_client):
     """
     Test using ERC1155 to buy token bundles.
     This corresponds to test_buy_bundle_with_erc1155() in main.rs
@@ -13,7 +13,6 @@ async def test_buy_bundle_with_erc1155():
     3. Alice creates purchase offer using ERC1155 to buy a token bundle
     4. Verify ERC1155 tokens are in escrow and attestation is created
     """
-    env = EnvTestManager()
     
     # Setup mock ERC1155 token
     mock_erc1155_a = MockERC1155(env.mock_addresses.erc1155_a, env.god_wallet_provider)
@@ -38,10 +37,10 @@ async def test_buy_bundle_with_erc1155():
     }
     
     # Alice approves tokens for escrow
-    await env.alice_client.erc1155.util.approve_all(env.mock_addresses.erc1155_a, "barter")
+    await alice_client.erc1155.util.approve_all(env.mock_addresses.erc1155_a, "barter")
     
     # Alice creates purchase offer
-    buy_result = await env.alice_client.erc1155.barter.buy_bundle_with_erc1155(bid_data, bundle_data, 0)
+    buy_result = await alice_client.erc1155.barter.buy_bundle_with_erc1155(bid_data, bundle_data, 0)
     
     assert buy_result['log']['uid'] and buy_result['log']['uid'] != "0x0000000000000000000000000000000000000000000000000000000000000000", "Invalid buy attestation UID"
     

--- a/sdks/py/alkahest_py/erc1155/test_buy_erc1155_for_erc1155.py
+++ b/sdks/py/alkahest_py/erc1155/test_buy_erc1155_for_erc1155.py
@@ -2,7 +2,7 @@ import pytest
 from alkahest_py import EnvTestManager, MockERC1155
 
 @pytest.mark.asyncio
-async def test_buy_erc1155_for_erc1155():
+async def test_buy_erc1155_for_erc1155(env, alice_client):
     """
     Test ERC1155 to ERC1155 exchange escrow creation.
     This corresponds to test_buy_erc1155_for_erc1155() in main.rs
@@ -13,7 +13,6 @@ async def test_buy_erc1155_for_erc1155():
     3. Alice creates escrow offering ERC1155A for ERC1155B
     4. Verify tokens are in escrow and attestation is created
     """
-    env = EnvTestManager()
     
     # Setup mock ERC1155 token
     mock_erc1155_a = MockERC1155(env.mock_addresses.erc1155_a, env.god_wallet_provider)
@@ -41,10 +40,10 @@ async def test_buy_erc1155_for_erc1155():
     }
     
     # Alice approves tokens for escrow
-    await env.alice_client.erc1155.util.approve_all(env.mock_addresses.erc1155_a, "barter")
+    await alice_client.erc1155.util.approve_all(env.mock_addresses.erc1155_a, "barter")
     
     # Alice creates escrow offering ERC1155A for ERC1155B
-    buy_result = await env.alice_client.erc1155.barter.buy_erc1155_for_erc1155(bid_data, ask_data, 0)
+    buy_result = await alice_client.erc1155.barter.buy_erc1155_for_erc1155(bid_data, ask_data, 0)
     
     assert buy_result['log']['uid'] and buy_result['log']['uid'] != "0x0000000000000000000000000000000000000000000000000000000000000000", "Invalid buy attestation UID"
     

--- a/sdks/py/alkahest_py/erc1155/test_buy_erc20_with_erc1155.py
+++ b/sdks/py/alkahest_py/erc1155/test_buy_erc20_with_erc1155.py
@@ -2,7 +2,7 @@ import pytest
 from alkahest_py import EnvTestManager, MockERC1155
 
 @pytest.mark.asyncio
-async def test_buy_erc20_with_erc1155():
+async def test_buy_erc20_with_erc1155(env, alice_client):
     """
     Test using ERC1155 to buy ERC20 tokens.
     This corresponds to test_buy_erc20_with_erc1155() in main.rs
@@ -13,7 +13,6 @@ async def test_buy_erc20_with_erc1155():
     3. Alice creates purchase offer using ERC1155 to buy ERC20
     4. Verify ERC1155 tokens are in escrow and attestation is created
     """
-    env = EnvTestManager()
     
     # Setup mock ERC1155 token
     mock_erc1155_a = MockERC1155(env.mock_addresses.erc1155_a, env.god_wallet_provider)
@@ -35,10 +34,10 @@ async def test_buy_erc20_with_erc1155():
     }
     
     # Alice approves tokens for escrow
-    await env.alice_client.erc1155.util.approve_all(env.mock_addresses.erc1155_a, "barter")
+    await alice_client.erc1155.util.approve_all(env.mock_addresses.erc1155_a, "barter")
     
     # Alice creates purchase offer
-    buy_result = await env.alice_client.erc1155.barter.buy_erc20_with_erc1155(bid_data, ask_data, 0)
+    buy_result = await alice_client.erc1155.barter.buy_erc20_with_erc1155(bid_data, ask_data, 0)
     
     assert buy_result['log']['uid'] and buy_result['log']['uid'] != "0x0000000000000000000000000000000000000000000000000000000000000000", "Invalid buy attestation UID"
     

--- a/sdks/py/alkahest_py/erc1155/test_buy_erc721_with_erc1155.py
+++ b/sdks/py/alkahest_py/erc1155/test_buy_erc721_with_erc1155.py
@@ -2,7 +2,7 @@ import pytest
 from alkahest_py import EnvTestManager, MockERC1155
 
 @pytest.mark.asyncio
-async def test_buy_erc721_with_erc1155():
+async def test_buy_erc721_with_erc1155(env, alice_client):
     """
     Test using ERC1155 to buy ERC721 tokens.
     This corresponds to test_buy_erc721_with_erc1155() in main.rs
@@ -13,7 +13,6 @@ async def test_buy_erc721_with_erc1155():
     3. Alice creates purchase offer using ERC1155 to buy ERC721
     4. Verify ERC1155 tokens are in escrow and attestation is created
     """
-    env = EnvTestManager()
     
     # Setup mock ERC1155 token
     mock_erc1155_a = MockERC1155(env.mock_addresses.erc1155_a, env.god_wallet_provider)
@@ -35,10 +34,10 @@ async def test_buy_erc721_with_erc1155():
     }
     
     # Alice approves tokens for escrow
-    await env.alice_client.erc1155.util.approve_all(env.mock_addresses.erc1155_a, "barter")
+    await alice_client.erc1155.util.approve_all(env.mock_addresses.erc1155_a, "barter")
     
     # Alice creates purchase offer
-    buy_result = await env.alice_client.erc1155.barter.buy_erc721_with_erc1155(bid_data, ask_data, 0)
+    buy_result = await alice_client.erc1155.barter.buy_erc721_with_erc1155(bid_data, ask_data, 0)
     
     assert buy_result['log']['uid'] and buy_result['log']['uid'] != "0x0000000000000000000000000000000000000000000000000000000000000000", "Invalid buy attestation UID"
     

--- a/sdks/py/alkahest_py/erc1155/test_buy_with_erc1155.py
+++ b/sdks/py/alkahest_py/erc1155/test_buy_with_erc1155.py
@@ -2,7 +2,7 @@ import pytest
 from alkahest_py import EnvTestManager, MockERC1155
 
 @pytest.mark.asyncio
-async def test_buy_with_erc1155():
+async def test_buy_with_erc1155(env, alice_client):
     """
     Test ERC1155 buy_with_erc1155 functionality with custom arbiter data.
     This corresponds to test_buy_with_erc1155() in main.rs
@@ -13,7 +13,6 @@ async def test_buy_with_erc1155():
     3. Alice creates escrow with custom demand using buy_with_erc1155
     4. Verify tokens are in escrow and attestation is created
     """
-    env = EnvTestManager()
     
     # Setup mock ERC1155 token
     mock_erc1155_a = MockERC1155(env.mock_addresses.erc1155_a, env.god_wallet_provider)
@@ -40,10 +39,10 @@ async def test_buy_with_erc1155():
     }
     
     # Alice approves tokens for escrow
-    await env.alice_client.erc1155.util.approve_all(env.mock_addresses.erc1155_a, "escrow")
+    await alice_client.erc1155.util.approve_all(env.mock_addresses.erc1155_a, "escrow")
     
     # Alice creates escrow with custom demand
-    buy_result = await env.alice_client.erc1155.escrow.non_tierable.create(price_data, arbiter_data, 0)
+    buy_result = await alice_client.erc1155.escrow.non_tierable.create(price_data, arbiter_data, 0)
     
     assert buy_result['log']['uid'] and buy_result['log']['uid'] != "0x0000000000000000000000000000000000000000000000000000000000000000", "Invalid buy attestation UID"
     

--- a/sdks/py/alkahest_py/erc1155/test_pay_erc1155_for_erc1155.py
+++ b/sdks/py/alkahest_py/erc1155/test_pay_erc1155_for_erc1155.py
@@ -2,7 +2,7 @@ import pytest
 from alkahest_py import EnvTestManager, MockERC1155
 
 @pytest.mark.asyncio
-async def test_pay_erc1155_for_erc1155():
+async def test_pay_erc1155_for_erc1155(env, alice_client, bob_client):
     """
     Test ERC1155 to ERC1155 exchange fulfillment.
     This corresponds to test_pay_erc1155_for_erc1155() in main.rs
@@ -13,7 +13,6 @@ async def test_pay_erc1155_for_erc1155():
     3. Bob fulfills the escrow with his ERC1155B tokens
     4. Verify both parties received their tokens
     """
-    env = EnvTestManager()
     
     # Setup mock ERC1155 tokens
     mock_erc1155_a = MockERC1155(env.mock_addresses.erc1155_a, env.god_wallet_provider)
@@ -39,20 +38,20 @@ async def test_pay_erc1155_for_erc1155():
     }
     
     # Alice approves tokens for escrow and creates buy attestation
-    await env.alice_client.erc1155.util.approve_all(env.mock_addresses.erc1155_a, "barter")
+    await alice_client.erc1155.util.approve_all(env.mock_addresses.erc1155_a, "barter")
 
-    buy_result = await env.alice_client.erc1155.barter.buy_erc1155_for_erc1155(bid_data, ask_data, 0)
+    buy_result = await alice_client.erc1155.barter.buy_erc1155_for_erc1155(bid_data, ask_data, 0)
     buy_attestation_uid = buy_result['log']['uid']
     
     # Bob approves tokens for payment
-    await env.bob_client.erc1155.util.approve_all(env.mock_addresses.erc1155_b, "barter")
+    await bob_client.erc1155.util.approve_all(env.mock_addresses.erc1155_b, "barter")
 
     # Check initial balances
     initial_alice_balance_b = mock_erc1155_b.balance_of(env.alice, 2)
     initial_bob_balance_a = mock_erc1155_a.balance_of(env.bob, 1)
     
     # Bob fulfills the buy attestation
-    pay_result = await env.bob_client.erc1155.barter.pay_erc1155_for_erc1155(buy_attestation_uid)
+    pay_result = await bob_client.erc1155.barter.pay_erc1155_for_erc1155(buy_attestation_uid)
 
     assert pay_result['log']['uid'] and pay_result['log']['uid'] != "0x0000000000000000000000000000000000000000000000000000000000000000", "Invalid payment attestation UID"
     

--- a/sdks/py/alkahest_py/erc1155/test_pay_erc1155_for_erc20.py
+++ b/sdks/py/alkahest_py/erc1155/test_pay_erc1155_for_erc20.py
@@ -2,7 +2,7 @@ import pytest
 from alkahest_py import EnvTestManager, MockERC1155, MockERC20
 
 @pytest.mark.asyncio
-async def test_pay_erc1155_for_erc20():
+async def test_pay_erc1155_for_erc20(env, alice_client, bob_client):
     """
     Test using ERC1155 to fulfill ERC20 escrow.
     This corresponds to test_pay_erc1155_for_erc20() in main.rs
@@ -13,7 +13,6 @@ async def test_pay_erc1155_for_erc20():
     3. Alice fulfills the escrow with her ERC1155 tokens
     4. Verify both parties received their tokens
     """
-    env = EnvTestManager()
     
     # Setup mock tokens
     mock_erc1155_a = MockERC1155(env.mock_addresses.erc1155_a, env.god_wallet_provider)
@@ -41,20 +40,20 @@ async def test_pay_erc1155_for_erc20():
     }
     
     # Bob approves tokens for escrow and creates buy attestation
-    await env.bob_client.erc20.util.approve(bid_data, "barter")
+    await bob_client.erc20.util.approve(bid_data, "barter")
 
-    buy_result = await env.bob_client.erc20.barter.buy_erc1155_for_erc20(bid_data, ask_data, 0)
+    buy_result = await bob_client.erc20.barter.buy_erc1155_for_erc20(bid_data, ask_data, 0)
     buy_attestation_uid = buy_result['log']['uid']
     
     # Alice approves her ERC1155 tokens for payment
-    await env.alice_client.erc1155.util.approve_all(env.mock_addresses.erc1155_a, "barter")
+    await alice_client.erc1155.util.approve_all(env.mock_addresses.erc1155_a, "barter")
     
     # Check initial balances
     initial_alice_erc20_balance = mock_erc20_a.balance_of(env.alice)
     initial_bob_erc1155_balance = mock_erc1155_a.balance_of(env.bob, 1)
     
     # Alice fulfills Bob's buy attestation with her ERC1155
-    pay_result = await env.alice_client.erc1155.barter.pay_erc1155_for_erc20(buy_attestation_uid)
+    pay_result = await alice_client.erc1155.barter.pay_erc1155_for_erc20(buy_attestation_uid)
     
     assert pay_result['log']['uid'] and pay_result['log']['uid'] != "0x0000000000000000000000000000000000000000000000000000000000000000", "Invalid payment attestation UID"
     

--- a/sdks/py/alkahest_py/erc1155/test_pay_erc1155_for_erc721.py
+++ b/sdks/py/alkahest_py/erc1155/test_pay_erc1155_for_erc721.py
@@ -2,7 +2,7 @@ import pytest
 from alkahest_py import EnvTestManager, MockERC1155, MockERC721
 
 @pytest.mark.asyncio
-async def test_pay_erc1155_for_erc721():
+async def test_pay_erc1155_for_erc721(env, alice_client, bob_client):
     """
     Test using ERC1155 to fulfill ERC721 escrow.
     This corresponds to test_pay_erc1155_for_erc721() in main.rs
@@ -13,7 +13,6 @@ async def test_pay_erc1155_for_erc721():
     3. Alice fulfills the escrow with her ERC1155 tokens
     4. Verify both parties received their tokens
     """
-    env = EnvTestManager()
     
     # Setup mock tokens
     mock_erc1155_a = MockERC1155(env.mock_addresses.erc1155_a, env.god_wallet_provider)
@@ -40,19 +39,19 @@ async def test_pay_erc1155_for_erc721():
     }
     
     # Bob approves tokens for escrow and creates buy attestation
-    await env.bob_client.erc721.util.approve(bid_data, "barter")
+    await bob_client.erc721.util.approve(bid_data, "barter")
 
-    buy_result = await env.bob_client.erc721.barter.buy_erc1155_with_erc721(bid_data, ask_data, 0)
+    buy_result = await bob_client.erc721.barter.buy_erc1155_with_erc721(bid_data, ask_data, 0)
     buy_attestation_uid = buy_result['log']['uid']
     
     # Alice approves her ERC1155 tokens for payment
-    await env.alice_client.erc1155.util.approve_all(env.mock_addresses.erc1155_a, "barter")
+    await alice_client.erc1155.util.approve_all(env.mock_addresses.erc1155_a, "barter")
     
     # Check initial ERC1155 balance for Bob
     initial_bob_erc1155_balance = mock_erc1155_a.balance_of(env.bob, 1)
     
     # Alice fulfills Bob's buy attestation with her ERC1155
-    pay_result = await env.alice_client.erc1155.barter.pay_erc1155_for_erc721(buy_attestation_uid)
+    pay_result = await alice_client.erc1155.barter.pay_erc1155_for_erc721(buy_attestation_uid)
     
     assert pay_result['log']['uid'] and pay_result['log']['uid'] != "0x0000000000000000000000000000000000000000000000000000000000000000", "Invalid payment attestation UID"
     

--- a/sdks/py/alkahest_py/erc1155/test_pay_with_erc1155.py
+++ b/sdks/py/alkahest_py/erc1155/test_pay_with_erc1155.py
@@ -2,7 +2,7 @@ import pytest
 from alkahest_py import EnvTestManager, MockERC1155
 
 @pytest.mark.asyncio
-async def test_pay_with_erc1155():
+async def test_pay_with_erc1155(env, alice_client):
     """
     Test ERC1155 pay_with_erc1155 functionality for direct payments.
     This corresponds to test_pay_with_erc1155() in main.rs
@@ -13,7 +13,6 @@ async def test_pay_with_erc1155():
     3. Alice makes direct payment to Bob using pay_with_erc1155
     4. Verify tokens transferred to Bob and payment attestation created
     """
-    env = EnvTestManager()
     
     # Setup mock ERC1155 token
     mock_erc1155_a = MockERC1155(env.mock_addresses.erc1155_a, env.god_wallet_provider)
@@ -34,13 +33,13 @@ async def test_pay_with_erc1155():
     }
     
     # Alice approves tokens for payment
-    await env.alice_client.erc1155.util.approve_all(env.mock_addresses.erc1155_a, "payment")
+    await alice_client.erc1155.util.approve_all(env.mock_addresses.erc1155_a, "payment")
     
     # Check initial Bob balance
     initial_bob_balance = mock_erc1155_a.balance_of(env.bob, 1)
     
     # Alice makes direct payment to Bob
-    pay_result = await env.alice_client.erc1155.payment.pay(price_data, env.bob)
+    pay_result = await alice_client.erc1155.payment.pay(price_data, env.bob)
 
     assert pay_result['log']['uid'] and pay_result['log']['uid'] != "0x0000000000000000000000000000000000000000000000000000000000000000", "Invalid payment attestation UID"
     

--- a/sdks/py/alkahest_py/erc1155/test_revoke_all.py
+++ b/sdks/py/alkahest_py/erc1155/test_revoke_all.py
@@ -2,7 +2,7 @@ import pytest
 from alkahest_py import EnvTestManager, MockERC1155
 
 @pytest.mark.asyncio
-async def test_revoke_all():
+async def test_revoke_all(env, alice_client):
     """
     Test ERC1155 revoke_all functionality for payment purpose.
     This corresponds to test_erc1155_revoke_all() in main.rs
@@ -13,7 +13,6 @@ async def test_revoke_all():
     3. Then revoke_all for payment purpose
     4. Verify that approval has been revoked using isApprovedForAll
     """
-    env = EnvTestManager()
     
     # Setup mock ERC1155 token
     mock_erc1155_a = MockERC1155(env.mock_addresses.erc1155_a, env.god_wallet_provider)
@@ -28,7 +27,7 @@ async def test_revoke_all():
     
     # First approve_all for payment
     print("Setting approve_all for payment purpose...")
-    await env.alice_client.erc1155.util.approve_all(env.mock_addresses.erc1155_a, "payment")
+    await alice_client.erc1155.util.approve_all(env.mock_addresses.erc1155_a, "payment")
     
     # Verify approval was set
     payment_approved_before = mock_erc1155_a.is_approved_for_all(
@@ -42,7 +41,7 @@ async def test_revoke_all():
     
     # Then revoke_all for payment
     print("Revoking all approvals for payment purpose...")
-    await env.alice_client.erc1155.util.revoke_all(env.mock_addresses.erc1155_a, "payment")
+    await alice_client.erc1155.util.revoke_all(env.mock_addresses.erc1155_a, "payment")
     
     # Verify revocation
     payment_approved_after = mock_erc1155_a.is_approved_for_all(

--- a/sdks/py/alkahest_py/erc20/test_approval.py
+++ b/sdks/py/alkahest_py/erc20/test_approval.py
@@ -1,28 +1,33 @@
 import pytest
-from alkahest_py import EnvTestManager, MockERC20
+from alkahest_py import AlkahestClient, EnvTestManager, MockERC20
+
 
 @pytest.mark.asyncio
-async def test_approvals():
+async def test_approvals(env, alice_client):
     # Test payment approval
-    env1 = EnvTestManager()
-    mock_erc20_1 = MockERC20(env1.mock_addresses.erc20_a, env1.god_wallet_provider)
-    
-    mock_erc20_1.transfer(env1.alice, 100)
-    
-    token_data = {"address": env1.mock_addresses.erc20_a, "value": 100}
-    receipt_hash = await env1.alice_client.erc20.util.approve(token_data, "payment")
-    
-    payment_allowance = mock_erc20_1.allowance(env1.alice, env1.addresses.erc20_addresses.payment_obligation)
+    mock_erc20_1 = MockERC20(env.mock_addresses.erc20_a, env.god_wallet_provider)
+
+    mock_erc20_1.transfer(env.alice, 100)
+
+    token_data = {"address": env.mock_addresses.erc20_a, "value": 100}
+    receipt_hash = await alice_client.erc20.util.approve(token_data, "payment")
+
+    payment_allowance = mock_erc20_1.allowance(env.alice, env.addresses.erc20_addresses.payment_obligation)
     assert payment_allowance == 100, "Payment approval failed"
 
-    # Test escrow approval
+    # Test escrow approval - create a new env and client for independent test
     env2 = EnvTestManager()
+    alice_client_2 = AlkahestClient(
+        private_key=env2.alice_private_key,
+        rpc_url=env2.rpc_url,
+        address_config=env2.addresses,
+    )
     mock_erc20_2 = MockERC20(env2.mock_addresses.erc20_a, env2.god_wallet_provider)
-    
+
     mock_erc20_2.transfer(env2.alice, 100)
-    
+
     token_data = {"address": env2.mock_addresses.erc20_a, "value": 100}
-    receipt_hash = await env2.alice_client.erc20.util.approve(token_data, "escrow")
+    receipt_hash = await alice_client_2.erc20.util.approve(token_data, "escrow")
 
     escrow_allowance = mock_erc20_2.allowance(env2.alice, env2.addresses.erc20_addresses.escrow_obligation_nontierable)
     assert escrow_allowance == 100, "Escrow approval failed"

--- a/sdks/py/alkahest_py/erc20/test_approve_if_less.py
+++ b/sdks/py/alkahest_py/erc20/test_approve_if_less.py
@@ -3,35 +3,34 @@ from alkahest_py import EnvTestManager, MockERC20
 
 
 @pytest.mark.asyncio
-async def test_approve_if_less():
-    test = EnvTestManager()
-    mock_erc20_a = MockERC20(test.mock_addresses.erc20_a, test.god_wallet_provider)
-    
-    mock_erc20_a.transfer(test.alice, 1000)
-    alice_balance = mock_erc20_a.balance_of(test.alice)
-    
-    token = {"address": test.mock_addresses.erc20_a, "value": 100}
-    
+async def test_approve_if_less(env, alice_client):
+    mock_erc20_a = MockERC20(env.mock_addresses.erc20_a, env.god_wallet_provider)
+
+    mock_erc20_a.transfer(env.alice, 1000)
+    alice_balance = mock_erc20_a.balance_of(env.alice)
+
+    token = {"address": env.mock_addresses.erc20_a, "value": 100}
+
     # First approval should return receipt
-    receipt_opt = await test.alice_client.erc20.util.approve_if_less(token, "payment")
+    receipt_opt = await alice_client.erc20.util.approve_if_less(token, "payment")
     assert receipt_opt is not None, "First approval should return receipt"
-    
+
     payment_allowance = mock_erc20_a.allowance(
-        test.alice,
-        test.addresses.erc20_addresses.payment_obligation
+        env.alice,
+        env.addresses.erc20_addresses.payment_obligation
     )
-    
+
     # Second approval with same amount should return None (no need to approve again)
-    receipt_opt = await test.alice_client.erc20.util.approve_if_less(token, "payment")
+    receipt_opt = await alice_client.erc20.util.approve_if_less(token, "payment")
     assert receipt_opt is None, f"Second approval should return None, got: {receipt_opt}"
-    
+
     # Third approval with larger amount should return receipt
-    larger_token = {"address": test.mock_addresses.erc20_a, "value": 150}
-    receipt_opt = await test.alice_client.erc20.util.approve_if_less(larger_token, "payment")
+    larger_token = {"address": env.mock_addresses.erc20_a, "value": 150}
+    receipt_opt = await alice_client.erc20.util.approve_if_less(larger_token, "payment")
     assert receipt_opt is not None, "Third approval should return receipt for larger amount"
-    
+
     new_payment_allowance = mock_erc20_a.allowance(
-        test.alice,
-        test.addresses.erc20_addresses.payment_obligation
+        env.alice,
+        env.addresses.erc20_addresses.payment_obligation
     )
     assert new_payment_allowance >= 150, f"New allowance {new_payment_allowance} is insufficient for 150"

--- a/sdks/py/alkahest_py/erc20/test_buy_bundle_for_erc20.py
+++ b/sdks/py/alkahest_py/erc20/test_buy_bundle_for_erc20.py
@@ -2,12 +2,11 @@ import pytest
 from alkahest_py import EnvTestManager, MockERC20
 
 @pytest.mark.asyncio
-async def test_buy_bundle_for_erc20():
+async def test_buy_bundle_for_erc20(env, alice_client):
     """
     Test buying a token bundle with ERC20 tokens.
     This corresponds to test_buy_bundle_for_erc20() in main.rs
     """
-    env = EnvTestManager()
     
     # Setup mock ERC20 token  
     mock_erc20 = MockERC20(env.mock_addresses.erc20_a, env.god_wallet_provider)
@@ -31,10 +30,10 @@ async def test_buy_bundle_for_erc20():
     }
     
     # Alice approves tokens for escrow
-    await env.alice_client.erc20.util.approve(bid_data, "barter")
+    await alice_client.erc20.util.approve(bid_data, "barter")
     
     # Alice creates the buy order for token bundle
-    buy_result = await env.alice_client.erc20.barter.buy_bundle_for_erc20(bid_data, bundle_data, 0)
+    buy_result = await alice_client.erc20.barter.buy_bundle_for_erc20(bid_data, bundle_data, 0)
     
     assert buy_result['log']['uid'] and buy_result['log']['uid'] != "0x0000000000000000000000000000000000000000000000000000000000000000", "Invalid buy attestation UID"
     

--- a/sdks/py/alkahest_py/erc20/test_buy_erc1155_for_erc20.py
+++ b/sdks/py/alkahest_py/erc20/test_buy_erc1155_for_erc20.py
@@ -2,12 +2,11 @@ import pytest
 from alkahest_py import EnvTestManager, MockERC20
 
 @pytest.mark.asyncio
-async def test_buy_erc1155_for_erc20():
+async def test_buy_erc1155_for_erc20(env, alice_client):
     """
     Test buying ERC1155 tokens with ERC20 tokens.
     This corresponds to test_buy_erc1155_for_erc20() in main.rs
     """
-    env = EnvTestManager()
     
     # Setup mock ERC20 token  
     mock_erc20 = MockERC20(env.mock_addresses.erc20_a, env.god_wallet_provider)
@@ -24,10 +23,10 @@ async def test_buy_erc1155_for_erc20():
     ask_data = {"address": env.mock_addresses.erc1155_a, "id": 1, "value": 10}  # Alice wants ERC1155 ID 1, amount 10
     
     # Alice approves tokens for escrow
-    await env.alice_client.erc20.util.approve(bid_data, "barter")
+    await alice_client.erc20.util.approve(bid_data, "barter")
 
     # Alice creates the buy order for ERC1155
-    buy_result = await env.alice_client.erc20.barter.buy_erc1155_for_erc20(bid_data, ask_data, 0)
+    buy_result = await alice_client.erc20.barter.buy_erc1155_for_erc20(bid_data, ask_data, 0)
     
     assert buy_result['log']['uid'] and buy_result['log']['uid'] != "0x0000000000000000000000000000000000000000000000000000000000000000", "Invalid buy attestation UID"
     

--- a/sdks/py/alkahest_py/erc20/test_buy_erc20_for_erc20.py
+++ b/sdks/py/alkahest_py/erc20/test_buy_erc20_for_erc20.py
@@ -2,8 +2,7 @@ import pytest
 from alkahest_py import EnvTestManager, MockERC20
 
 @pytest.mark.asyncio
-async def test_buy_erc20_for_erc20():
-    env = EnvTestManager()
+async def test_buy_erc20_for_erc20(env, alice_client):
     mock_erc20_a = MockERC20(env.mock_addresses.erc20_a, env.god_wallet_provider)
     
     transfer_amount = 100
@@ -15,7 +14,7 @@ async def test_buy_erc20_for_erc20():
     bid_amount = 100
     bid_data = {"address": env.mock_addresses.erc20_a, "value": bid_amount}
     
-    await env.alice_client.erc20.util.approve(bid_data, "barter")
+    await alice_client.erc20.util.approve(bid_data, "barter")
 
     barter_allowance = mock_erc20_a.allowance(env.alice, env.addresses.erc20_addresses.barter_utils)
     assert barter_allowance >= bid_amount, "Insufficient allowance. Expected >= {bid_amount}, got {barter_allowance}"
@@ -24,7 +23,7 @@ async def test_buy_erc20_for_erc20():
     ask_data = {"address": env.mock_addresses.erc20_b, "value": ask_amount}
     expiration = 0
     
-    escrow_result = await env.alice_client.erc20.barter.buy_erc20_for_erc20(bid_data, ask_data, expiration)
+    escrow_result = await alice_client.erc20.barter.buy_erc20_for_erc20(bid_data, ask_data, expiration)
     
     alice_final_a = mock_erc20_a.balance_of(env.alice)
     escrow_balance_a = mock_erc20_a.balance_of(env.addresses.erc20_addresses.escrow_obligation_nontierable)

--- a/sdks/py/alkahest_py/erc20/test_buy_erc721_for_erc20.py
+++ b/sdks/py/alkahest_py/erc20/test_buy_erc721_for_erc20.py
@@ -2,8 +2,7 @@ import pytest
 from alkahest_py import EnvTestManager, MockERC20
 
 @pytest.mark.asyncio
-async def test_buy_erc721_for_erc20():
-    env = EnvTestManager()
+async def test_buy_erc721_for_erc20(env, alice_client):
     
     # Setup mock ERC20 token
     mock_erc20 = MockERC20(env.mock_addresses.erc20_a, env.god_wallet_provider)
@@ -21,10 +20,10 @@ async def test_buy_erc721_for_erc20():
     ask_data = {"address": env.mock_addresses.erc721_a, "id": 1}  # Alice wants NFT ID 1
     
     # Alice approves tokens for escrow
-    await env.alice_client.erc20.util.approve(bid_data, "barter")
+    await alice_client.erc20.util.approve(bid_data, "barter")
     
     # Alice creates the buy order for ERC721
-    buy_result = await env.alice_client.erc20.barter.buy_erc721_for_erc20(bid_data, ask_data, 0)
+    buy_result = await alice_client.erc20.barter.buy_erc721_for_erc20(bid_data, ask_data, 0)
     
     assert buy_result['log']['uid'] and buy_result['log']['uid'] != "0x0000000000000000000000000000000000000000000000000000000000000000", "Invalid buy attestation UID"
     

--- a/sdks/py/alkahest_py/erc20/test_buy_with_erc20.py
+++ b/sdks/py/alkahest_py/erc20/test_buy_with_erc20.py
@@ -2,8 +2,7 @@ import pytest
 from alkahest_py import EnvTestManager, MockERC20
 
 @pytest.mark.asyncio
-async def test_buy_with_erc20():
-    env = EnvTestManager()
+async def test_buy_with_erc20(env, alice_client):
     mock_erc20 = MockERC20(env.mock_addresses.erc20_a, env.god_wallet_provider)
     alice_initial = mock_erc20.balance_of(env.alice)
 
@@ -20,7 +19,7 @@ async def test_buy_with_erc20():
     "value": 100
     }
     
-    await env.alice_client.erc20.util.approve(price_data, "escrow")
+    await alice_client.erc20.util.approve(price_data, "escrow")
 
     arbiter_data = {
     "arbiter": env.addresses.erc20_addresses.payment_obligation,
@@ -28,7 +27,7 @@ async def test_buy_with_erc20():
     }
     expiration = 0
 
-    result = await env.alice_client.erc20.escrow.non_tierable.create(
+    result = await alice_client.erc20.escrow.non_tierable.create(
     price_data, arbiter_data, expiration
     )
     

--- a/sdks/py/alkahest_py/erc20/test_pay_erc20_for_erc20.py
+++ b/sdks/py/alkahest_py/erc20/test_pay_erc20_for_erc20.py
@@ -2,8 +2,7 @@ import pytest
 from alkahest_py import EnvTestManager, MockERC20
 
 @pytest.mark.asyncio
-async def test_pay_erc20_for_erc20():
-    env = EnvTestManager()
+async def test_pay_erc20_for_erc20(env, alice_client, bob_client):
     
     # Setup mock ERC20 tokens
     mock_erc20_a = MockERC20(env.mock_addresses.erc20_a, env.god_wallet_provider)
@@ -28,10 +27,10 @@ async def test_pay_erc20_for_erc20():
     ask_data = {"address": env.mock_addresses.erc20_b, "value": 200}  # Alice wants token B
     
     # Alice approves tokens for escrow
-    await env.alice_client.erc20.util.approve(bid_data, "barter")
+    await alice_client.erc20.util.approve(bid_data, "barter")
     
     # Alice creates the buy order
-    buy_result = await env.alice_client.erc20.barter.buy_erc20_for_erc20(bid_data, ask_data, 0)
+    buy_result = await alice_client.erc20.barter.buy_erc20_for_erc20(bid_data, ask_data, 0)
 
     assert buy_result['log']['uid'] and buy_result['log']['uid'] != "0x0000000000000000000000000000000000000000000000000000000000000000", "Invalid buy attestation UID"
     
@@ -46,10 +45,10 @@ async def test_pay_erc20_for_erc20():
     assert escrow_balance_a == 100, "Escrow should have 100 token A, got {escrow_balance_a}"
     
     # Bob approves tokens for barter (pay_erc20_for_erc20 is a barter function)
-    await env.bob_client.erc20.util.approve(ask_data, "barter")
+    await bob_client.erc20.util.approve(ask_data, "barter")
 
     # Bob fulfills the buy order
-    pay_result = await env.bob_client.erc20.barter.pay_erc20_for_erc20(buy_attestation_uid)
+    pay_result = await bob_client.erc20.barter.pay_erc20_for_erc20(buy_attestation_uid)
 
     assert pay_result['log']['uid'] and pay_result['log']['uid'] != "0x0000000000000000000000000000000000000000000000000000000000000000", "Invalid payment attestation UID"
     

--- a/sdks/py/alkahest_py/erc20/test_pay_erc20_for_erc721.py
+++ b/sdks/py/alkahest_py/erc20/test_pay_erc20_for_erc721.py
@@ -2,14 +2,13 @@ import pytest
 from alkahest_py import EnvTestManager, MockERC20, MockERC721
 
 @pytest.mark.asyncio
-async def test_pay_erc20_for_erc721():
+async def test_pay_erc20_for_erc721(env, alice_client, bob_client):
     """
     Test paying ERC20 tokens to fulfill an ERC721 escrow.
     This corresponds to test_pay_erc20_for_erc721() in main.rs
     
     Flow: Bob escrows ERC721, Alice pays ERC20 to get the ERC721
     """
-    env = EnvTestManager()
     
     # Setup mock tokens
     mock_erc20_a = MockERC20(env.mock_addresses.erc20_a, env.god_wallet_provider)
@@ -40,11 +39,11 @@ async def test_pay_erc20_for_erc721():
     
     # Step 1: Bob approves his ERC721 for escrow
     erc721_data = {"address": env.mock_addresses.erc721_a, "id": erc721_token_id}
-    await env.bob_client.erc721.util.approve(erc721_data, "barter")
+    await bob_client.erc721.util.approve(erc721_data, "barter")
 
     # Step 2: Bob creates ERC721 escrow requesting ERC20
     erc20_data = {"address": env.mock_addresses.erc20_a, "value": erc20_amount}
-    buy_result = await env.bob_client.erc721.barter.buy_erc20_with_erc721(erc721_data, erc20_data, expiration)
+    buy_result = await bob_client.erc721.barter.buy_erc20_with_erc721(erc721_data, erc20_data, expiration)
 
     assert buy_result['log']['uid'] and buy_result['log']['uid'] != "0x0000000000000000000000000000000000000000000000000000000000000000", "Invalid buy attestation UID"
     
@@ -58,10 +57,10 @@ async def test_pay_erc20_for_erc721():
     initial_alice_erc20_balance = mock_erc20_a.balance_of(env.alice)
     
     # Step 3: Alice approves her ERC20 tokens for payment
-    await env.alice_client.erc20.util.approve(erc20_data, "barter")
+    await alice_client.erc20.util.approve(erc20_data, "barter")
     
     # Step 4: Alice fulfills Bob's escrow
-    pay_result = await env.alice_client.erc20.barter.pay_erc20_for_erc721(buy_attestation_uid)
+    pay_result = await alice_client.erc20.barter.pay_erc20_for_erc721(buy_attestation_uid)
     
     assert pay_result['log']['uid'] and pay_result['log']['uid'] != "0x0000000000000000000000000000000000000000000000000000000000000000", "Invalid payment attestation UID"
     

--- a/sdks/py/alkahest_py/erc20/test_pay_with_erc20.py
+++ b/sdks/py/alkahest_py/erc20/test_pay_with_erc20.py
@@ -2,8 +2,7 @@ import pytest
 from alkahest_py import EnvTestManager, MockERC20
 
 @pytest.mark.asyncio
-async def test_pay_with_erc20():
-    env = EnvTestManager()
+async def test_pay_with_erc20(env, alice_client):
     mock_erc20 = MockERC20(env.mock_addresses.erc20_a, env.god_wallet_provider)
     
     alice_initial = mock_erc20.balance_of(env.alice)
@@ -18,12 +17,12 @@ async def test_pay_with_erc20():
     payment_amount = 50
     price_data = {"address": env.mock_addresses.erc20_a, "value": payment_amount}
     
-    await env.alice_client.erc20.util.approve(price_data, "payment")
+    await alice_client.erc20.util.approve(price_data, "payment")
     
     payment_allowance = mock_erc20.allowance(env.alice, env.addresses.erc20_addresses.payment_obligation)
     assert payment_allowance >= payment_amount, "Insufficient allowance. Expected >= {payment_amount}, got {payment_allowance}"
 
-    payment_result = await env.alice_client.erc20.payment.pay(price_data, env.bob)
+    payment_result = await alice_client.erc20.payment.pay(price_data, env.bob)
     
     alice_final = mock_erc20.balance_of(env.alice)
     bob_final = mock_erc20.balance_of(env.bob)

--- a/sdks/py/alkahest_py/erc20/test_permit_and_buy_bundle_for_erc20.py
+++ b/sdks/py/alkahest_py/erc20/test_permit_and_buy_bundle_for_erc20.py
@@ -2,12 +2,11 @@ import pytest
 from alkahest_py import EnvTestManager, MockERC20
 
 @pytest.mark.asyncio
-async def test_permit_and_buy_bundle_for_erc20():
+async def test_permit_and_buy_bundle_for_erc20(env, alice_client):
     """
     Test buying a token bundle with ERC20 tokens using permit (no pre-approval needed).
     This corresponds to test_permit_and_buy_bundle_for_erc20() in main.rs
     """
-    env = EnvTestManager()
     
     # Setup mock ERC20 token  
     mock_erc20 = MockERC20(env.mock_addresses.erc20_a, env.god_wallet_provider)
@@ -32,7 +31,7 @@ async def test_permit_and_buy_bundle_for_erc20():
     }
     
     # Alice creates the buy order for token bundle with permit (no pre-approval needed)
-    buy_result = await env.alice_client.erc20.barter.permit_and_buy_bundle_for_erc20(bid_data, bundle_data, 0)
+    buy_result = await alice_client.erc20.barter.permit_and_buy_bundle_for_erc20(bid_data, bundle_data, 0)
     
     assert buy_result['log']['uid'] and buy_result['log']['uid'] != "0x0000000000000000000000000000000000000000000000000000000000000000", "Invalid buy attestation UID"
     

--- a/sdks/py/alkahest_py/erc20/test_permit_and_buy_erc1155_for_erc20.py
+++ b/sdks/py/alkahest_py/erc20/test_permit_and_buy_erc1155_for_erc20.py
@@ -2,12 +2,11 @@ import pytest
 from alkahest_py import EnvTestManager, MockERC20
 
 @pytest.mark.asyncio
-async def test_permit_and_buy_erc1155_for_erc20():
+async def test_permit_and_buy_erc1155_for_erc20(env, alice_client):
     """
     Test buying ERC1155 tokens with ERC20 tokens using permit (no pre-approval needed).
     This corresponds to test_permit_and_buy_erc1155_for_erc20() in main.rs
     """
-    env = EnvTestManager()
     
     # Setup mock ERC20 token  
     mock_erc20 = MockERC20(env.mock_addresses.erc20_a, env.god_wallet_provider)
@@ -25,7 +24,7 @@ async def test_permit_and_buy_erc1155_for_erc20():
     ask_data = {"address": env.mock_addresses.erc1155_a, "id": 1, "value": 10}  # Alice wants ERC1155 ID 1, amount 10
     
     # Alice creates the buy order for ERC1155 with permit (no pre-approval needed)
-    buy_result = await env.alice_client.erc20.barter.permit_and_buy_erc1155_for_erc20(bid_data, ask_data, 0)
+    buy_result = await alice_client.erc20.barter.permit_and_buy_erc1155_for_erc20(bid_data, ask_data, 0)
     
     assert buy_result['log']['uid'] and buy_result['log']['uid'] != "0x0000000000000000000000000000000000000000000000000000000000000000", "Invalid buy attestation UID"
     

--- a/sdks/py/alkahest_py/erc20/test_permit_and_buy_erc20_for_erc20.py
+++ b/sdks/py/alkahest_py/erc20/test_permit_and_buy_erc20_for_erc20.py
@@ -2,8 +2,7 @@ import pytest
 from alkahest_py import EnvTestManager, MockERC20
 
 @pytest.mark.asyncio
-async def test_permit_and_buy_erc20_for_erc20():
-    env = EnvTestManager()
+async def test_permit_and_buy_erc20_for_erc20(env, alice_client):
     mock_erc20_a = MockERC20(env.mock_addresses.erc20_a, env.god_wallet_provider)
     
     transfer_amount = 100
@@ -18,7 +17,7 @@ async def test_permit_and_buy_erc20_for_erc20():
     ask_data = {"address": env.mock_addresses.erc20_b, "value": ask_amount}
     expiration = 0
     
-    escrow_result = await env.alice_client.erc20.barter.permit_and_buy_erc20_for_erc20(bid_data, ask_data, expiration)
+    escrow_result = await alice_client.erc20.barter.permit_and_buy_erc20_for_erc20(bid_data, ask_data, expiration)
     
     alice_final_a = mock_erc20_a.balance_of(env.alice)
     escrow_balance_a = mock_erc20_a.balance_of(env.addresses.erc20_addresses.escrow_obligation_nontierable)

--- a/sdks/py/alkahest_py/erc20/test_permit_and_buy_erc721_for_erc20.py
+++ b/sdks/py/alkahest_py/erc20/test_permit_and_buy_erc721_for_erc20.py
@@ -2,12 +2,11 @@ import pytest
 from alkahest_py import EnvTestManager, MockERC20
 
 @pytest.mark.asyncio
-async def test_permit_and_buy_erc721_for_erc20():
+async def test_permit_and_buy_erc721_for_erc20(env, alice_client):
     """
     Test buying ERC721 tokens with ERC20 tokens using permit (no pre-approval needed).
     This corresponds to test_permit_and_buy_erc721_for_erc20() in main.rs
     """
-    env = EnvTestManager()
     
     # Setup mock ERC20 token  
     mock_erc20 = MockERC20(env.mock_addresses.erc20_a, env.god_wallet_provider)
@@ -25,7 +24,7 @@ async def test_permit_and_buy_erc721_for_erc20():
     ask_data = {"address": env.mock_addresses.erc721_a, "id": 1}  # Alice wants NFT ID 1
     
     # Alice creates the buy order for ERC721 with permit (no pre-approval needed)
-    buy_result = await env.alice_client.erc20.barter.permit_and_buy_erc721_for_erc20(bid_data, ask_data, 0)
+    buy_result = await alice_client.erc20.barter.permit_and_buy_erc721_for_erc20(bid_data, ask_data, 0)
     
     assert buy_result['log']['uid'] and buy_result['log']['uid'] != "0x0000000000000000000000000000000000000000000000000000000000000000", "Invalid buy attestation UID"
     

--- a/sdks/py/alkahest_py/erc20/test_permit_and_buy_with_erc20.py
+++ b/sdks/py/alkahest_py/erc20/test_permit_and_buy_with_erc20.py
@@ -3,8 +3,7 @@ import time
 from alkahest_py import EnvTestManager, MockERC20
 
 @pytest.mark.asyncio
-async def test_permit_and_buy_with_erc20():
-    env = EnvTestManager()
+async def test_permit_and_buy_with_erc20(env, alice_client):
     mock_erc20 = MockERC20(env.mock_addresses.erc20_a, env.god_wallet_provider)
     
     god_initial = mock_erc20.balance_of(env.god)
@@ -25,7 +24,7 @@ async def test_permit_and_buy_with_erc20():
     }
     expiration = int(time.time()) + 3600
     
-    result = await env.alice_client.erc20.escrow.non_tierable.permit_and_create(
+    result = await alice_client.erc20.escrow.non_tierable.permit_and_create(
     price_data, arbiter_data, expiration
     )
     

--- a/sdks/py/alkahest_py/erc20/test_permit_and_pay_erc20_for_bundle.py
+++ b/sdks/py/alkahest_py/erc20/test_permit_and_pay_erc20_for_bundle.py
@@ -2,14 +2,13 @@ import pytest
 from alkahest_py import EnvTestManager, MockERC20, ERC20PaymentObligationData
 
 @pytest.mark.asyncio
-async def test_permit_and_pay_erc20_for_bundle():
+async def test_permit_and_pay_erc20_for_bundle(env, alice_client, bob_client):
     """
     Test paying ERC20 tokens to fulfill a token bundle escrow using permit (no pre-approval needed).
     This corresponds to test_permit_and_pay_erc20_for_bundle() in main.rs
     
     Flow: Bob escrows a bundle (ERC20 + ERC721 + ERC1155), Alice pays ERC20 using permit to get the bundle
     """
-    env = EnvTestManager()
     
     # Setup mock tokens
     mock_erc20_a = MockERC20(env.mock_addresses.erc20_a, env.god_wallet_provider)  # Alice's payment token
@@ -52,7 +51,7 @@ async def test_permit_and_pay_erc20_for_bundle():
     }
     
     # Step 1: Bob approves his tokens for the bundle escrow
-    await env.bob_client.token_bundle.util.approve(bundle_data, "escrow")
+    await bob_client.token_bundle.util.approve(bundle_data, "escrow")
     
     # Step 2: Bob creates bundle escrow demanding ERC20 from Alice
     # Create proper ABI-encoded payment obligation data
@@ -70,7 +69,7 @@ async def test_permit_and_pay_erc20_for_bundle():
         "demand": demand_bytes
     }
     
-    buy_result = await env.bob_client.token_bundle.escrow.non_tierable.create(
+    buy_result = await bob_client.token_bundle.escrow.non_tierable.create(
         bundle_data, arbiter_data, expiration
     )
     
@@ -84,7 +83,7 @@ async def test_permit_and_pay_erc20_for_bundle():
     # initial_alice_erc1155_balance = mock_erc1155_a.balance_of(env.alice, erc1155_token_id)  # When available
     
     # Step 3: Alice fulfills Bob's bundle escrow using permit (no pre-approval needed)
-    pay_result = await env.alice_client.erc20.barter.permit_and_pay_erc20_for_bundle(buy_attestation_uid)
+    pay_result = await alice_client.erc20.barter.permit_and_pay_erc20_for_bundle(buy_attestation_uid)
     
     assert pay_result['log']['uid'] and pay_result['log']['uid'] != "0x0000000000000000000000000000000000000000000000000000000000000000", "Invalid payment attestation UID"
     

--- a/sdks/py/alkahest_py/erc20/test_permit_and_pay_erc20_for_erc1155.py
+++ b/sdks/py/alkahest_py/erc20/test_permit_and_pay_erc20_for_erc1155.py
@@ -2,7 +2,7 @@ import pytest
 from alkahest_py import EnvTestManager, MockERC20, MockERC1155
 
 @pytest.mark.asyncio
-async def test_permit_and_pay_erc20_for_erc1155():
+async def test_permit_and_pay_erc20_for_erc1155(env, alice_client, bob_client):
     """
     Test paying ERC20 tokens to fulfill an ERC1155 escrow using permit (no pre-approval needed).
     This corresponds to test_permit_and_pay_erc20_for_erc1155() in main.rs
@@ -15,7 +15,6 @@ async def test_permit_and_pay_erc20_for_erc1155():
     
     TO FIX: Export MockERC1155 in lib.rs and ensure it's available in the Python module.
     """
-    env = EnvTestManager()
     
     # Setup mock tokens
     mock_erc20_a = MockERC20(env.mock_addresses.erc20_a, env.god_wallet_provider)
@@ -48,12 +47,12 @@ async def test_permit_and_pay_erc20_for_erc1155():
     expiration = int(time.time()) + 3600  # 1 hour from now
     
     # Step 1: Bob approves his ERC1155 for escrow
-    await env.bob_client.erc1155.util.approve_all(env.mock_addresses.erc1155_a, "barter")
+    await bob_client.erc1155.util.approve_all(env.mock_addresses.erc1155_a, "barter")
     
     # Step 2: Bob creates ERC1155 escrow requesting ERC20
     erc1155_data = {"address": env.mock_addresses.erc1155_a, "id": token_id, "value": token_amount}
     erc20_data = {"address": env.mock_addresses.erc20_a, "value": erc20_amount}
-    buy_result = await env.bob_client.erc1155.barter.buy_erc20_with_erc1155(
+    buy_result = await bob_client.erc1155.barter.buy_erc20_with_erc1155(
         erc1155_data, erc20_data, expiration
     )
     
@@ -69,7 +68,7 @@ async def test_permit_and_pay_erc20_for_erc1155():
     initial_alice_erc20_balance = mock_erc20_a.balance_of(env.alice)
     
     # Step 3: Alice fulfills Bob's escrow using permit (no pre-approval needed)
-    pay_result = await env.alice_client.erc20.barter.permit_and_pay_erc20_for_erc1155(buy_attestation_uid)
+    pay_result = await alice_client.erc20.barter.permit_and_pay_erc20_for_erc1155(buy_attestation_uid)
     
     assert pay_result['log']['uid'] and pay_result['log']['uid'] != "0x0000000000000000000000000000000000000000000000000000000000000000", "Invalid payment attestation UID"
     

--- a/sdks/py/alkahest_py/erc20/test_permit_and_pay_erc20_for_erc20.py
+++ b/sdks/py/alkahest_py/erc20/test_permit_and_pay_erc20_for_erc20.py
@@ -3,8 +3,7 @@ import time
 from alkahest_py import EnvTestManager, MockERC20
 
 @pytest.mark.asyncio
-async def test_permit_and_pay_erc20_for_erc20():
-    env = EnvTestManager()
+async def test_permit_and_pay_erc20_for_erc20(env, alice_client, bob_client):
     
     # Setup mock ERC20 tokens
     mock_erc20_a = MockERC20(env.mock_addresses.erc20_a, env.god_wallet_provider)
@@ -29,10 +28,10 @@ async def test_permit_and_pay_erc20_for_erc20():
     ask_data = {"address": env.mock_addresses.erc20_b, "value": 200}  # Alice wants token B
     
     # Alice approves tokens for escrow (still needed for escrow creation)
-    await env.alice_client.erc20.util.approve(bid_data, "barter")
+    await alice_client.erc20.util.approve(bid_data, "barter")
     
     # Alice creates the buy order
-    buy_result = await env.alice_client.erc20.barter.buy_erc20_for_erc20(bid_data, ask_data, 0)
+    buy_result = await alice_client.erc20.barter.buy_erc20_for_erc20(bid_data, ask_data, 0)
     
     assert buy_result['log']['uid'] and buy_result['log']['uid'] != "0x0000000000000000000000000000000000000000000000000000000000000000", "Invalid buy attestation UID"
     
@@ -51,7 +50,7 @@ async def test_permit_and_pay_erc20_for_erc20():
     assert bob_allowance == 0, "Bob should have no allowance before permit, got {bob_allowance}"
     
     # Bob fulfills the buy order using permit (no pre-approval needed)
-    pay_result =await env.bob_client.erc20.barter.permit_and_pay_erc20_for_erc20(buy_attestation_uid)
+    pay_result =await bob_client.erc20.barter.permit_and_pay_erc20_for_erc20(buy_attestation_uid)
     
     assert pay_result['log']['uid'] and pay_result['log']['uid'] != "0x0000000000000000000000000000000000000000000000000000000000000000", "Invalid payment attestation UID"
     

--- a/sdks/py/alkahest_py/erc20/test_permit_and_pay_erc20_for_erc721.py
+++ b/sdks/py/alkahest_py/erc20/test_permit_and_pay_erc20_for_erc721.py
@@ -2,14 +2,13 @@ import pytest
 from alkahest_py import EnvTestManager, MockERC20, MockERC721
 
 @pytest.mark.asyncio
-async def test_permit_and_pay_erc20_for_erc721():
+async def test_permit_and_pay_erc20_for_erc721(env, alice_client, bob_client):
     """
     Test paying ERC20 tokens to fulfill an ERC721 escrow using permit (no pre-approval needed).
     This corresponds to test_permit_and_pay_erc20_for_erc721() in main.rs
     
     Flow: Bob escrows ERC721, Alice pays ERC20 using permit to get the ERC721
     """
-    env = EnvTestManager()
     
     # Setup mock tokens
     mock_erc20_a = MockERC20(env.mock_addresses.erc20_a, env.god_wallet_provider)
@@ -40,11 +39,11 @@ async def test_permit_and_pay_erc20_for_erc721():
     
     # Step 1: Bob approves his ERC721 for escrow
     erc721_data = {"address": env.mock_addresses.erc721_a, "id": erc721_token_id}
-    await env.bob_client.erc721.util.approve(erc721_data, "barter")
+    await bob_client.erc721.util.approve(erc721_data, "barter")
     
     # Step 2: Bob creates ERC721 escrow requesting ERC20
     erc20_data = {"address": env.mock_addresses.erc20_a, "value": erc20_amount}
-    buy_result = await env.bob_client.erc721.barter.buy_erc20_with_erc721(erc721_data, erc20_data, expiration)
+    buy_result = await bob_client.erc721.barter.buy_erc20_with_erc721(erc721_data, erc20_data, expiration)
 
     assert buy_result['log']['uid'] and buy_result['log']['uid'] != "0x0000000000000000000000000000000000000000000000000000000000000000", "Invalid buy attestation UID"
     
@@ -58,7 +57,7 @@ async def test_permit_and_pay_erc20_for_erc721():
     initial_alice_erc20_balance = mock_erc20_a.balance_of(env.alice)
     
     # Step 3: Alice fulfills Bob's escrow using permit (no pre-approval needed)
-    pay_result = await env.alice_client.erc20.barter.permit_and_pay_erc20_for_erc721(buy_attestation_uid)
+    pay_result = await alice_client.erc20.barter.permit_and_pay_erc20_for_erc721(buy_attestation_uid)
     
     assert pay_result['log']['uid'] and pay_result['log']['uid'] != "0x0000000000000000000000000000000000000000000000000000000000000000", "Invalid payment attestation UID"
     

--- a/sdks/py/alkahest_py/erc20/test_permit_and_pay_with_erc20.py
+++ b/sdks/py/alkahest_py/erc20/test_permit_and_pay_with_erc20.py
@@ -2,8 +2,7 @@ import pytest
 from alkahest_py import EnvTestManager, MockERC20
 
 @pytest.mark.asyncio
-async def test_permit_and_pay_with_erc20():
-    env = EnvTestManager()
+async def test_permit_and_pay_with_erc20(env, alice_client):
     mock_erc20 = MockERC20(env.mock_addresses.erc20_a, env.god_wallet_provider)
     
     alice_initial = mock_erc20.balance_of(env.alice)
@@ -18,7 +17,7 @@ async def test_permit_and_pay_with_erc20():
     payment_amount = 100
     price_data = {"address": env.mock_addresses.erc20_a, "value": payment_amount}
     
-    payment_result = await env.alice_client.erc20.payment.permit_and_pay(price_data, env.bob)
+    payment_result = await alice_client.erc20.payment.permit_and_pay(price_data, env.bob)
     
     alice_final = mock_erc20.balance_of(env.alice)
     bob_final = mock_erc20.balance_of(env.bob)

--- a/sdks/py/alkahest_py/erc20/test_permit_signature.py
+++ b/sdks/py/alkahest_py/erc20/test_permit_signature.py
@@ -2,14 +2,12 @@ import pytest
 import time
 from alkahest_py import EnvTestManager, MockERC20
 
-
 @pytest.mark.asyncio
-async def test_get_permit_deadline():
+async def test_get_permit_deadline(env, alice_client):
     """Test that get_permit_deadline returns a timestamp ~1 hour in the future"""
-    env = EnvTestManager()
     current_time = int(time.time())
     # Access static method via the util instance
-    deadline = type(env.alice_client.erc20.util).get_permit_deadline()
+    deadline = type(alice_client.erc20.util).get_permit_deadline()
 
     # Deadline should be approximately 1 hour (3600 seconds) in the future
     # Allow 10 seconds tolerance for test execution time
@@ -17,20 +15,18 @@ async def test_get_permit_deadline():
     assert abs(deadline - expected_deadline) < 10, f"Deadline {deadline} not within 10s of expected {expected_deadline}"
     print(f"Permit deadline: {deadline} (current: {current_time})")
 
-
 @pytest.mark.asyncio
-async def test_get_permit_signature():
+async def test_get_permit_signature(env, alice_client):
     """Test that get_permit_signature returns valid signature components"""
-    env = EnvTestManager()
     mock_erc20 = MockERC20(env.mock_addresses.erc20_a, env.god_wallet_provider)
     mock_erc20.transfer(env.alice, 1000)
 
     token_data = {"address": env.mock_addresses.erc20_a, "value": 100}
     spender = env.addresses.erc20_addresses.payment_obligation
-    deadline = type(env.alice_client.erc20.util).get_permit_deadline()
+    deadline = type(alice_client.erc20.util).get_permit_deadline()
 
     # Get permit signature
-    v, r, s = await env.alice_client.erc20.util.get_permit_signature(spender, token_data, deadline)
+    v, r, s = await alice_client.erc20.util.get_permit_signature(spender, token_data, deadline)
 
     # Verify signature components
     assert v in [27, 28], f"v should be 27 or 28, got {v}"
@@ -41,22 +37,20 @@ async def test_get_permit_signature():
 
     print(f"Permit signature: v={v}, r={r[:10]}..., s={s[:10]}...")
 
-
 @pytest.mark.asyncio
-async def test_permit_signature_different_amounts():
+async def test_permit_signature_different_amounts(env, alice_client):
     """Test that different amounts produce different signatures"""
-    env = EnvTestManager()
     mock_erc20 = MockERC20(env.mock_addresses.erc20_a, env.god_wallet_provider)
     mock_erc20.transfer(env.alice, 1000)
 
     spender = env.addresses.erc20_addresses.payment_obligation
-    deadline = type(env.alice_client.erc20.util).get_permit_deadline()
+    deadline = type(alice_client.erc20.util).get_permit_deadline()
 
     token_data_100 = {"address": env.mock_addresses.erc20_a, "value": 100}
     token_data_200 = {"address": env.mock_addresses.erc20_a, "value": 200}
 
-    v1, r1, s1 = await env.alice_client.erc20.util.get_permit_signature(spender, token_data_100, deadline)
-    v2, r2, s2 = await env.alice_client.erc20.util.get_permit_signature(spender, token_data_200, deadline)
+    v1, r1, s1 = await alice_client.erc20.util.get_permit_signature(spender, token_data_100, deadline)
+    v2, r2, s2 = await alice_client.erc20.util.get_permit_signature(spender, token_data_200, deadline)
 
     # Signatures should be different for different amounts
     assert (r1, s1) != (r2, s2), "Signatures should differ for different amounts"

--- a/sdks/py/alkahest_py/erc721/test_approve.py
+++ b/sdks/py/alkahest_py/erc721/test_approve.py
@@ -2,7 +2,7 @@ import pytest
 from alkahest_py import EnvTestManager, MockERC721
 
 @pytest.mark.asyncio
-async def test_erc721_approve():
+async def test_erc721_approve(env, alice_client):
     """
     Test ERC721 token approval for both payment and escrow purposes.
     This corresponds to test_approve() in main.rs (lines 81-135)
@@ -12,7 +12,6 @@ async def test_erc721_approve():
     2. Test approve for payment purpose and verify approval
     3. Test approve for escrow purpose and verify approval
     """
-    env = EnvTestManager()
     
     # Setup mock ERC721 token
     mock_erc721_a = MockERC721(env.mock_addresses.erc721_a, env.god_wallet_provider)
@@ -24,7 +23,7 @@ async def test_erc721_approve():
     token_data = {"address": env.mock_addresses.erc721_a, "id": 1}
     
     # Test approve for payment
-    await env.alice_client.erc721.util.approve(token_data, "payment")
+    await alice_client.erc721.util.approve(token_data, "payment")
     
     # Verify approval for payment obligation
     payment_approved = mock_erc721_a.get_approved(1)
@@ -35,7 +34,7 @@ async def test_erc721_approve():
     print(f"✓ Payment approval verified: token 1 approved for {payment_approved}")
     
     # Test approve for escrow
-    await env.alice_client.erc721.util.approve(token_data, "escrow")
+    await alice_client.erc721.util.approve(token_data, "escrow")
     
     # Verify approval for escrow obligation
     escrow_approved = mock_erc721_a.get_approved(1)

--- a/sdks/py/alkahest_py/erc721/test_approve_all.py
+++ b/sdks/py/alkahest_py/erc721/test_approve_all.py
@@ -2,7 +2,7 @@ import pytest
 from alkahest_py import EnvTestManager, MockERC721
 
 @pytest.mark.asyncio
-async def test_approve_all():
+async def test_approve_all(env, alice_client):
     """
     Test ERC721 approve_all functionality for both payment and escrow purposes.
     This corresponds to test_approve_all() in main.rs
@@ -12,7 +12,6 @@ async def test_approve_all():
     2. Test approve_all for payment purpose and verify with isApprovedForAll
     3. Test approve_all for escrow purpose and verify with isApprovedForAll
     """
-    env = EnvTestManager()
     
     # Setup mock ERC721 token
     mock_erc721_a = MockERC721(env.mock_addresses.erc721_a, env.god_wallet_provider)
@@ -30,7 +29,7 @@ async def test_approve_all():
     
     # Test approve_all for payment
     print("Testing approve_all for payment purpose...")
-    await env.alice_client.erc721.util.approve_all(env.mock_addresses.erc721_a, "payment")
+    await alice_client.erc721.util.approve_all(env.mock_addresses.erc721_a, "payment")
     
     # Verify approval for payment obligation using isApprovedForAll
     payment_approved = mock_erc721_a.is_approved_for_all(
@@ -44,7 +43,7 @@ async def test_approve_all():
     
     # Test approve_all for escrow
     print("Testing approve_all for escrow purpose...")
-    await env.alice_client.erc721.util.approve_all(env.mock_addresses.erc721_a, "escrow")
+    await alice_client.erc721.util.approve_all(env.mock_addresses.erc721_a, "escrow")
     
     # Verify approval for escrow obligation using isApprovedForAll
     escrow_approved = mock_erc721_a.is_approved_for_all(

--- a/sdks/py/alkahest_py/erc721/test_buy_bundle_with_erc721.py
+++ b/sdks/py/alkahest_py/erc721/test_buy_bundle_with_erc721.py
@@ -2,14 +2,13 @@ import pytest
 from alkahest_py import EnvTestManager, MockERC721
 
 @pytest.mark.asyncio
-async def test_buy_bundle_with_erc721():
+async def test_buy_bundle_with_erc721(env, alice_client):
     """
     Test buying a token bundle with ERC721.
     This corresponds to test_buy_bundle_with_erc721() in main.rs
     
     Flow: Alice escrows ERC721 to buy a token bundle (ERC20 + ERC721 + ERC1155)
     """
-    env = EnvTestManager()
     
     # Setup mock ERC721 token
     mock_erc721_a = MockERC721(env.mock_addresses.erc721_a, env.god_wallet_provider)
@@ -37,10 +36,10 @@ async def test_buy_bundle_with_erc721():
     }
     
     # Alice approves token for escrow
-    await env.alice_client.erc721.util.approve(bid_data, "barter")
+    await alice_client.erc721.util.approve(bid_data, "barter")
 
     # Alice creates purchase offer for the bundle
-    buy_result = await env.alice_client.erc721.barter.buy_bundle_with_erc721(bid_data, bundle_data, 0)
+    buy_result = await alice_client.erc721.barter.buy_bundle_with_erc721(bid_data, bundle_data, 0)
     
     assert buy_result['log']['uid'] and buy_result['log']['uid'] != "0x0000000000000000000000000000000000000000000000000000000000000000", "Invalid buy attestation UID"
     

--- a/sdks/py/alkahest_py/erc721/test_buy_erc1155_with_erc721.py
+++ b/sdks/py/alkahest_py/erc721/test_buy_erc1155_with_erc721.py
@@ -2,14 +2,13 @@ import pytest
 from alkahest_py import EnvTestManager, MockERC721
 
 @pytest.mark.asyncio
-async def test_buy_erc1155_with_erc721():
+async def test_buy_erc1155_with_erc721(env, alice_client):
     """
     Test buying ERC1155 tokens with ERC721.
     This corresponds to test_buy_erc1155_with_erc721() in main.rs
     
     Flow: Alice escrows ERC721 to buy ERC1155 tokens
     """
-    env = EnvTestManager()
     
     # Setup mock ERC721 token
     mock_erc721_a = MockERC721(env.mock_addresses.erc721_a, env.god_wallet_provider)
@@ -34,10 +33,10 @@ async def test_buy_erc1155_with_erc721():
     }
     
     # Alice approves token for escrow
-    await env.alice_client.erc721.util.approve(bid_data, "barter")
+    await alice_client.erc721.util.approve(bid_data, "barter")
 
     # Alice creates purchase offer
-    buy_result = await env.alice_client.erc721.barter.buy_erc1155_with_erc721(bid_data, ask_data, 0)
+    buy_result = await alice_client.erc721.barter.buy_erc1155_with_erc721(bid_data, ask_data, 0)
     
     assert buy_result['log']['uid'] and buy_result['log']['uid'] != "0x0000000000000000000000000000000000000000000000000000000000000000", "Invalid buy attestation UID"
     

--- a/sdks/py/alkahest_py/erc721/test_buy_erc20_with_erc721.py
+++ b/sdks/py/alkahest_py/erc721/test_buy_erc20_with_erc721.py
@@ -2,14 +2,13 @@ import pytest
 from alkahest_py import EnvTestManager, MockERC721
 
 @pytest.mark.asyncio
-async def test_buy_erc20_with_erc721():
+async def test_buy_erc20_with_erc721(env, alice_client):
     """
     Test buying ERC20 tokens with ERC721.
     This corresponds to test_buy_erc20_with_erc721() in main.rs
     
     Flow: Alice escrows ERC721 to buy ERC20 tokens
     """
-    env = EnvTestManager()
     
     # Setup mock ERC721 token
     mock_erc721_a = MockERC721(env.mock_addresses.erc721_a, env.god_wallet_provider)
@@ -33,10 +32,10 @@ async def test_buy_erc20_with_erc721():
     }
     
     # Alice approves token for escrow
-    await env.alice_client.erc721.util.approve(bid_data, "barter")
+    await alice_client.erc721.util.approve(bid_data, "barter")
     
     # Alice creates purchase offer
-    buy_result = await env.alice_client.erc721.barter.buy_erc20_with_erc721(bid_data, ask_data, 0)
+    buy_result = await alice_client.erc721.barter.buy_erc20_with_erc721(bid_data, ask_data, 0)
     
     assert buy_result['log']['uid'] and buy_result['log']['uid'] != "0x0000000000000000000000000000000000000000000000000000000000000000", "Invalid buy attestation UID"
     

--- a/sdks/py/alkahest_py/erc721/test_buy_erc721_for_erc721.py
+++ b/sdks/py/alkahest_py/erc721/test_buy_erc721_for_erc721.py
@@ -2,14 +2,13 @@ import pytest
 from alkahest_py import EnvTestManager, MockERC721
 
 @pytest.mark.asyncio
-async def test_buy_erc721_for_erc721():
+async def test_buy_erc721_for_erc721(env, alice_client):
     """
     Test buying ERC721 for ERC721 tokens.
     This corresponds to test_buy_erc721_for_erc721() in main.rs
     
     Flow: Alice escrows ERC721 A to buy ERC721 B
     """
-    env = EnvTestManager()
     
     # Setup mock ERC721 tokens
     mock_erc721_a = MockERC721(env.mock_addresses.erc721_a, env.god_wallet_provider)
@@ -33,10 +32,10 @@ async def test_buy_erc721_for_erc721():
     }
     
     # Alice approves token for escrow
-    await env.alice_client.erc721.util.approve(bid_data, "barter")
+    await alice_client.erc721.util.approve(bid_data, "barter")
     
     # Alice makes escrow (creates buy order)
-    buy_result = await env.alice_client.erc721.barter.buy_erc721_for_erc721(bid_data, ask_data, 0)
+    buy_result = await alice_client.erc721.barter.buy_erc721_for_erc721(bid_data, ask_data, 0)
     
     assert buy_result['log']['uid'] and buy_result['log']['uid'] != "0x0000000000000000000000000000000000000000000000000000000000000000", "Invalid buy attestation UID"
     

--- a/sdks/py/alkahest_py/erc721/test_buy_with_erc721.py
+++ b/sdks/py/alkahest_py/erc721/test_buy_with_erc721.py
@@ -2,14 +2,13 @@ import pytest
 from alkahest_py import EnvTestManager, MockERC721
 
 @pytest.mark.asyncio
-async def test_buy_with_erc721():
+async def test_buy_with_erc721(env, alice_client):
     """
     Test buying with ERC721 tokens.
     This corresponds to test_buy_with_erc721() in main.rs
     
     Flow: Alice uses ERC721 to create a buy order with custom arbiter data
     """
-    env = EnvTestManager()
     
     # Setup mock ERC721 token
     mock_erc721_a = MockERC721(env.mock_addresses.erc721_a, env.god_wallet_provider)
@@ -35,10 +34,10 @@ async def test_buy_with_erc721():
     }
     
     # Alice approves token for escrow
-    await env.alice_client.erc721.util.approve(price_data, "escrow")
+    await alice_client.erc721.util.approve(price_data, "escrow")
     
     # Alice creates buy order with ERC721
-    buy_result = await env.alice_client.erc721.escrow.non_tierable.create(price_data, arbiter_data, 0)
+    buy_result = await alice_client.erc721.escrow.non_tierable.create(price_data, arbiter_data, 0)
 
     assert buy_result['log']['uid'] and buy_result['log']['uid'] != "0x0000000000000000000000000000000000000000000000000000000000000000", "Invalid buy attestation UID"
     

--- a/sdks/py/alkahest_py/erc721/test_collect_expired.py
+++ b/sdks/py/alkahest_py/erc721/test_collect_expired.py
@@ -3,14 +3,13 @@ import time
 from alkahest_py import EnvTestManager, MockERC721
 
 @pytest.mark.asyncio
-async def test_reclaim_expired():
+async def test_reclaim_expired(env, alice_client):
     """
     Test collecting expired escrowed tokens.
     This corresponds to test_reclaim_expired() in main.rs
     
     Flow: Alice creates escrow with short expiration, waits for expiration, then collects
     """
-    env = EnvTestManager()
     
     # Setup mock ERC721 token
     mock_erc721_a = MockERC721(env.mock_addresses.erc721_a, env.god_wallet_provider)
@@ -34,11 +33,11 @@ async def test_reclaim_expired():
     }
     
     # Alice approves token for barter (since we use barter.buy_erc721_for_erc721)
-    await env.alice_client.erc721.util.approve(bid_data, "barter")
+    await alice_client.erc721.util.approve(bid_data, "barter")
     
     # Alice makes escrow with a short expiration (current time + 15 seconds)
     expiration = int(time.time()) + 15
-    buy_result = await env.alice_client.erc721.barter.buy_erc721_for_erc721(bid_data, ask_data, expiration)
+    buy_result = await alice_client.erc721.barter.buy_erc721_for_erc721(bid_data, ask_data, expiration)
     
     assert buy_result['log']['uid'] and buy_result['log']['uid'] != "0x0000000000000000000000000000000000000000000000000000000000000000", "Invalid buy attestation UID"
     
@@ -54,7 +53,7 @@ async def test_reclaim_expired():
     await env.god_wallet_provider.anvil_increase_time(20)
     
     # Alice collects expired funds
-    collect_result = await env.alice_client.erc721.escrow.non_tierable.reclaim_expired(buy_attestation_uid)
+    collect_result = await alice_client.erc721.escrow.non_tierable.reclaim_expired(buy_attestation_uid)
     print(f"Collected expired escrow, transaction: {collect_result}")
     
     # Verify token returned to Alice

--- a/sdks/py/alkahest_py/erc721/test_pay_erc721_for_bundle.py
+++ b/sdks/py/alkahest_py/erc721/test_pay_erc721_for_bundle.py
@@ -2,14 +2,13 @@ import pytest
 from alkahest_py import EnvTestManager, MockERC721, MockERC20, MockERC1155, ERC721PaymentObligationData
 
 @pytest.mark.asyncio
-async def test_pay_erc721_for_bundle():
+async def test_pay_erc721_for_bundle(env, alice_client, bob_client):
     """
     Test paying ERC721 for a token bundle.
     This corresponds to test_pay_erc721_for_bundle() in main.rs
     
     Flow: Bob escrows a bundle (ERC20 + ERC721 + ERC1155), Alice pays ERC721 to get the bundle
     """
-    env = EnvTestManager()
     
     # Setup mock tokens
     mock_erc721_a = MockERC721(env.mock_addresses.erc721_a, env.god_wallet_provider)
@@ -59,7 +58,7 @@ async def test_pay_erc721_for_bundle():
     demand_bytes = payment_obligation.encode_self()
     
     # Bob approves all tokens for the bundle escrow
-    await env.bob_client.token_bundle.util.approve(bundle_data, "escrow")
+    await bob_client.token_bundle.util.approve(bundle_data, "escrow")
     
     # Bob creates bundle escrow demanding ERC721 from Alice
     arbiter_data = {
@@ -67,7 +66,7 @@ async def test_pay_erc721_for_bundle():
         "demand": demand_bytes
     }
     
-    buy_result = await env.bob_client.token_bundle.escrow.non_tierable.create(bundle_data, arbiter_data, 0)
+    buy_result = await bob_client.token_bundle.escrow.non_tierable.create(bundle_data, arbiter_data, 0)
     
     assert buy_result['log']['uid'] and buy_result['log']['uid'] != "0x0000000000000000000000000000000000000000000000000000000000000000", "Invalid buy attestation UID"
     
@@ -75,10 +74,10 @@ async def test_pay_erc721_for_bundle():
     
     # Alice approves her ERC721 for payment
     erc721_data = {"address": env.mock_addresses.erc721_a, "id": alice_token_id}
-    await env.alice_client.erc721.util.approve(erc721_data, "barter")
+    await alice_client.erc721.util.approve(erc721_data, "barter")
     
     # Alice fulfills Bob's buy attestation with her ERC721
-    pay_result = await env.alice_client.erc721.barter.pay_erc721_for_bundle(buy_attestation_uid)
+    pay_result = await alice_client.erc721.barter.pay_erc721_for_bundle(buy_attestation_uid)
 
     assert pay_result['log']['uid'] and pay_result['log']['uid'] != "0x0000000000000000000000000000000000000000000000000000000000000000", "Invalid payment attestation UID"
     

--- a/sdks/py/alkahest_py/erc721/test_pay_erc721_for_erc1155.py
+++ b/sdks/py/alkahest_py/erc721/test_pay_erc721_for_erc1155.py
@@ -2,14 +2,13 @@ import pytest
 from alkahest_py import EnvTestManager, MockERC721, MockERC1155
 
 @pytest.mark.asyncio
-async def test_pay_erc721_for_erc1155():
+async def test_pay_erc721_for_erc1155(env, alice_client, bob_client):
     """
     Test paying ERC721 for ERC1155 tokens.
     This corresponds to test_pay_erc721_for_erc1155() in main.rs
     
     Flow: Bob escrows ERC1155, Alice pays ERC721 to get the ERC1155
     """
-    env = EnvTestManager()
     
     # Setup mock tokens
     mock_erc721_a = MockERC721(env.mock_addresses.erc721_a, env.god_wallet_provider)
@@ -38,9 +37,9 @@ async def test_pay_erc721_for_erc1155():
     }
     
     # Bob approves tokens for escrow and creates buy attestation
-    await env.bob_client.erc1155.util.approve_all(env.mock_addresses.erc1155_a, "barter")
+    await bob_client.erc1155.util.approve_all(env.mock_addresses.erc1155_a, "barter")
 
-    buy_result = await env.bob_client.erc1155.barter.buy_erc721_with_erc1155(bid_data, ask_data, 0)
+    buy_result = await bob_client.erc1155.barter.buy_erc721_with_erc1155(bid_data, ask_data, 0)
 
     assert buy_result['log']['uid'] and buy_result['log']['uid'] != "0x0000000000000000000000000000000000000000000000000000000000000000", "Invalid buy attestation UID"
     
@@ -48,10 +47,10 @@ async def test_pay_erc721_for_erc1155():
     
     # Alice approves her token for payment
     erc721_data = {"address": env.mock_addresses.erc721_a, "id": token_id}
-    await env.alice_client.erc721.util.approve(erc721_data, "barter")
+    await alice_client.erc721.util.approve(erc721_data, "barter")
     
     # Alice fulfills the buy attestation
-    pay_result = await env.alice_client.erc721.barter.pay_erc721_for_erc1155(buy_attestation_uid)
+    pay_result = await alice_client.erc721.barter.pay_erc721_for_erc1155(buy_attestation_uid)
 
     assert pay_result['log']['uid'] and pay_result['log']['uid'] != "0x0000000000000000000000000000000000000000000000000000000000000000", "Invalid payment attestation UID"
     

--- a/sdks/py/alkahest_py/erc721/test_pay_erc721_for_erc20.py
+++ b/sdks/py/alkahest_py/erc721/test_pay_erc721_for_erc20.py
@@ -2,14 +2,13 @@ import pytest
 from alkahest_py import EnvTestManager, MockERC721, MockERC20
 
 @pytest.mark.asyncio
-async def test_pay_erc721_for_erc20():
+async def test_pay_erc721_for_erc20(env, alice_client, bob_client):
     """
     Test paying ERC721 for ERC20 tokens.
     This corresponds to test_pay_erc721_for_erc20() in main.rs
     
     Flow: Bob escrows ERC20, Alice pays ERC721 to get the ERC20
     """
-    env = EnvTestManager()
     
     # Setup mock tokens
     mock_erc721_a = MockERC721(env.mock_addresses.erc721_a, env.god_wallet_provider)
@@ -37,9 +36,9 @@ async def test_pay_erc721_for_erc20():
     }
     
     # Bob approves tokens for escrow and creates buy attestation
-    await env.bob_client.erc20.util.approve(bid_data, "barter")
+    await bob_client.erc20.util.approve(bid_data, "barter")
 
-    buy_result = await env.bob_client.erc20.barter.buy_erc721_for_erc20(bid_data, ask_data, 0)
+    buy_result = await bob_client.erc20.barter.buy_erc721_for_erc20(bid_data, ask_data, 0)
 
     assert buy_result['log']['uid'] and buy_result['log']['uid'] != "0x0000000000000000000000000000000000000000000000000000000000000000", "Invalid buy attestation UID"
     
@@ -47,10 +46,10 @@ async def test_pay_erc721_for_erc20():
     
     # Alice approves her ERC721 token for payment
     erc721_data = {"address": env.mock_addresses.erc721_a, "id": token_id}
-    await env.alice_client.erc721.util.approve(erc721_data, "barter")
+    await alice_client.erc721.util.approve(erc721_data, "barter")
     
     # Alice fulfills Bob's buy attestation with her ERC721
-    pay_result = await env.alice_client.erc721.barter.pay_erc721_for_erc20(buy_attestation_uid)
+    pay_result = await alice_client.erc721.barter.pay_erc721_for_erc20(buy_attestation_uid)
     
     assert pay_result['log']['uid'] and pay_result['log']['uid'] != "0x0000000000000000000000000000000000000000000000000000000000000000", "Invalid payment attestation UID"
     

--- a/sdks/py/alkahest_py/erc721/test_pay_erc721_for_erc721.py
+++ b/sdks/py/alkahest_py/erc721/test_pay_erc721_for_erc721.py
@@ -2,14 +2,13 @@ import pytest
 from alkahest_py import EnvTestManager, MockERC721
 
 @pytest.mark.asyncio
-async def test_pay_erc721_for_erc721():
+async def test_pay_erc721_for_erc721(env, alice_client, bob_client):
     """
     Test paying ERC721 for ERC721 tokens.
     This corresponds to test_pay_erc721_for_erc721() in main.rs
     
     Flow: Alice creates ERC721 escrow, Bob fulfills with his ERC721
     """
-    env = EnvTestManager()
     
     # Setup mock ERC721 tokens
     mock_erc721_a = MockERC721(env.mock_addresses.erc721_a, env.god_wallet_provider)
@@ -38,19 +37,19 @@ async def test_pay_erc721_for_erc721():
     }
     
     # Alice approves token for escrow and creates buy attestation
-    await env.alice_client.erc721.util.approve(bid_data, "barter")
+    await alice_client.erc721.util.approve(bid_data, "barter")
     
-    buy_result = await env.alice_client.erc721.barter.buy_erc721_for_erc721(bid_data, ask_data, 0)
+    buy_result = await alice_client.erc721.barter.buy_erc721_for_erc721(bid_data, ask_data, 0)
     
     assert buy_result['log']['uid'] and buy_result['log']['uid'] != "0x0000000000000000000000000000000000000000000000000000000000000000", "Invalid buy attestation UID"
     
     buy_attestation_uid = buy_result['log']['uid']
     
     # Bob approves token for payment
-    await env.bob_client.erc721.util.approve(ask_data, "barter")
+    await bob_client.erc721.util.approve(ask_data, "barter")
 
     # Bob fulfills the buy attestation
-    pay_result = await env.bob_client.erc721.barter.pay_erc721_for_erc721(buy_attestation_uid)
+    pay_result = await bob_client.erc721.barter.pay_erc721_for_erc721(buy_attestation_uid)
 
     assert pay_result['log']['uid'] and pay_result['log']['uid'] != "0x0000000000000000000000000000000000000000000000000000000000000000", "Invalid payment attestation UID"
     

--- a/sdks/py/alkahest_py/erc721/test_pay_with_erc721.py
+++ b/sdks/py/alkahest_py/erc721/test_pay_with_erc721.py
@@ -2,14 +2,13 @@ import pytest
 from alkahest_py import EnvTestManager, MockERC721
 
 @pytest.mark.asyncio
-async def test_pay_with_erc721():
+async def test_pay_with_erc721(env, alice_client):
     """
     Test paying with ERC721 tokens.
     This corresponds to test_pay_with_erc721() in main.rs
     
     Flow: Alice pays ERC721 token directly to Bob
     """
-    env = EnvTestManager()
     
     # Setup mock ERC721 token
     mock_erc721_a = MockERC721(env.mock_addresses.erc721_a, env.god_wallet_provider)
@@ -29,10 +28,10 @@ async def test_pay_with_erc721():
     }
     
     # Alice approves token for payment
-    await env.alice_client.erc721.util.approve(price_data, "payment")
+    await alice_client.erc721.util.approve(price_data, "payment")
     
     # Alice makes direct payment to Bob
-    payment_result = await env.alice_client.erc721.payment.pay(price_data, env.bob)
+    payment_result = await alice_client.erc721.payment.pay(price_data, env.bob)
 
     assert payment_result['log']['uid'] and payment_result['log']['uid'] != "0x0000000000000000000000000000000000000000000000000000000000000000", "Invalid payment attestation UID"
     

--- a/sdks/py/alkahest_py/erc721/test_revoke_all.py
+++ b/sdks/py/alkahest_py/erc721/test_revoke_all.py
@@ -2,7 +2,7 @@ import pytest
 from alkahest_py import EnvTestManager, MockERC721
 
 @pytest.mark.asyncio
-async def test_revoke_all():
+async def test_revoke_all(env, alice_client):
     """
     Test ERC721 revoke_all functionality for payment purpose.
     This corresponds to test_revoke_all() in main.rs
@@ -13,7 +13,6 @@ async def test_revoke_all():
     3. Then revoke_all for payment purpose
     4. Verify that approval has been revoked using isApprovedForAll
     """
-    env = EnvTestManager()
     
     # Setup mock ERC721 token
     mock_erc721_a = MockERC721(env.mock_addresses.erc721_a, env.god_wallet_provider)
@@ -28,7 +27,7 @@ async def test_revoke_all():
     
     # First approve_all for payment
     print("Setting approve_all for payment purpose...")
-    await env.alice_client.erc721.util.approve_all(env.mock_addresses.erc721_a, "payment")
+    await alice_client.erc721.util.approve_all(env.mock_addresses.erc721_a, "payment")
     
     # Verify approval was set
     payment_approved_before = mock_erc721_a.is_approved_for_all(
@@ -42,7 +41,7 @@ async def test_revoke_all():
     
     # Then revoke_all for payment
     print("Revoking all approvals for payment purpose...")
-    await env.alice_client.erc721.util.revoke_all(env.mock_addresses.erc721_a, "payment")
+    await alice_client.erc721.util.revoke_all(env.mock_addresses.erc721_a, "payment")
     
     # Verify revocation
     payment_approved_after = mock_erc721_a.is_approved_for_all(

--- a/sdks/py/alkahest_py/native_token/test_barter.py
+++ b/sdks/py/alkahest_py/native_token/test_barter.py
@@ -2,14 +2,12 @@ import pytest
 import time
 from alkahest_py import EnvTestManager, MockERC20
 
-
 @pytest.mark.asyncio
-async def test_buy_erc20_for_native():
+async def test_buy_erc20_for_native(env, alice_client):
     """
     Test buying ERC20 with native tokens.
     Alice escrows native tokens demanding ERC20.
     """
-    env = EnvTestManager()
 
     escrow_amount = 1000  # wei of native token
     ask_amount = 100  # ERC20 amount
@@ -19,7 +17,7 @@ async def test_buy_erc20_for_native():
     ask_data = {"address": env.mock_addresses.erc20_a, "value": ask_amount}
     expiration = 0  # no expiration
 
-    escrow_result = await env.alice_client.native_token.barter.buy_erc20_for_native(
+    escrow_result = await alice_client.native_token.barter.buy_erc20_for_native(
         native_data, ask_data, expiration
     )
 
@@ -30,14 +28,12 @@ async def test_buy_erc20_for_native():
 
     print(f"Buy ERC20 for native escrow created: {escrow_uid}")
 
-
 @pytest.mark.asyncio
-async def test_pay_erc20_for_native():
+async def test_pay_erc20_for_native(env, alice_client, bob_client):
     """
     Test paying ERC20 for native tokens.
     Alice escrows native tokens demanding ERC20, Bob pays with ERC20.
     """
-    env = EnvTestManager()
     mock_erc20 = MockERC20(env.mock_addresses.erc20_a, env.god_wallet_provider)
 
     # Setup: Bob has ERC20 to pay with
@@ -50,28 +46,26 @@ async def test_pay_erc20_for_native():
     ask_data = {"address": env.mock_addresses.erc20_a, "value": ask_amount}
 
     # Alice creates native-for-erc20 escrow (offering native, wanting ERC20)
-    escrow_result = await env.alice_client.native_token.barter.buy_erc20_for_native(
+    escrow_result = await alice_client.native_token.barter.buy_erc20_for_native(
         native_data, ask_data, 0
     )
 
     escrow_uid = escrow_result['log']['uid']
 
     # Bob approves and pays with ERC20 using pay_erc20_for_native
-    await env.bob_client.erc20.util.approve(ask_data, "barter")
-    payment_result = await env.bob_client.erc20.barter.pay_erc20_for_native(escrow_uid)
+    await bob_client.erc20.util.approve(ask_data, "barter")
+    payment_result = await bob_client.erc20.barter.pay_erc20_for_native(escrow_uid)
 
     assert payment_result is not None, "Payment should succeed"
     assert 'log' in payment_result, "Should have log in result"
 
     print(f"ERC20 payment for native token escrow succeeded: {payment_result['log']['uid']}")
 
-
 @pytest.mark.asyncio
-async def test_buy_native_for_native():
+async def test_buy_native_for_native(env, alice_client, bob_client):
     """
     Test buying native tokens with native tokens (native-to-native swap).
     """
-    env = EnvTestManager()
 
     bid_amount = 1000  # wei Alice offers
     ask_amount = 500  # wei Alice wants
@@ -80,7 +74,7 @@ async def test_buy_native_for_native():
     ask_data = {"value": ask_amount}
 
     # Alice creates native-for-native escrow
-    escrow_result = await env.alice_client.native_token.barter.buy_native_for_native(
+    escrow_result = await alice_client.native_token.barter.buy_native_for_native(
         bid_data, ask_data, 0
     )
 
@@ -88,58 +82,52 @@ async def test_buy_native_for_native():
     escrow_uid = escrow_result['log']['uid']
 
     # Bob pays with native tokens
-    payment_result = await env.bob_client.native_token.barter.pay_native_for_native(escrow_uid)
+    payment_result = await bob_client.native_token.barter.pay_native_for_native(escrow_uid)
 
     assert payment_result is not None, "Payment should succeed"
     print(f"Native-for-native swap succeeded")
 
-
 @pytest.mark.asyncio
-async def test_buy_erc721_for_native():
+async def test_buy_erc721_for_native(env, alice_client):
     """
     Test buying ERC721 with native tokens.
     """
-    env = EnvTestManager()
 
     escrow_amount = 1000  # wei
 
     native_data = {"value": escrow_amount}
     ask_data = {"address": env.mock_addresses.erc721_a, "id": 1}
 
-    escrow_result = await env.alice_client.native_token.barter.buy_erc721_for_native(
+    escrow_result = await alice_client.native_token.barter.buy_erc721_for_native(
         native_data, ask_data, 0
     )
 
     assert escrow_result is not None, "Escrow should succeed"
     print(f"Buy ERC721 for native escrow created: {escrow_result['log']['uid']}")
 
-
 @pytest.mark.asyncio
-async def test_buy_erc1155_for_native():
+async def test_buy_erc1155_for_native(env, alice_client):
     """
     Test buying ERC1155 with native tokens.
     """
-    env = EnvTestManager()
 
     escrow_amount = 1000  # wei
 
     native_data = {"value": escrow_amount}
     ask_data = {"address": env.mock_addresses.erc1155_a, "id": 1, "value": 10}
 
-    escrow_result = await env.alice_client.native_token.barter.buy_erc1155_for_native(
+    escrow_result = await alice_client.native_token.barter.buy_erc1155_for_native(
         native_data, ask_data, 0
     )
 
     assert escrow_result is not None, "Escrow should succeed"
     print(f"Buy ERC1155 for native escrow created: {escrow_result['log']['uid']}")
 
-
 @pytest.mark.asyncio
-async def test_buy_bundle_for_native():
+async def test_buy_bundle_for_native(env, alice_client):
     """
     Test buying token bundle with native tokens.
     """
-    env = EnvTestManager()
 
     escrow_amount = 1000  # wei
 
@@ -151,7 +139,7 @@ async def test_buy_bundle_for_native():
         "native_amount": 0,
     }
 
-    escrow_result = await env.alice_client.native_token.barter.buy_bundle_for_native(
+    escrow_result = await alice_client.native_token.barter.buy_bundle_for_native(
         native_data, bundle_data, 0
     )
 

--- a/sdks/py/alkahest_py/native_token/test_escrow.py
+++ b/sdks/py/alkahest_py/native_token/test_escrow.py
@@ -2,13 +2,11 @@ import pytest
 import time
 from alkahest_py import EnvTestManager, TrustedOracleArbiterDemandData
 
-
 @pytest.mark.asyncio
-async def test_native_token_escrow_non_tierable():
+async def test_native_token_escrow_non_tierable(env, alice_client, bob_client):
     """
     Test native token non-tierable escrow: create, fulfill, collect.
     """
-    env = EnvTestManager()
 
     # Use small amounts for testing
     escrow_amount = 1000  # wei
@@ -28,7 +26,7 @@ async def test_native_token_escrow_non_tierable():
 
     # Alice creates native token escrow
     native_data = {"value": escrow_amount}
-    escrow_result = await env.alice_client.native_token.escrow.non_tierable.create(
+    escrow_result = await alice_client.native_token.escrow.non_tierable.create(
         native_data, arbiter, expiration
     )
 
@@ -40,29 +38,27 @@ async def test_native_token_escrow_non_tierable():
     print(f"Native token escrow created: {escrow_uid}")
 
     # Bob makes fulfillment
-    string_client = env.bob_client.string_obligation
+    string_client = bob_client.string_obligation
     fulfillment_uid = await string_client.do_obligation("fulfilled", escrow_uid)
 
     # Request and perform arbitration
-    oracle_client = env.bob_client.oracle
+    oracle_client = bob_client.oracle
     await oracle_client.request_arbitration(fulfillment_uid, env.bob, inner_demand_data)
     await oracle_client.arbitrate(fulfillment_uid, inner_demand_data, True)
 
     # Bob collects
-    collect_result = await env.bob_client.native_token.escrow.non_tierable.collect(
+    collect_result = await bob_client.native_token.escrow.non_tierable.collect(
         escrow_uid, fulfillment_uid
     )
 
     assert collect_result is not None, "Collection should succeed"
     print(f"Native token collected: {collect_result}")
 
-
 @pytest.mark.asyncio
-async def test_native_token_escrow_tierable():
+async def test_native_token_escrow_tierable(env, alice_client, bob_client):
     """
     Test native token tierable escrow: create, fulfill, collect.
     """
-    env = EnvTestManager()
 
     escrow_amount = 1000  # wei
 
@@ -81,7 +77,7 @@ async def test_native_token_escrow_tierable():
 
     # Alice creates tierable native token escrow
     native_data = {"value": escrow_amount}
-    escrow_result = await env.alice_client.native_token.escrow.tierable.create(
+    escrow_result = await alice_client.native_token.escrow.tierable.create(
         native_data, arbiter, expiration
     )
 
@@ -92,30 +88,28 @@ async def test_native_token_escrow_tierable():
     print(f"Native token tierable escrow created: {escrow_uid}")
 
     # Bob makes fulfillment
-    string_client = env.bob_client.string_obligation
+    string_client = bob_client.string_obligation
     fulfillment_uid = await string_client.do_obligation("fulfilled", escrow_uid)
 
     # Request and perform arbitration
-    oracle_client = env.bob_client.oracle
+    oracle_client = bob_client.oracle
     await oracle_client.request_arbitration(fulfillment_uid, env.bob, inner_demand_data)
     await oracle_client.arbitrate(fulfillment_uid, inner_demand_data, True)
 
     # Bob collects from tierable escrow
-    collect_result = await env.bob_client.native_token.escrow.tierable.collect(
+    collect_result = await bob_client.native_token.escrow.tierable.collect(
         escrow_uid, fulfillment_uid
     )
 
     assert collect_result is not None, "Tierable collection should succeed"
     print(f"Native token tierable collected: {collect_result}")
 
-
 @pytest.mark.asyncio
-async def test_native_token_escrow_reclaim_expired():
+async def test_native_token_escrow_reclaim_expired(env, alice_client):
     """
     Test native token escrow reclaim when expired.
     Creates an escrow with short expiration, advances time, then reclaims.
     """
-    env = EnvTestManager()
 
     escrow_amount = 1000  # wei
 
@@ -134,7 +128,7 @@ async def test_native_token_escrow_reclaim_expired():
     expiration = int(time.time()) + 15
 
     native_data = {"value": escrow_amount}
-    escrow_result = await env.alice_client.native_token.escrow.non_tierable.create(
+    escrow_result = await alice_client.native_token.escrow.non_tierable.create(
         native_data, arbiter, expiration
     )
 
@@ -145,7 +139,7 @@ async def test_native_token_escrow_reclaim_expired():
     await env.god_wallet_provider.anvil_increase_time(20)
 
     # Alice reclaims expired escrow
-    reclaim_result = await env.alice_client.native_token.escrow.non_tierable.reclaim_expired(
+    reclaim_result = await alice_client.native_token.escrow.non_tierable.reclaim_expired(
         escrow_uid
     )
 

--- a/sdks/py/alkahest_py/native_token/test_payment.py
+++ b/sdks/py/alkahest_py/native_token/test_payment.py
@@ -1,23 +1,21 @@
 import pytest
 from alkahest_py import EnvTestManager
 
-
 @pytest.mark.asyncio
-async def test_native_token_payment():
+async def test_native_token_payment(env, bob_client):
     """
     Test native token direct payment functionality.
 
     Flow:
     1. Bob makes a direct native token payment to Alice
     """
-    env = EnvTestManager()
 
     # Use a small amount for testing
     payment_amount = 1000  # wei
 
     # Bob makes native token payment to Alice
     native_data = {"value": payment_amount}
-    payment_result = await env.bob_client.native_token.payment.pay(
+    payment_result = await bob_client.native_token.payment.pay(
         native_data, env.alice  # payee address
     )
 

--- a/sdks/py/alkahest_py/oracle/test_arbitrate_direct.py
+++ b/sdks/py/alkahest_py/oracle/test_arbitrate_direct.py
@@ -12,11 +12,9 @@ from alkahest_py import (
     TrustedOracleArbiterDemandData,
 )
 
-
 @pytest.mark.asyncio
-async def test_arbitrate_direct():
+async def test_arbitrate_direct(env, alice_client, bob_client):
     """Test direct arbitration using oracle_client.arbitrate()"""
-    env = EnvTestManager()
 
     # Setup escrow
     mock_erc20 = MockERC20(env.mock_addresses.erc20_a, env.god_wallet_provider)
@@ -38,17 +36,17 @@ async def test_arbitrate_direct():
     }
 
     expiration = int(time.time()) + 3600
-    escrow_receipt = await env.alice_client.erc20.escrow.non_tierable.permit_and_create(
+    escrow_receipt = await alice_client.erc20.escrow.non_tierable.permit_and_create(
         price, arbiter, expiration
     )
     escrow_uid = escrow_receipt['log']['uid']
 
     # Make fulfillment
-    string_client = env.bob_client.string_obligation
+    string_client = bob_client.string_obligation
     fulfillment_uid = await string_client.do_obligation("good", escrow_uid)
 
     # Request arbitration
-    oracle_client = env.bob_client.oracle
+    oracle_client = bob_client.oracle
     await oracle_client.request_arbitration(fulfillment_uid, env.bob, inner_demand_data)
 
     # Direct arbitration call
@@ -58,11 +56,9 @@ async def test_arbitrate_direct():
 
     print(f"Direct arbitration succeeded with tx: {tx_hash}")
 
-
 @pytest.mark.asyncio
-async def test_wait_for_arbitration():
+async def test_wait_for_arbitration(env, alice_client, bob_client):
     """Test waiting for arbitration event using oracle_client.wait_for_arbitration()"""
-    env = EnvTestManager()
 
     # Setup escrow
     mock_erc20 = MockERC20(env.mock_addresses.erc20_a, env.god_wallet_provider)
@@ -81,17 +77,17 @@ async def test_wait_for_arbitration():
     }
 
     expiration = int(time.time()) + 3600
-    escrow_receipt = await env.alice_client.erc20.escrow.non_tierable.permit_and_create(
+    escrow_receipt = await alice_client.erc20.escrow.non_tierable.permit_and_create(
         price, arbiter, expiration
     )
     escrow_uid = escrow_receipt['log']['uid']
 
     # Make fulfillment
-    string_client = env.bob_client.string_obligation
+    string_client = bob_client.string_obligation
     fulfillment_uid = await string_client.do_obligation("good", escrow_uid)
 
     # Request and perform arbitration
-    oracle_client = env.bob_client.oracle
+    oracle_client = bob_client.oracle
     await oracle_client.request_arbitration(fulfillment_uid, env.bob, inner_demand_data)
     await oracle_client.arbitrate(fulfillment_uid, inner_demand_data, True)
 
@@ -109,11 +105,9 @@ async def test_wait_for_arbitration():
 
     print(f"Found arbitration event: decision={event.decision}")
 
-
 @pytest.mark.asyncio
-async def test_get_escrow_attestation():
+async def test_get_escrow_attestation(env, alice_client, bob_client):
     """Test getting escrow attestation from a fulfillment attestation"""
-    env = EnvTestManager()
 
     # Setup escrow
     mock_erc20 = MockERC20(env.mock_addresses.erc20_a, env.god_wallet_provider)
@@ -132,17 +126,17 @@ async def test_get_escrow_attestation():
     }
 
     expiration = int(time.time()) + 3600
-    escrow_receipt = await env.alice_client.erc20.escrow.non_tierable.permit_and_create(
+    escrow_receipt = await alice_client.erc20.escrow.non_tierable.permit_and_create(
         price, arbiter, expiration
     )
     escrow_uid = escrow_receipt['log']['uid']
 
     # Make fulfillment
-    string_client = env.bob_client.string_obligation
+    string_client = bob_client.string_obligation
     fulfillment_uid = await string_client.do_obligation("test_data", escrow_uid)
 
     # Request arbitration
-    oracle_client = env.bob_client.oracle
+    oracle_client = bob_client.oracle
     await oracle_client.request_arbitration(fulfillment_uid, env.bob, inner_demand_data)
 
     # Get a fulfillment attestation (we need to construct one with the ref_uid)
@@ -168,11 +162,9 @@ async def test_get_escrow_attestation():
 
     print(f"Got escrow attestation: {escrow_attestation.uid}")
 
-
 @pytest.mark.asyncio
-async def test_get_escrow_and_demand():
+async def test_get_escrow_and_demand(env, alice_client, bob_client):
     """Test getting escrow attestation and demand data in one call"""
-    env = EnvTestManager()
 
     # Setup escrow
     mock_erc20 = MockERC20(env.mock_addresses.erc20_a, env.god_wallet_provider)
@@ -191,13 +183,13 @@ async def test_get_escrow_and_demand():
     }
 
     expiration = int(time.time()) + 3600
-    escrow_receipt = await env.alice_client.erc20.escrow.non_tierable.permit_and_create(
+    escrow_receipt = await alice_client.erc20.escrow.non_tierable.permit_and_create(
         price, arbiter, expiration
     )
     escrow_uid = escrow_receipt['log']['uid']
 
     # Make fulfillment
-    string_client = env.bob_client.string_obligation
+    string_client = bob_client.string_obligation
     fulfillment_uid = await string_client.do_obligation("test_data", escrow_uid)
 
     # Construct fulfillment attestation
@@ -216,7 +208,7 @@ async def test_get_escrow_and_demand():
     )
 
     # Get escrow and demand in one call
-    oracle_client = env.bob_client.oracle
+    oracle_client = bob_client.oracle
     escrow_attestation, extracted_demand = await oracle_client.get_escrow_and_demand(fulfillment_attestation)
 
     assert escrow_attestation is not None, "Should get escrow attestation"

--- a/sdks/py/alkahest_py/oracle/test_capitalization.py
+++ b/sdks/py/alkahest_py/oracle/test_capitalization.py
@@ -15,21 +15,18 @@ from alkahest_py import (
     AlkahestClient,
 )
 
-
 @dataclass
 class ShellTestCase:
     input: str
     output: str
-
 
 @dataclass
 class ShellOracleDemand:
     description: str
     test_cases: List[ShellTestCase]
 
-
 @pytest.mark.asyncio
-async def test_synchronous_offchain_oracle_capitalization_flow():
+async def test_synchronous_offchain_oracle_capitalization_flow(env, alice_client, bob_client):
     """
     Test a synchronous offchain oracle that verifies shell commands
     Alice escrows ERC20 collateral guarded by Charlie's oracle.
@@ -37,11 +34,10 @@ async def test_synchronous_offchain_oracle_capitalization_flow():
     Charlie evaluates and arbitrates the fulfillment.
     Bob collects the escrowed payment upon successful arbitration.
     """
-    env = EnvTestManager()
 
     # Bob acts as the oracle for this test
     oracle_address = env.bob
-    oracle_client = env.bob_client
+    oracle_client = bob_client
 
     # Step 1: Alice escrows ERC20 collateral guarded by Charlie's oracle suite
     mock_erc20 = MockERC20(env.mock_addresses.erc20_a, env.god_wallet_provider)
@@ -76,13 +72,13 @@ async def test_synchronous_offchain_oracle_capitalization_flow():
     price = {"address": env.mock_addresses.erc20_a, "value": 100}
     expiration = int(time.time()) + 3600
 
-    escrow_receipt = await env.alice_client.erc20.escrow.non_tierable.permit_and_create(
+    escrow_receipt = await alice_client.erc20.escrow.non_tierable.permit_and_create(
         price, arbiter, expiration
     )
     escrow_uid = escrow_receipt['log']['uid']
 
     # Step 2: Bob submits a bash pipeline fulfillment
-    fulfillment_uid = await env.bob_client.string_obligation.do_obligation(
+    fulfillment_uid = await bob_client.string_obligation.do_obligation(
         "tr '[:lower:]' '[:upper:]'",
         escrow_uid
     )
@@ -90,7 +86,7 @@ async def test_synchronous_offchain_oracle_capitalization_flow():
     # Step 3: Bob asks the oracle to arbitrate his fulfillment
     # Pass the inner data field (not the full encoded DemandData) because
     # TrustedOracleArbiter.checkObligation() uses only demand_.data for the decisionKey
-    await env.bob_client.oracle.request_arbitration(fulfillment_uid, oracle_address, inner_demand_data)
+    await bob_client.oracle.request_arbitration(fulfillment_uid, oracle_address, inner_demand_data)
 
     # Step 4: Oracle evaluates with async decision function
     async def decision_function(attestation, demand):
@@ -147,6 +143,6 @@ async def test_synchronous_offchain_oracle_capitalization_flow():
     assert all(d.decision for d in decisions), "Oracle rejected fulfillment"
 
     # Step 5: The successful arbitration lets Bob claim the escrowed payment
-    await env.bob_client.erc20.escrow.non_tierable.collect(escrow_uid, fulfillment_uid)
+    await bob_client.erc20.escrow.non_tierable.collect(escrow_uid, fulfillment_uid)
 
     print("Synchronous offchain oracle capitalization test passed")

--- a/sdks/py/alkahest_py/string/test_obligation.py
+++ b/sdks/py/alkahest_py/string/test_obligation.py
@@ -8,9 +8,8 @@ from alkahest_py import (
 )
 
 @pytest.mark.asyncio
-async def test_string_obligation():
-    env = EnvTestManager()
-    string_client = env.alice_client.string_obligation
+async def test_string_obligation(env, alice_client):
+    string_client = alice_client.string_obligation
     
     tx_hash = await string_client.do_obligation("Test obligation for PyDecodedAttestation<T>", None)
     
@@ -18,12 +17,11 @@ async def test_string_obligation():
     assert tx_hash.startswith('0x') and len(tx_hash) == 66
 
 @pytest.mark.asyncio
-async def test_do_obligation_json():
+async def test_do_obligation_json(env, alice_client):
     """
     Test the do_obligation_json function with various Python objects
     """
-    env = EnvTestManager()
-    string_client = env.alice_client.string_obligation
+    string_client = alice_client.string_obligation
     
     # Test with dictionary
     dict_data = {

--- a/sdks/py/alkahest_py/test_alkahest_client_init.py
+++ b/sdks/py/alkahest_py/test_alkahest_client_init.py
@@ -7,11 +7,9 @@ from alkahest_py import (
     EnvTestManager,
 )
 
-
 @pytest.mark.asyncio
-async def test_alkahest_client_init_default():
+async def test_alkahest_client_init_default(env):
     """Test AlkahestClient initialization with default extensions (no custom config)."""
-    env = EnvTestManager()
 
     # Initialize client without custom address config (should use defaults)
     client = AlkahestClient(
@@ -49,11 +47,9 @@ async def test_alkahest_client_init_default():
 
     print("✅ Default AlkahestClient initialization test passed!")
 
-
 @pytest.mark.asyncio
-async def test_alkahest_client_init_with_custom_config():
+async def test_alkahest_client_init_with_custom_config(env, alice_client):
     """Test AlkahestClient initialization with custom address configuration."""
-    env = EnvTestManager()
 
     # Test that the environment addresses are accessible and client works
     # NOTE: Creating a client with custom config requires proper config format
@@ -64,8 +60,8 @@ async def test_alkahest_client_init_with_custom_config():
     assert hasattr(env.addresses, 'arbiters_addresses'), "Should have arbiters addresses"
 
     # Verify alice_client from env works (it's already initialized with proper addresses)
-    assert env.alice_client is not None, "Alice client should exist"
-    assert env.alice_client.erc20 is not None, "Alice ERC20 client should exist"
-    assert env.alice_client.erc721 is not None, "Alice ERC721 client should exist"
+    assert alice_client is not None, "Alice client should exist"
+    assert alice_client.erc20 is not None, "Alice ERC20 client should exist"
+    assert alice_client.erc721 is not None, "Alice ERC721 client should exist"
 
     print("✅ Custom config AlkahestClient initialization test passed!")

--- a/sdks/py/alkahest_py/token_bundle/test_revoke_erc1155s.py
+++ b/sdks/py/alkahest_py/token_bundle/test_revoke_erc1155s.py
@@ -1,9 +1,8 @@
 import pytest
 from alkahest_py import EnvTestManager, MockERC1155
 
-
 @pytest.mark.asyncio
-async def test_revoke_erc1155s_in_bundle():
+async def test_revoke_erc1155s_in_bundle(env, alice_client):
     """
     Test token_bundle revoke_erc1155s functionality.
 
@@ -14,7 +13,6 @@ async def test_revoke_erc1155s_in_bundle():
     4. Revoke ERC1155 approvals in the bundle
     5. Verify that approval has been revoked
     """
-    env = EnvTestManager()
 
     # Setup mock ERC1155 tokens
     mock_erc1155_a = MockERC1155(env.mock_addresses.erc1155_a, env.god_wallet_provider)
@@ -37,7 +35,7 @@ async def test_revoke_erc1155s_in_bundle():
 
     # First approve the bundle for barter
     print("Approving bundle for barter...")
-    await env.alice_client.token_bundle.util.approve(bundle, "barter")
+    await alice_client.token_bundle.util.approve(bundle, "barter")
 
     # Verify approval was set for ERC1155
     barter_approved_before = mock_erc1155_a.is_approved_for_all(
@@ -49,7 +47,7 @@ async def test_revoke_erc1155s_in_bundle():
 
     # Revoke ERC1155 approvals in the bundle
     print("Revoking ERC1155 approvals in bundle...")
-    await env.alice_client.token_bundle.util.revoke_erc1155s(bundle, "barter")
+    await alice_client.token_bundle.util.revoke_erc1155s(bundle, "barter")
 
     # Verify revocation
     barter_approved_after = mock_erc1155_a.is_approved_for_all(
@@ -60,14 +58,12 @@ async def test_revoke_erc1155s_in_bundle():
 
     print("ERC1155 approvals in bundle successfully revoked")
 
-
 @pytest.mark.asyncio
-async def test_revoke_erc1155s_empty_bundle():
+async def test_revoke_erc1155s_empty_bundle(env, alice_client):
     """
     Test revoke_erc1155s with a bundle that has no ERC1155 tokens.
     Should complete without error.
     """
-    env = EnvTestManager()
 
     # Create an empty bundle (no ERC1155s)
     bundle = {
@@ -78,7 +74,7 @@ async def test_revoke_erc1155s_empty_bundle():
     }
 
     # Revoke should succeed even with empty bundle
-    result = await env.alice_client.token_bundle.util.revoke_erc1155s(bundle, "barter")
+    result = await alice_client.token_bundle.util.revoke_erc1155s(bundle, "barter")
 
     # Empty result is expected (empty string means no receipts)
     assert result == "", f"Expected empty result for empty bundle, got {result}"


### PR DESCRIPTION
## Summary
- Tests now use the same `AlkahestClient` constructor path as real users
- Previously, tests used `env.alice_client`/`env.bob_client` which bypassed Python constructor initialization
- This change ensures test coverage catches bugs in the actual SDK interface

## Changes
- Add `alice_private_key` and `bob_private_key` fields to `EnvTestManager` 
- Remove pre-built `alice_client`/`bob_client` from `EnvTestManager`
- Add `conftest.py` with pytest fixtures that create clients via `AlkahestClient(private_key, rpc_url, address_config)`
- Update all 63 test files to use the new fixtures

## Test plan
- [x] All 88 tests pass with `uv run python -m pytest alkahest_py/`
- [x] Tests now exercise the same initialization path users would hit

🤖 Generated with [Claude Code](https://claude.com/claude-code)