### PR TITLE
fix: add reentrancy guards to escrow functions as preventative measure

### DIFF
--- a/contracts/src/BaseEscrowObligation.sol
+++ b/contracts/src/BaseEscrowObligation.sol
@@ -58,7 +58,7 @@ abstract contract BaseEscrowObligation is BaseObligation {
     function collectEscrowRaw(
         bytes32 _escrow,
         bytes32 _fulfillment
-    ) public virtual returns (bytes memory) {
+    ) public virtual nonReentrant returns (bytes memory) {
         Attestation memory escrow;
         Attestation memory fulfillment;
 
@@ -120,7 +120,7 @@ abstract contract BaseEscrowObligation is BaseObligation {
         return result;
     }
 
-    function reclaimExpired(bytes32 uid) public virtual returns (bool) {
+    function reclaimExpired(bytes32 uid) public virtual nonReentrant returns (bool) {
         Attestation memory attestation;
 
         // Get attestation with error handling

--- a/contracts/src/BaseEscrowObligationTierable.sol
+++ b/contracts/src/BaseEscrowObligationTierable.sol
@@ -58,7 +58,7 @@ abstract contract BaseEscrowObligationTierable is BaseObligation {
     function collectEscrowRaw(
         bytes32 _escrow,
         bytes32 _fulfillment
-    ) public virtual returns (bytes memory) {
+    ) public virtual nonReentrant returns (bytes memory) {
         Attestation memory escrow;
         Attestation memory fulfillment;
 
@@ -120,7 +120,7 @@ abstract contract BaseEscrowObligationTierable is BaseObligation {
         return result;
     }
 
-    function reclaimExpired(bytes32 uid) public virtual returns (bool) {
+    function reclaimExpired(bytes32 uid) public virtual nonReentrant returns (bool) {
         Attestation memory attestation;
 
         // Get attestation with error handling

--- a/contracts/src/BaseObligation.sol
+++ b/contracts/src/BaseObligation.sol
@@ -5,8 +5,9 @@ import {BaseAttester} from "./BaseAttester.sol";
 import {IEAS} from "@eas/IEAS.sol";
 import {ISchemaRegistry} from "@eas/ISchemaRegistry.sol";
 import {Attestation} from "@eas/Common.sol";
+import {ReentrancyGuard} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
 
-abstract contract BaseObligation is BaseAttester {
+abstract contract BaseObligation is BaseAttester, ReentrancyGuard {
     constructor(
         IEAS _eas,
         ISchemaRegistry _schemaRegistry,
@@ -33,7 +34,7 @@ abstract contract BaseObligation is BaseAttester {
         uint64 expirationTime,
         address recipient,
         bytes32 refUID
-    ) internal virtual returns (bytes32 uid_) {
+    ) internal virtual nonReentrant returns (bytes32 uid_) {
         _beforeAttest(data, msg.sender, recipient);
         uid_ = _attest(data, recipient, expirationTime, refUID);
         _afterAttest(uid_, data, msg.sender, recipient);

--- a/contracts/src/obligations/escrow/non-tierable/TokenBundleEscrowObligation.sol
+++ b/contracts/src/obligations/escrow/non-tierable/TokenBundleEscrowObligation.sol
@@ -580,7 +580,7 @@ contract TokenBundleEscrowObligation is
     function unsafePartiallyCollectEscrow(
         bytes32 _escrow,
         bytes32 _fulfillment
-    ) external returns (bool) {
+    ) external nonReentrant returns (bool) {
         Attestation memory escrow;
         Attestation memory fulfillment;
 
@@ -642,7 +642,7 @@ contract TokenBundleEscrowObligation is
     /// @dev Use only as a last resort when some tokens in the bundle cannot be reclaimed.
     /// Failed transfers emit events but do not revert. The escrow will be marked as reclaimed
     /// even if some tokens remain stuck. This can result in permanent loss of stuck tokens.
-    function unsafePartiallyReclaimExpired(bytes32 uid) external returns (bool) {
+    function unsafePartiallyReclaimExpired(bytes32 uid) external nonReentrant returns (bool) {
         Attestation memory attestation;
 
         // Get attestation with error handling

--- a/contracts/src/obligations/escrow/tierable/TokenBundleEscrowObligation.sol
+++ b/contracts/src/obligations/escrow/tierable/TokenBundleEscrowObligation.sol
@@ -580,7 +580,7 @@ contract TokenBundleEscrowObligation is
     function unsafePartiallyCollectEscrow(
         bytes32 _escrow,
         bytes32 _fulfillment
-    ) external returns (bool) {
+    ) external nonReentrant returns (bool) {
         Attestation memory escrow;
         Attestation memory fulfillment;
 
@@ -642,7 +642,7 @@ contract TokenBundleEscrowObligation is
     /// @dev Use only as a last resort when some tokens in the bundle cannot be reclaimed.
     /// Failed transfers emit events but do not revert. The escrow will be marked as reclaimed
     /// even if some tokens remain stuck. This can result in permanent loss of stuck tokens.
-    function unsafePartiallyReclaimExpired(bytes32 uid) external returns (bool) {
+    function unsafePartiallyReclaimExpired(bytes32 uid) external nonReentrant returns (bool) {
         Attestation memory attestation;
 
         // Get attestation with error handling


### PR DESCRIPTION
## Summary
- Add OpenZeppelin's ReentrancyGuard to base obligation contracts
- Protect functions that call `_releaseEscrow` or `_returnEscrow` (which use `call` to send ETH)
- Preventative measure per Zellic audit recommendation

## Protected Functions
- `BaseObligation._doObligationForRaw`
- `BaseEscrowObligation.collectEscrowRaw`
- `BaseEscrowObligation.reclaimExpired`
- `BaseEscrowObligationTierable.collectEscrowRaw`
- `BaseEscrowObligationTierable.reclaimExpired`
- `TokenBundleEscrowObligation.unsafePartiallyCollectEscrow` (both non-tierable and tierable)
- `TokenBundleEscrowObligation.unsafePartiallyReclaimExpired` (both non-tierable and tierable)

## Audit Context
> As mentioned in the first kickoff regarding the reentrancy vulnerability risk in this audit, I'd like to add some of my conclusions here. I didn't find any feasible call chain for "repeatedly releasing the same escrow asset via reentrancy" because escrow is already revoked before _releaseEscrow is entered. However, to prevent potential future code changes, adding a reentrancy lock could be considered as a preventative measure.

No actual reentrancy vulnerability exists in the current code since escrow attestations are revoked before `_releaseEscrow` is called. This is a defense-in-depth measure to protect against potential future vulnerabilities.

## Test plan
- [x] All 457 existing tests pass
- [x] Contracts compile without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)