### PR TITLE
fix: use SafeERC20 for ERC20 transfers to support weird tokens

### DIFF
--- a/contracts/src/obligations/escrow/non-tierable/ERC20EscrowObligation.sol
+++ b/contracts/src/obligations/escrow/non-tierable/ERC20EscrowObligation.sol
@@ -8,9 +8,11 @@ import {Attestation} from "@eas/Common.sol";
 import {IEAS} from "@eas/IEAS.sol";
 import {ISchemaRegistry} from "@eas/ISchemaRegistry.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 
 contract ERC20EscrowObligation is BaseEscrowObligation, IArbiter {
     using ArbiterUtils for Attestation;
+    using SafeERC20 for IERC20;
 
     struct ObligationData {
         address arbiter;
@@ -54,18 +56,11 @@ contract ERC20EscrowObligation is BaseEscrowObligation, IArbiter {
         // Check balance before transfer
         uint256 balanceBefore = IERC20(decoded.token).balanceOf(address(this));
 
-        bool success;
-        try
-            IERC20(decoded.token).transferFrom(
-                from,
-                address(this),
-                decoded.amount
-            )
-        returns (bool result) {
-            success = result;
-        } catch {
-            success = false;
-        }
+        bool success = IERC20(decoded.token).trySafeTransferFrom(
+            from,
+            address(this),
+            decoded.amount
+        );
 
         // Check balance after transfer
         uint256 balanceAfter = IERC20(decoded.token).balanceOf(address(this));
@@ -95,14 +90,7 @@ contract ERC20EscrowObligation is BaseEscrowObligation, IArbiter {
         // Check balance before transfer
         uint256 balanceBefore = IERC20(decoded.token).balanceOf(to);
 
-        bool success;
-        try IERC20(decoded.token).transfer(to, decoded.amount) returns (
-            bool result
-        ) {
-            success = result;
-        } catch {
-            success = false;
-        }
+        bool success = IERC20(decoded.token).trySafeTransfer(to, decoded.amount);
 
         // Check balance after transfer
         uint256 balanceAfter = IERC20(decoded.token).balanceOf(to);

--- a/contracts/src/obligations/escrow/tierable/ERC20EscrowObligation.sol
+++ b/contracts/src/obligations/escrow/tierable/ERC20EscrowObligation.sol
@@ -8,9 +8,11 @@ import {Attestation} from "@eas/Common.sol";
 import {IEAS} from "@eas/IEAS.sol";
 import {ISchemaRegistry} from "@eas/ISchemaRegistry.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 
 contract ERC20EscrowObligation is BaseEscrowObligationTierable, IArbiter {
     using ArbiterUtils for Attestation;
+    using SafeERC20 for IERC20;
 
     struct ObligationData {
         address arbiter;
@@ -54,18 +56,11 @@ contract ERC20EscrowObligation is BaseEscrowObligationTierable, IArbiter {
         // Check balance before transfer
         uint256 balanceBefore = IERC20(decoded.token).balanceOf(address(this));
 
-        bool success;
-        try
-            IERC20(decoded.token).transferFrom(
-                from,
-                address(this),
-                decoded.amount
-            )
-        returns (bool result) {
-            success = result;
-        } catch {
-            success = false;
-        }
+        bool success = IERC20(decoded.token).trySafeTransferFrom(
+            from,
+            address(this),
+            decoded.amount
+        );
 
         // Check balance after transfer
         uint256 balanceAfter = IERC20(decoded.token).balanceOf(address(this));
@@ -95,14 +90,7 @@ contract ERC20EscrowObligation is BaseEscrowObligationTierable, IArbiter {
         // Check balance before transfer
         uint256 balanceBefore = IERC20(decoded.token).balanceOf(to);
 
-        bool success;
-        try IERC20(decoded.token).transfer(to, decoded.amount) returns (
-            bool result
-        ) {
-            success = result;
-        } catch {
-            success = false;
-        }
+        bool success = IERC20(decoded.token).trySafeTransfer(to, decoded.amount);
 
         // Check balance after transfer
         uint256 balanceAfter = IERC20(decoded.token).balanceOf(to);

--- a/contracts/src/obligations/payment/ERC20PaymentObligation.sol
+++ b/contracts/src/obligations/payment/ERC20PaymentObligation.sol
@@ -5,12 +5,14 @@ import {Attestation} from "@eas/Common.sol";
 import {IEAS, AttestationRequest, AttestationRequestData, RevocationRequest, RevocationRequestData} from "@eas/IEAS.sol";
 import {ISchemaRegistry} from "@eas/ISchemaRegistry.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import {BaseObligation} from "../../BaseObligation.sol";
 import {IArbiter} from "../../IArbiter.sol";
 import {ArbiterUtils} from "../../ArbiterUtils.sol";
 
 contract ERC20PaymentObligation is BaseObligation, IArbiter {
     using ArbiterUtils for Attestation;
+    using SafeERC20 for IERC20;
 
     struct ObligationData {
         address token;
@@ -76,18 +78,11 @@ contract ERC20PaymentObligation is BaseObligation, IArbiter {
             (ObligationData)
         );
 
-        bool success;
-        try
-            IERC20(obligationData.token).transferFrom(
-                payer,
-                obligationData.payee,
-                obligationData.amount
-            )
-        returns (bool result) {
-            success = result;
-        } catch {
-            success = false;
-        }
+        bool success = IERC20(obligationData.token).trySafeTransferFrom(
+            payer,
+            obligationData.payee,
+            obligationData.amount
+        );
 
         if (!success) {
             revert ERC20TransferFailed(

--- a/contracts/src/obligations/payment/TokenBundlePaymentObligation.sol
+++ b/contracts/src/obligations/payment/TokenBundlePaymentObligation.sol
@@ -5,6 +5,7 @@ import {Attestation} from "@eas/Common.sol";
 import {IEAS, AttestationRequest, AttestationRequestData} from "@eas/IEAS.sol";
 import {ISchemaRegistry} from "@eas/ISchemaRegistry.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import {IERC721} from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
 import {IERC1155} from "@openzeppelin/contracts/token/ERC1155/IERC1155.sol";
 import {BaseObligation} from "../../BaseObligation.sol";
@@ -13,6 +14,7 @@ import {ArbiterUtils} from "../../ArbiterUtils.sol";
 
 contract TokenBundlePaymentObligation is BaseObligation, IArbiter {
     using ArbiterUtils for Attestation;
+    using SafeERC20 for IERC20;
 
     struct ObligationData {
         // Native tokens
@@ -154,13 +156,10 @@ contract TokenBundlePaymentObligation is BaseObligation, IArbiter {
     function transferBundle(ObligationData memory data, address from) internal {
         // Transfer ERC20s
         for (uint i = 0; i < data.erc20Tokens.length; i++) {
-            require(
-                IERC20(data.erc20Tokens[i]).transferFrom(
-                    from,
-                    data.payee,
-                    data.erc20Amounts[i]
-                ),
-                "ERC20 transfer failed"
+            IERC20(data.erc20Tokens[i]).safeTransferFrom(
+                from,
+                data.payee,
+                data.erc20Amounts[i]
             );
         }
 


### PR DESCRIPTION
## Summary
- Replace direct `transfer`/`transferFrom` calls with SafeERC20's `trySafeTransfer`/`trySafeTransferFrom` to properly handle ERC20 tokens that don't return a boolean value (like USDT, BNB, OMG)
- Upgrade OpenZeppelin to v5.5.0 to access `trySafeTransfer` functions
- Preserve custom `ERC20TransferFailed` errors while properly handling weird ERC20 tokens

## Updated contracts
- `ERC20EscrowObligation` (non-tierable and tierable)
- `TokenBundleEscrowObligation` (non-tierable and tierable)
- `ERC20PaymentObligation`
- `TokenBundlePaymentObligation`

## Test plan
- [ ] Verify contracts compile successfully
- [ ] Run existing test suite
- [ ] Test with standard ERC20 tokens
- [ ] Test with non-standard ERC20 tokens (no return value)

🤖 Generated with [Claude Code](https://claude.com/claude-code)