### PR TITLE
feature: Add CommitRevealObligation and schema tagging for StringObligation

### DIFF
--- a/contracts/src/obligations/CommitRevealObligation.sol
+++ b/contracts/src/obligations/CommitRevealObligation.sol
@@ -1,0 +1,177 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.26;
+
+import {Attestation} from "@eas/Common.sol";
+import {IEAS} from "@eas/IEAS.sol";
+import {ISchemaRegistry} from "@eas/ISchemaRegistry.sol";
+import {BaseObligation} from "../BaseObligation.sol";
+import {IArbiter} from "../IArbiter.sol";
+import {ArbiterUtils} from "../ArbiterUtils.sol";
+import {ReentrancyGuard} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
+
+/// @title CommitRevealObligation
+/// @notice Obligation with built-in commit–reveal anti-front‑running checks.
+/// The attestation data is self contained (payload + salt), and the arbiter
+/// verifies that a matching commit exists and was made in an earlier block.
+contract CommitRevealObligation is BaseObligation, IArbiter, ReentrancyGuard {
+    using ArbiterUtils for Attestation;
+
+    /// @dev Data stored inside the fulfillment attestation.
+    struct ObligationData {
+        bytes payload; // arbitrary self-contained data the fulfiller reveals
+        bytes32 salt;  // fulfiller-chosen salt to harden the commitment
+        bytes32 schema; // arbitrary tag describing the payload format
+    }
+
+    /// @dev Per-escrow commitment details for a fulfiller.
+    struct CommitInfo {
+        bytes32 commitment;
+        uint64 commitBlock;
+    }
+
+    /// @notice commitments[escrowUid][claimer] => commit information.
+    mapping(bytes32 => mapping(address => CommitInfo)) public commitments;
+    /// @notice bondClaimed[obligationUid] => bond already returned.
+    mapping(bytes32 => bool) public bondClaimed;
+
+    event Committed(bytes32 indexed escrowUid, address indexed claimer, bytes32 commitment);
+    event BondReclaimed(bytes32 indexed obligationUid, address indexed claimer, uint256 amount);
+
+    error CommitmentMissing(bytes32 escrowUid, address claimer);
+    error CommitmentTooRecent(bytes32 escrowUid, address claimer);
+    error CommitmentMismatch(bytes32 escrowUid, address claimer);
+    error BondAlreadyClaimed(bytes32 obligationUid);
+    error NoBondToReclaim(bytes32 escrowUid, address claimer);
+
+    /// @notice Fixed bond amount required for each commit.
+    uint256 public immutable bondAmount;
+
+    constructor(IEAS _eas, ISchemaRegistry _schemaRegistry, uint256 _bondAmount)
+        BaseObligation(_eas, _schemaRegistry, "bytes payload, bytes32 salt, bytes32 schema", true)
+    {
+        bondAmount = _bondAmount;
+    }
+
+    // ---------------------------------------------------------------------
+    // Attestation (reveal) path
+    // ---------------------------------------------------------------------
+
+    /// @notice Creates a fulfillment attestation containing the payload and salt.
+    /// @param data Revealed data (must match a prior commit) and salt.
+    /// @param refUID Escrow attestation UID being fulfilled.
+    function doObligation(ObligationData calldata data, bytes32 refUID) external returns (bytes32 uid_) {
+        bytes memory encodedData = abi.encode(data);
+        uid_ = _doObligationForRaw(encodedData, 0, msg.sender, refUID);
+    }
+
+    // ---------------------------------------------------------------------
+    // Commit phase helpers
+    // ---------------------------------------------------------------------
+
+    /// @notice Records a commitment for a given escrow UID and claimer, locking the fixed bond.
+    /// @param escrowUid UID of the escrow attestation this commitment targets.
+    /// @param commitment keccak256(abi.encode(escrowUid, claimer, keccak256(abi.encode(data)))).
+    /// @dev msg.value must equal `bondAmount` and is held as a bond reclaimable after a valid reveal.
+    function commit(bytes32 escrowUid, bytes32 commitment) external payable {
+        require(commitment != bytes32(0), "empty commitment");
+        require(msg.value == bondAmount, "incorrect bond");
+
+        commitments[escrowUid][msg.sender] = CommitInfo({
+            commitment: commitment,
+            commitBlock: uint64(block.number)
+        });
+
+        emit Committed(escrowUid, msg.sender, commitment);
+    }
+
+    /// @notice Pure helper to compute the commitment expected by this contract.
+    function computeCommitment(bytes32 escrowUid, address claimer, ObligationData calldata data)
+        external
+        pure
+        returns (bytes32)
+    {
+        return keccak256(abi.encode(escrowUid, claimer, keccak256(abi.encode(data))));
+    }
+
+    // ---------------------------------------------------------------------
+    // Arbiter logic (called from escrow contracts)
+    // ---------------------------------------------------------------------
+
+    /// @inheritdoc IArbiter
+    function checkObligation(
+        Attestation memory obligation,
+        bytes memory /* demand (unused) */,
+        bytes32 fulfilling
+    ) public view override returns (bool) {
+        // Basic attestation sanity checks (schema + expiry + revocation)
+        obligation._checkIntrinsic(ATTESTATION_SCHEMA);
+
+        // Lookup the prior commitment made by the fulfiller for this escrow
+        CommitInfo memory info = commitments[fulfilling][obligation.recipient];
+        if (info.commitment == bytes32(0)) {
+            revert CommitmentMissing(fulfilling, obligation.recipient);
+        }
+
+        // Enforce commit happened in an earlier block to block same-block frontruns
+        if (info.commitBlock >= block.number) {
+            revert CommitmentTooRecent(fulfilling, obligation.recipient);
+        }
+
+        // Recompute commitment from the revealed data and compare
+        bytes32 revealedCommitment = keccak256(
+            abi.encode(fulfilling, obligation.recipient, keccak256(obligation.data))
+        );
+
+        if (revealedCommitment != info.commitment) {
+            revert CommitmentMismatch(fulfilling, obligation.recipient);
+        }
+
+        return true;
+    }
+
+    // ---------------------------------------------------------------------
+    // Bond reclaim
+    // ---------------------------------------------------------------------
+
+    /// @notice Returns the bond associated with a fulfilled attestation to its claimer.
+    /// @param obligationUid UID of the fulfillment attestation (reveal).
+    function reclaimBond(bytes32 obligationUid) external nonReentrant returns (uint256 amount) {
+        Attestation memory obligation = _getAttestation(obligationUid);
+
+        address claimer = obligation.recipient;
+        if (bondClaimed[obligationUid]) revert BondAlreadyClaimed(obligationUid);
+
+        bytes32 escrowUid = obligation.refUID;
+        CommitInfo memory info = commitments[escrowUid][claimer];
+        if (info.commitment == bytes32(0)) revert CommitmentMissing(escrowUid, claimer);
+
+        // Ensure commitment matches the revealed data
+        bytes32 revealedCommitment = keccak256(
+            abi.encode(escrowUid, claimer, keccak256(obligation.data))
+        );
+        if (revealedCommitment != info.commitment) revert CommitmentMismatch(escrowUid, claimer);
+
+        amount = bondAmount;
+        if (amount == 0) revert NoBondToReclaim(escrowUid, claimer);
+
+        bondClaimed[obligationUid] = true;
+
+        (bool success, ) = claimer.call{value: amount}("");
+        require(success, "bond transfer failed");
+
+        emit BondReclaimed(obligationUid, claimer, amount);
+    }
+
+    // ---------------------------------------------------------------------
+    // Convenience getters
+    // ---------------------------------------------------------------------
+
+    function getObligationData(bytes32 uid) external view returns (ObligationData memory) {
+        Attestation memory attestation = _getAttestation(uid);
+        return abi.decode(attestation.data, (ObligationData));
+    }
+
+    function decodeObligationData(bytes calldata data) external pure returns (ObligationData memory) {
+        return abi.decode(data, (ObligationData));
+    }
+}

--- a/contracts/src/obligations/StringObligation.sol
+++ b/contracts/src/obligations/StringObligation.sol
@@ -9,12 +9,13 @@ import {BaseObligation} from "../BaseObligation.sol";
 contract StringObligation is BaseObligation {
     struct ObligationData {
         string item;
+        bytes32 schema; // arbitrary tag describing the payload format
     }
 
     constructor(
         IEAS _eas,
         ISchemaRegistry _schemaRegistry
-    ) BaseObligation(_eas, _schemaRegistry, "string item", true) {}
+    ) BaseObligation(_eas, _schemaRegistry, "string item, bytes32 schema", true) {}
 
     function doObligation(
         ObligationData calldata data,

--- a/contracts/src/obligations/example/ApiCallExample1.sol
+++ b/contracts/src/obligations/example/ApiCallExample1.sol
@@ -108,8 +108,7 @@ contract ApiCallExample1 {
         bytes32 escrowUid
     ) external returns (bytes32 fulfillmentUid) {
         // Submit the result via StringObligation with reference to the escrow
-        StringObligation.ObligationData memory resultData = StringObligation
-            .ObligationData({item: apiResult});
+        StringObligation.ObligationData memory resultData = StringObligation.ObligationData({item: apiResult, schema: bytes32(0)});
 
         fulfillmentUid = stringObligation.doObligation(resultData, escrowUid);
 

--- a/contracts/test/gas/EscrowCommitRevealOracleGas.t.sol
+++ b/contracts/test/gas/EscrowCommitRevealOracleGas.t.sol
@@ -1,0 +1,254 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.26;
+
+import "forge-std/Test.sol";
+import {IEAS} from "@eas/IEAS.sol";
+import {ISchemaRegistry} from "@eas/ISchemaRegistry.sol";
+import {CommitRevealObligation} from "@src/obligations/CommitRevealObligation.sol";
+import {TrustedOracleArbiter} from "@src/arbiters/TrustedOracleArbiter.sol";
+import {ERC20EscrowObligation} from "@src/obligations/escrow/non-tierable/ERC20EscrowObligation.sol";
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import {EASDeployer} from "@test/utils/EASDeployer.sol";
+
+contract MockToken is ERC20 {
+    constructor() ERC20("Mock Token", "MOCK") {
+        _mint(msg.sender, 1_000_000e18);
+    }
+
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+}
+
+contract EscrowCommitRevealOracleGasTest is Test {
+    IEAS internal eas;
+    ISchemaRegistry internal schemaRegistry;
+    CommitRevealObligation internal commitReveal;
+    TrustedOracleArbiter internal trustedOracleArbiter;
+    ERC20EscrowObligation internal erc20Escrow;
+    MockToken internal paymentToken;
+
+    address internal alice;
+    address internal bob;
+    address internal charlie;
+
+    uint256 internal constant PAYMENT_AMOUNT = 100e18;
+    uint256 internal constant BOND = 0.1 ether;
+    uint256 internal constant PAYLOAD_SIZE = 64;
+
+    function setUp() public {
+        EASDeployer easDeployer = new EASDeployer();
+        (eas, schemaRegistry) = easDeployer.deployEAS();
+
+        commitReveal = new CommitRevealObligation(eas, schemaRegistry, BOND, 1 hours, address(0));
+        trustedOracleArbiter = new TrustedOracleArbiter(eas);
+        erc20Escrow = new ERC20EscrowObligation(eas, schemaRegistry);
+
+        paymentToken = new MockToken();
+
+        alice = makeAddr("alice");
+        bob = makeAddr("bob");
+        charlie = makeAddr("charlie");
+
+        paymentToken.mint(alice, PAYMENT_AMOUNT * 10);
+        vm.deal(alice, 10 ether);
+        vm.deal(bob, 10 ether);
+        vm.deal(charlie, 10 ether);
+    }
+
+    function _innerDemand() internal pure returns (bytes memory) {
+        return abi.encode("QUERY");
+    }
+
+    function _escrowData(bytes memory demand) internal view returns (ERC20EscrowObligation.ObligationData memory) {
+        return ERC20EscrowObligation.ObligationData({
+            token: address(paymentToken),
+            amount: PAYMENT_AMOUNT,
+            arbiter: address(trustedOracleArbiter),
+            demand: demand
+        });
+    }
+
+    function _commitData() internal pure returns (CommitRevealObligation.ObligationData memory) {
+        bytes memory payload = new bytes(PAYLOAD_SIZE);
+        return CommitRevealObligation.ObligationData({
+            payload: payload,
+            salt: bytes32("salt"),
+            schema: bytes32("schema")
+        });
+    }
+
+    function _commitDataWithSize(uint256 payloadSize)
+        internal
+        pure
+        returns (CommitRevealObligation.ObligationData memory)
+    {
+        bytes memory payload = new bytes(payloadSize);
+        return CommitRevealObligation.ObligationData({
+            payload: payload,
+            salt: bytes32("salt"),
+            schema: bytes32("schema")
+        });
+    }
+
+
+    function _createEscrow() internal returns (bytes32 escrowUid, bytes memory innerDemand) {
+        innerDemand = _innerDemand();
+        bytes memory demand = abi.encode(TrustedOracleArbiter.DemandData({oracle: charlie, data: innerDemand}));
+        ERC20EscrowObligation.ObligationData memory escrowData = _escrowData(demand);
+
+        vm.startPrank(alice);
+        paymentToken.approve(address(erc20Escrow), PAYMENT_AMOUNT);
+        escrowUid = erc20Escrow.doObligation(escrowData, uint64(block.timestamp + 1 days));
+        vm.stopPrank();
+    }
+
+    function _setupEscrowAndCommit()
+        internal
+        returns (bytes32 escrowUid, bytes memory innerDemand, CommitRevealObligation.ObligationData memory data)
+    {
+        (escrowUid, innerDemand) = _createEscrow();
+        data = _commitData();
+
+        bytes32 commitment = commitReveal.computeCommitment(escrowUid, bob, data);
+        vm.deal(bob, BOND);
+        vm.prank(bob);
+        commitReveal.commit{value: BOND}(commitment);
+    }
+
+    function _setupEscrowCommitReveal()
+        internal
+        returns (bytes32 escrowUid, bytes32 fulfillmentUid, bytes memory innerDemand)
+    {
+        CommitRevealObligation.ObligationData memory data;
+        (escrowUid, innerDemand, data) = _setupEscrowAndCommit();
+
+        vm.roll(block.number + 1);
+        vm.prank(bob);
+        fulfillmentUid = commitReveal.doObligation(data, escrowUid);
+    }
+
+    // ---------------------------------------------------------------------
+    // Gas measurements (one measured call per test)
+    // ---------------------------------------------------------------------
+
+    function testGas_Escrower_Approve() public {
+        vm.prank(alice);
+        paymentToken.approve(address(erc20Escrow), PAYMENT_AMOUNT);
+    }
+
+    function testGas_Escrower_CreateEscrow() public {
+        bytes memory innerDemand = _innerDemand();
+        bytes memory demand = abi.encode(TrustedOracleArbiter.DemandData({oracle: charlie, data: innerDemand}));
+        ERC20EscrowObligation.ObligationData memory escrowData = _escrowData(demand);
+
+        vm.pauseGasMetering();
+        vm.prank(alice);
+        paymentToken.approve(address(erc20Escrow), PAYMENT_AMOUNT);
+        vm.resumeGasMetering();
+
+        vm.prank(alice);
+        erc20Escrow.doObligation(escrowData, uint64(block.timestamp + 1 days));
+    }
+
+    function testGas_Fulfiller_Commit() public {
+        vm.pauseGasMetering();
+        (bytes32 escrowUid, ) = _createEscrow();
+        CommitRevealObligation.ObligationData memory data = _commitData();
+        bytes32 commitment = commitReveal.computeCommitment(escrowUid, bob, data);
+        vm.deal(bob, BOND);
+        vm.resumeGasMetering();
+
+        vm.prank(bob);
+        commitReveal.commit{value: BOND}(commitment);
+    }
+
+    function testGas_Fulfiller_Reveal() public {
+        vm.pauseGasMetering();
+        (bytes32 escrowUid, , CommitRevealObligation.ObligationData memory data) = _setupEscrowAndCommit();
+        vm.roll(block.number + 1);
+        vm.resumeGasMetering();
+
+        vm.prank(bob);
+        commitReveal.doObligation(data, escrowUid);
+    }
+
+    function testGas_Fulfiller_RequestArbitration() public {
+        vm.pauseGasMetering();
+        (bytes32 escrowUid, bytes32 fulfillmentUid, bytes memory innerDemand) = _setupEscrowCommitReveal();
+        escrowUid;
+        vm.resumeGasMetering();
+
+        vm.prank(bob);
+        trustedOracleArbiter.requestArbitration(fulfillmentUid, charlie, innerDemand);
+    }
+
+    function testGas_Oracle_Arbitrate() public {
+        vm.pauseGasMetering();
+        (, bytes32 fulfillmentUid, bytes memory innerDemand) = _setupEscrowCommitReveal();
+        vm.resumeGasMetering();
+
+        vm.prank(charlie);
+        trustedOracleArbiter.arbitrate(fulfillmentUid, innerDemand, true);
+    }
+
+    function testGas_Fulfiller_CollectEscrow() public {
+        vm.pauseGasMetering();
+        (bytes32 escrowUid, bytes32 fulfillmentUid, bytes memory innerDemand) = _setupEscrowCommitReveal();
+        vm.prank(charlie);
+        trustedOracleArbiter.arbitrate(fulfillmentUid, innerDemand, true);
+        vm.resumeGasMetering();
+
+        vm.prank(bob);
+        erc20Escrow.collectEscrow(escrowUid, fulfillmentUid);
+    }
+
+    function testGas_Fulfiller_ReclaimBond() public {
+        vm.pauseGasMetering();
+        (, bytes32 fulfillmentUid, ) = _setupEscrowCommitReveal();
+        vm.resumeGasMetering();
+
+        vm.prank(bob);
+        commitReveal.reclaimBond(fulfillmentUid);
+    }
+
+    function _measureRevealWithPayload(uint256 payloadSize) internal {
+        vm.pauseGasMetering();
+        (bytes32 escrowUid, ) = _createEscrow();
+        CommitRevealObligation.ObligationData memory data = _commitDataWithSize(payloadSize);
+        bytes32 commitment = commitReveal.computeCommitment(escrowUid, bob, data);
+        vm.deal(bob, BOND);
+        vm.prank(bob);
+        commitReveal.commit{value: BOND}(commitment);
+        vm.roll(block.number + 1);
+        vm.resumeGasMetering();
+
+        vm.prank(bob);
+        commitReveal.doObligation(data, escrowUid);
+    }
+
+    function testGas_Payload_0() public {
+        _measureRevealWithPayload(0);
+    }
+
+    function testGas_Payload_32() public {
+        _measureRevealWithPayload(32);
+    }
+
+    function testGas_Payload_128() public {
+        _measureRevealWithPayload(128);
+    }
+
+    function testGas_Payload_512() public {
+        _measureRevealWithPayload(512);
+    }
+
+    function testGas_Payload_2048() public {
+        _measureRevealWithPayload(2048);
+    }
+
+    function testGas_Payload_4096() public {
+        _measureRevealWithPayload(4096);
+    }
+
+}

--- a/contracts/test/integration/ApiCallExample1.t.sol
+++ b/contracts/test/integration/ApiCallExample1.t.sol
@@ -133,8 +133,7 @@ contract ApiCallExample1Test is Test {
 
         // Step 2: Bob submits API result using StringObligation
         vm.startPrank(bob);
-        StringObligation.ObligationData memory resultData = StringObligation
-            .ObligationData({item: API_RESULT});
+        StringObligation.ObligationData memory resultData = StringObligation.ObligationData({item: API_RESULT, schema: bytes32(0)});
 
         bytes32 fulfillmentUid = stringObligation.doObligation(
             resultData,
@@ -204,7 +203,7 @@ contract ApiCallExample1Test is Test {
         // Bob submits result
         vm.prank(bob);
         bytes32 fulfillmentUid = stringObligation.doObligation(
-            StringObligation.ObligationData({item: API_RESULT}),
+            StringObligation.ObligationData({item: API_RESULT, schema: bytes32(0)}),
             escrowUid
         );
 
@@ -260,7 +259,7 @@ contract ApiCallExample1Test is Test {
         // Bob submits wrong result
         vm.prank(bob);
         bytes32 fulfillmentUid = stringObligation.doObligation(
-            StringObligation.ObligationData({item: "wrong result"}),
+            StringObligation.ObligationData({item: "wrong result", schema: bytes32(0)}),
             escrowUid
         );
 

--- a/contracts/test/integration/AttestationEscrowObligation.t.sol
+++ b/contracts/test/integration/AttestationEscrowObligation.t.sol
@@ -117,7 +117,7 @@ contract AttestationEscrowObligationTest is Test {
 
         vm.prank(bob);
         bytes32 fulfillmentId = stringObligation.doObligation(
-            StringObligation.ObligationData({item: "Test demand"}),
+            StringObligation.ObligationData({item: "Test demand", schema: bytes32(0)}),
             escrowId  // Reference the escrow for non-tierable pattern
         );
 

--- a/contracts/test/integration/ERC8004.t.sol
+++ b/contracts/test/integration/ERC8004.t.sol
@@ -172,7 +172,7 @@ contract ERC8004IntegrationTest is Test {
         // === Step 2: Bob creates a fulfillment obligation ===
         vm.prank(bob);
         bytes32 fulfillmentUid = fulfillmentObligation.doObligation(
-            StringObligation.ObligationData({item: "<fullfillment data>"}),
+            StringObligation.ObligationData({item: "<fullfillment data>", schema: bytes32(0)}),
             escrowUid // Reference the escrow
         );
 
@@ -282,7 +282,7 @@ contract ERC8004IntegrationTest is Test {
         // === Step 2: Bob creates a fulfillment obligation ===
         vm.prank(bob);
         bytes32 fulfillmentUid = fulfillmentObligation.doObligation(
-            StringObligation.ObligationData({item: "<fulfillment data>"}),
+            StringObligation.ObligationData({item: "<fulfillment data>", schema: bytes32(0)}),
             escrowUid
         );
 
@@ -356,7 +356,7 @@ contract ERC8004IntegrationTest is Test {
         // === Step 2: Bob creates a fulfillment obligation ===
         vm.prank(bob);
         bytes32 fulfillmentUid = fulfillmentObligation.doObligation(
-            StringObligation.ObligationData({item: "<fulfillment data>"}),
+            StringObligation.ObligationData({item: "<fulfillment data>", schema: bytes32(0)}),
             escrowUid
         );
 
@@ -427,7 +427,7 @@ contract ERC8004IntegrationTest is Test {
         // === Step 2: Bob creates a fulfillment obligation ===
         vm.prank(bob);
         bytes32 fulfillmentUid = fulfillmentObligation.doObligation(
-            StringObligation.ObligationData({item: "<fulfillment data>"}),
+            StringObligation.ObligationData({item: "<fulfillment data>", schema: bytes32(0)}),
             escrowUid
         );
 

--- a/contracts/test/integration/MajorityVoteArbiter.t.sol
+++ b/contracts/test/integration/MajorityVoteArbiter.t.sol
@@ -72,7 +72,7 @@ contract MajorityVoteArbiterTest is Test {
         // Register a test schema
         vm.prank(attester);
         testSchema = schemaRegistry.register(
-            "string item",
+            "string item, bytes32 schema",
             ISchemaResolver(address(0)),
             true // revocable
         );

--- a/contracts/test/integration/StringCapitalizer.t.sol
+++ b/contracts/test/integration/StringCapitalizer.t.sol
@@ -45,8 +45,7 @@ contract StringCapitalizerTest is Test {
             .DemandData({query: "hello world"});
 
         // Create an obligation with the capitalized result
-        StringObligation.ObligationData memory obligationData = StringObligation
-            .ObligationData({item: "HELLO WORLD"});
+        StringObligation.ObligationData memory obligationData = StringObligation.ObligationData({item: "HELLO WORLD", schema: bytes32(0)});
 
         // Create the attestation as bob
         vm.prank(bob);
@@ -74,8 +73,7 @@ contract StringCapitalizerTest is Test {
             .DemandData({query: "hello world"});
 
         // Create an obligation with incorrectly capitalized result
-        StringObligation.ObligationData memory obligationData = StringObligation
-            .ObligationData({item: "Hello World"}); // Only first letters capitalized
+        StringObligation.ObligationData memory obligationData = StringObligation.ObligationData({item: "Hello World", schema: bytes32(0)}); // Only first letters capitalized
 
         // Create the attestation as bob
         vm.prank(bob);
@@ -103,8 +101,7 @@ contract StringCapitalizerTest is Test {
             .DemandData({query: "HeLLo WoRLd 123!"});
 
         // Create an obligation with correctly capitalized result
-        StringObligation.ObligationData memory obligationData = StringObligation
-            .ObligationData({item: "HELLO WORLD 123!"}); // All letters uppercase, others unchanged
+        StringObligation.ObligationData memory obligationData = StringObligation.ObligationData({item: "HELLO WORLD 123!", schema: bytes32(0)}); // All letters uppercase, others unchanged
 
         // Create the attestation as bob
         vm.prank(bob);
@@ -135,8 +132,7 @@ contract StringCapitalizerTest is Test {
             .DemandData({query: "test123@email.com"});
 
         // Create an obligation with correctly capitalized result
-        StringObligation.ObligationData memory obligationData = StringObligation
-            .ObligationData({item: "TEST123@EMAIL.COM"});
+        StringObligation.ObligationData memory obligationData = StringObligation.ObligationData({item: "TEST123@EMAIL.COM", schema: bytes32(0)});
 
         // Create the attestation as bob
         vm.prank(bob);
@@ -167,8 +163,7 @@ contract StringCapitalizerTest is Test {
             .DemandData({query: "hello"});
 
         // Create an obligation with different length string
-        StringObligation.ObligationData memory obligationData = StringObligation
-            .ObligationData({item: "HELLO WORLD"}); // Different length
+        StringObligation.ObligationData memory obligationData = StringObligation.ObligationData({item: "HELLO WORLD", schema: bytes32(0)}); // Different length
 
         // Create the attestation as bob
         vm.prank(bob);
@@ -194,7 +189,7 @@ contract StringCapitalizerTest is Test {
         // First create an escrow attestation to reference
         vm.prank(alice);
         bytes32 escrowUID = stringObligation.doObligation(
-            StringObligation.ObligationData({item: "request"}),
+            StringObligation.ObligationData({item: "request", schema: bytes32(0)}),
             bytes32(0)
         );
 
@@ -203,8 +198,7 @@ contract StringCapitalizerTest is Test {
             .DemandData({query: "hello"});
 
         // Create an obligation with correct capitalization and reference
-        StringObligation.ObligationData memory obligationData = StringObligation
-            .ObligationData({item: "HELLO"});
+        StringObligation.ObligationData memory obligationData = StringObligation.ObligationData({item: "HELLO", schema: bytes32(0)});
 
         // Create the attestation with reference UID
         vm.prank(bob);
@@ -255,7 +249,7 @@ contract StringCapitalizerTest is Test {
             recipient: bob,
             attester: alice,
             revocable: true,
-            data: abi.encode(StringObligation.ObligationData({item: "HELLO"}))
+            data: abi.encode(StringObligation.ObligationData({item: "HELLO", schema: bytes32(0)}))
         });
 
         // The arbiter should revert when checking revoked attestations
@@ -287,7 +281,7 @@ contract StringCapitalizerTest is Test {
             recipient: bob,
             attester: alice,
             revocable: true,
-            data: abi.encode(StringObligation.ObligationData({item: "HELLO"}))
+            data: abi.encode(StringObligation.ObligationData({item: "HELLO", schema: bytes32(0)}))
         });
 
         // The arbiter should revert when checking expired attestations
@@ -312,8 +306,7 @@ contract StringCapitalizerTest is Test {
         StringCapitalizer.DemandData memory demand = StringCapitalizer
             .DemandData({query: input});
 
-        StringObligation.ObligationData memory obligationData = StringObligation
-            .ObligationData({item: output});
+        StringObligation.ObligationData memory obligationData = StringObligation.ObligationData({item: output, schema: bytes32(0)});
 
         // Create the attestation
         vm.prank(bob);

--- a/contracts/test/integration/VoteEscrowObligation.t.sol
+++ b/contracts/test/integration/VoteEscrowObligation.t.sol
@@ -128,7 +128,7 @@ contract VoteEscrowObligationTest is Test {
 
         // Create fulfillment attestation via StringObligation
         bytes32 fulfillmentUid = stringObligation.doObligation(
-            StringObligation.ObligationData({item: "Vote for proposal 42"}),
+            StringObligation.ObligationData({item: "Vote for proposal 42", schema: bytes32(0)}),
             escrowUid  // Reference the escrow for non-tierable pattern
         );
         assertNotEq(
@@ -381,7 +381,7 @@ contract VoteEscrowObligationTest is Test {
         // Fulfill and collect
         vm.startPrank(bob);
         bytes32 fulfillmentUid = stringObligation.doObligation(
-            StringObligation.ObligationData({item: "Test vote"}),
+            StringObligation.ObligationData({item: "Test vote", schema: bytes32(0)}),
             escrowUid  // Reference the escrow for non-tierable pattern
         );
 
@@ -418,7 +418,7 @@ contract VoteEscrowObligationTest is Test {
         // First collection should work
         vm.startPrank(bob);
         bytes32 fulfillmentUid = stringObligation.doObligation(
-            StringObligation.ObligationData({item: "Vote once"}),
+            StringObligation.ObligationData({item: "Vote once", schema: bytes32(0)}),
             escrowUid  // Reference the escrow for non-tierable pattern
         );
         voteEscrow.collectEscrowRaw(escrowUid, fulfillmentUid);
@@ -433,7 +433,7 @@ contract VoteEscrowObligationTest is Test {
         // Second collection should fail because vote was already cast
         vm.startPrank(bob);
         bytes32 secondFulfillmentUid = stringObligation.doObligation(
-            StringObligation.ObligationData({item: "Vote once"}),
+            StringObligation.ObligationData({item: "Vote once", schema: bytes32(0)}),
             secondEscrowUid  // Reference the second escrow for non-tierable pattern
         );
 

--- a/contracts/test/unit/arbiters/TrustedOracleArbiter.t.sol
+++ b/contracts/test/unit/arbiters/TrustedOracleArbiter.t.sol
@@ -30,7 +30,7 @@ contract TrustedOracleArbiterTest is Test {
 
         // Register a test schema
         testSchema = schemaRegistry.register(
-            "string item",
+            "string item, bytes32 schema",
             ISchemaResolver(address(0)),
             true
         );

--- a/contracts/test/unit/arbiters/confirmation/ExclusiveRevocableConfirmationArbiter.t.sol
+++ b/contracts/test/unit/arbiters/confirmation/ExclusiveRevocableConfirmationArbiter.t.sol
@@ -26,7 +26,7 @@ contract ExclusiveRevocableConfirmationArbiterTest is Test {
 
         // Register a test schema
         testSchema = schemaRegistry.register(
-            "string item",
+            "string item, bytes32 schema",
             ISchemaResolver(address(0)),
             true
         );

--- a/contracts/test/unit/arbiters/confirmation/ExclusiveUnrevocableConfirmationArbiter.t.sol
+++ b/contracts/test/unit/arbiters/confirmation/ExclusiveUnrevocableConfirmationArbiter.t.sol
@@ -26,7 +26,7 @@ contract ExclusiveUnrevocableConfirmationArbiterTest is Test {
 
         // Register a test schema
         testSchema = schemaRegistry.register(
-            "string item",
+            "string item, bytes32 schema",
             ISchemaResolver(address(0)),
             true
         );

--- a/contracts/test/unit/arbiters/confirmation/NonexclusiveRevocableConfirmationArbiter.t.sol
+++ b/contracts/test/unit/arbiters/confirmation/NonexclusiveRevocableConfirmationArbiter.t.sol
@@ -26,7 +26,7 @@ contract NonexclusiveRevocableConfirmationArbiterTest is Test {
 
         // Register a test schema
         testSchema = schemaRegistry.register(
-            "string item",
+            "string item, bytes32 schema",
             ISchemaResolver(address(0)),
             true
         );

--- a/contracts/test/unit/arbiters/confirmation/NonexclusiveUnrevocableConfirmationArbiter.t.sol
+++ b/contracts/test/unit/arbiters/confirmation/NonexclusiveUnrevocableConfirmationArbiter.t.sol
@@ -26,7 +26,7 @@ contract NonexclusiveUnrevocableConfirmationArbiterTest is Test {
 
         // Register a test schema
         testSchema = schemaRegistry.register(
-            "string item",
+            "string item, bytes32 schema",
             ISchemaResolver(address(0)),
             true
         );

--- a/contracts/test/unit/obligations/CommitRevealObligation.t.sol
+++ b/contracts/test/unit/obligations/CommitRevealObligation.t.sol
@@ -48,7 +48,7 @@ contract CommitRevealObligationTest is Test {
         bytes32 escrowUid = _makeEscrow();
         CommitRevealObligation.ObligationData memory data = _obligationData();
 
-        bytes32 commitment = obligation.computeCommitment(claimer, data);
+        bytes32 commitment = obligation.computeCommitment(escrowUid, claimer, data);
 
         // Commit with bond
         vm.deal(claimer, BOND);
@@ -94,7 +94,7 @@ contract CommitRevealObligationTest is Test {
         bytes32 fulfillmentUid = obligation.doObligation(data, escrowUid);
         Attestation memory fulfillment = eas.getAttestation(fulfillmentUid);
 
-        bytes32 commitment = obligation.computeCommitment(claimer, data);
+        bytes32 commitment = obligation.computeCommitment(escrowUid, claimer, data);
         vm.expectRevert(
             abi.encodeWithSelector(
                 CommitRevealObligation.CommitmentMissing.selector,
@@ -109,7 +109,7 @@ contract CommitRevealObligationTest is Test {
         bytes32 escrowUid = _makeEscrow();
         CommitRevealObligation.ObligationData memory data = _obligationData();
 
-        bytes32 commitment = obligation.computeCommitment(claimer, data);
+        bytes32 commitment = obligation.computeCommitment(escrowUid, claimer, data);
 
         vm.deal(claimer, BOND);
         vm.prank(claimer);
@@ -133,7 +133,7 @@ contract CommitRevealObligationTest is Test {
     function testPoc_MultipleReclaimsSameCommitmentReverts() public {
         bytes32 escrowUid = _makeEscrow();
         CommitRevealObligation.ObligationData memory data = _obligationData();
-        bytes32 commitment = obligation.computeCommitment(claimer, data);
+        bytes32 commitment = obligation.computeCommitment(escrowUid, claimer, data);
 
         vm.deal(claimer, BOND);
         vm.prank(claimer);
@@ -173,8 +173,8 @@ contract CommitRevealObligationTest is Test {
             schema: bytes32("schema-tag")
         });
 
-        bytes32 commitmentOld = obligation.computeCommitment(claimer, dataOld);
-        bytes32 commitmentNew = obligation.computeCommitment(claimer, dataNew);
+        bytes32 commitmentOld = obligation.computeCommitment(escrowUid, claimer, dataOld);
+        bytes32 commitmentNew = obligation.computeCommitment(escrowUid, claimer, dataNew);
 
         vm.deal(claimer, 2 * BOND);
         vm.startPrank(claimer);

--- a/contracts/test/unit/obligations/CommitRevealObligation.t.sol
+++ b/contracts/test/unit/obligations/CommitRevealObligation.t.sol
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.26;
+
+import "forge-std/Test.sol";
+import {IEAS, Attestation, AttestationRequest, AttestationRequestData} from "@eas/IEAS.sol";
+import {ISchemaRegistry} from "@eas/ISchemaRegistry.sol";
+import {CommitRevealObligation} from "@src/obligations/CommitRevealObligation.sol";
+import {NativeTokenEscrowObligation} from "@src/obligations/escrow/non-tierable/NativeTokenEscrowObligation.sol";
+import {EASDeployer} from "@test/utils/EASDeployer.sol";
+
+contract CommitRevealObligationTest is Test {
+    CommitRevealObligation public obligation;
+    NativeTokenEscrowObligation public nativeEscrow;
+    IEAS public eas;
+    ISchemaRegistry public schemaRegistry;
+
+    address internal claimer;
+    uint256 internal constant BOND = 0.1 ether;
+
+    function setUp() public {
+        EASDeployer easDeployer = new EASDeployer();
+        (eas, schemaRegistry) = easDeployer.deployEAS();
+
+        obligation = new CommitRevealObligation(eas, schemaRegistry, BOND);
+        nativeEscrow = new NativeTokenEscrowObligation(eas, schemaRegistry);
+        claimer = makeAddr("claimer");
+    }
+
+    function _obligationData() internal pure returns (CommitRevealObligation.ObligationData memory) {
+        return CommitRevealObligation.ObligationData({
+            payload: bytes("payload"),
+            salt: bytes32("salt"),
+            schema: bytes32("schema-tag")
+        });
+    }
+
+    function _makeEscrow() internal returns (bytes32 escrowUid) {
+        NativeTokenEscrowObligation.ObligationData memory escrowData = NativeTokenEscrowObligation
+            .ObligationData({
+                arbiter: address(obligation), // not used in these tests but consistent with flow
+                demand: "",
+                amount: 0
+            });
+        escrowUid = nativeEscrow.doObligation{value: 0}(escrowData, 0);
+    }
+
+    function testCommitRevealAndReclaimBond() public {
+        bytes32 escrowUid = _makeEscrow();
+        CommitRevealObligation.ObligationData memory data = _obligationData();
+
+        bytes32 commitment = obligation.computeCommitment(escrowUid, claimer, data);
+
+        // Commit with bond
+        vm.deal(claimer, BOND);
+        vm.prank(claimer);
+        obligation.commit{value: BOND}(escrowUid, commitment);
+
+        // Ensure reveal occurs in a later block
+        vm.roll(block.number + 1);
+
+        // Reveal (fulfillment attestation)
+        vm.prank(claimer);
+        bytes32 fulfillmentUid = obligation.doObligation(data, escrowUid);
+
+        // Arbiter check should pass
+        Attestation memory fulfillment = eas.getAttestation(fulfillmentUid);
+        assertTrue(obligation.checkObligation(fulfillment, "", escrowUid));
+
+        // Reclaim bond (any caller can trigger; funds to claimer)
+        address caller = makeAddr("anyone");
+        uint256 claimerBalanceBefore = claimer.balance;
+        vm.prank(caller);
+        uint256 returned = obligation.reclaimBond(fulfillmentUid);
+
+        assertEq(returned, BOND, "returned bond amount");
+        assertEq(claimer.balance, claimerBalanceBefore + BOND, "claimer received bond");
+
+        // Second reclaim should revert
+        vm.prank(caller);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                CommitRevealObligation.BondAlreadyClaimed.selector,
+                fulfillmentUid
+            )
+        );
+        obligation.reclaimBond(fulfillmentUid);
+    }
+
+    function testCheckObligationRevertsWithoutCommit() public {
+        bytes32 escrowUid = _makeEscrow();
+        CommitRevealObligation.ObligationData memory data = _obligationData();
+
+        vm.prank(claimer);
+        bytes32 fulfillmentUid = obligation.doObligation(data, escrowUid);
+        Attestation memory fulfillment = eas.getAttestation(fulfillmentUid);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                CommitRevealObligation.CommitmentMissing.selector,
+                escrowUid,
+                claimer
+            )
+        );
+        obligation.checkObligation(fulfillment, "", escrowUid);
+    }
+
+    function testCheckObligationRevertsIfSameBlock() public {
+        bytes32 escrowUid = _makeEscrow();
+        CommitRevealObligation.ObligationData memory data = _obligationData();
+
+        bytes32 commitment = obligation.computeCommitment(escrowUid, claimer, data);
+
+        vm.deal(claimer, BOND);
+        vm.prank(claimer);
+        obligation.commit{value: BOND}(escrowUid, commitment);
+
+        // Reveal in the same block (no vm.roll)
+        vm.prank(claimer);
+        bytes32 fulfillmentUid = obligation.doObligation(data, escrowUid);
+        Attestation memory fulfillment = eas.getAttestation(fulfillmentUid);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                CommitRevealObligation.CommitmentTooRecent.selector,
+                escrowUid,
+                claimer
+            )
+        );
+        obligation.checkObligation(fulfillment, "", escrowUid);
+    }
+}

--- a/contracts/test/unit/obligations/StringObligation.t.sol
+++ b/contracts/test/unit/obligations/StringObligation.t.sol
@@ -30,13 +30,12 @@ contract StringObligationTest is Test {
         // Verify schema details
         SchemaRecord memory schema = stringObligation.getSchema();
         assertEq(schema.uid, schemaId, "Schema UID should match");
-        assertEq(schema.schema, "string item", "Schema string should match");
+        assertEq(schema.schema, "string item, bytes32 schema", "Schema string should match");
     }
 
     function testDoObligation() public {
         // Setup test data
-        StringObligation.ObligationData memory data = StringObligation
-            .ObligationData({item: "Test String Data"});
+        StringObligation.ObligationData memory data = StringObligation.ObligationData({item: "Test String Data", schema: bytes32(0)});
 
         // Make an obligation
         vm.prank(testUser);

--- a/contracts/test/unit/obligations/escrow/non-tierable/AttestationEscrowObligation.t.sol
+++ b/contracts/test/unit/obligations/escrow/non-tierable/AttestationEscrowObligation.t.sol
@@ -173,7 +173,7 @@ contract AttestationEscrowObligationTest is Test {
 
         vm.startPrank(attester);
         fulfillmentUid = stringObligation.doObligation(
-            StringObligation.ObligationData({item: "fulfillment data"}),
+            StringObligation.ObligationData({item: "fulfillment data", schema: bytes32(0)}),
             escrowUid  // Reference the escrow for non-tierable pattern
         );
         vm.stopPrank();
@@ -243,7 +243,7 @@ contract AttestationEscrowObligationTest is Test {
         // Create a fulfillment attestation
         vm.startPrank(attester);
         bytes32 fulfillmentUid = stringObligation.doObligation(
-            StringObligation.ObligationData({item: "fulfillment data"}),
+            StringObligation.ObligationData({item: "fulfillment data", schema: bytes32(0)}),
             escrowUid
         );
 

--- a/contracts/test/unit/obligations/escrow/non-tierable/AttestationEscrowObligation2.t.sol
+++ b/contracts/test/unit/obligations/escrow/non-tierable/AttestationEscrowObligation2.t.sol
@@ -228,8 +228,7 @@ contract AttestationEscrowObligation2Test is Test {
 
         // Create a fulfillment attestation from the attester using StringObligation
         vm.prank(attester);
-        StringObligation.ObligationData memory stringData = StringObligation
-            .ObligationData({item: "fulfillment data"});
+        StringObligation.ObligationData memory stringData = StringObligation.ObligationData({item: "fulfillment data", schema: bytes32(0)});
 
         bytes32 fulfillmentUid = stringObligation.doObligation(
             stringData,
@@ -295,8 +294,7 @@ contract AttestationEscrowObligation2Test is Test {
 
         // Create a fulfillment attestation from the attester using StringObligation
         vm.prank(attester);
-        StringObligation.ObligationData memory stringData = StringObligation
-            .ObligationData({item: "fulfillment data"});
+        StringObligation.ObligationData memory stringData = StringObligation.ObligationData({item: "fulfillment data", schema: bytes32(0)});
 
         bytes32 fulfillmentUid = stringObligation.doObligation(
             stringData,
@@ -417,8 +415,7 @@ contract AttestationEscrowObligation2Test is Test {
         // Create a fulfillment attestation using StringObligation
         // Note: fulfillment doesn't reference anything since the escrow doesn't exist yet
         vm.prank(attester);
-        StringObligation.ObligationData memory stringData = StringObligation
-            .ObligationData({item: "fulfillment data"});
+        StringObligation.ObligationData memory stringData = StringObligation.ObligationData({item: "fulfillment data", schema: bytes32(0)});
 
         bytes32 fulfillmentUid = stringObligation.doObligation(
             stringData,

--- a/contracts/test/unit/obligations/escrow/non-tierable/ERC1155EscrowObligation.t.sol
+++ b/contracts/test/unit/obligations/escrow/non-tierable/ERC1155EscrowObligation.t.sol
@@ -201,7 +201,7 @@ contract ERC1155EscrowObligationTest is Test {
 
         vm.prank(seller);
         bytes32 fulfillmentUid = stringObligation.doObligation(
-            StringObligation.ObligationData({item: "fulfillment data"}),
+            StringObligation.ObligationData({item: "fulfillment data", schema: bytes32(0)}),
             paymentUid  // Reference the escrow for non-tierable pattern
         );
 
@@ -254,7 +254,7 @@ contract ERC1155EscrowObligationTest is Test {
 
         vm.prank(seller);
         bytes32 fulfillmentUid = stringObligation.doObligation(
-            StringObligation.ObligationData({item: "fulfillment data"}),
+            StringObligation.ObligationData({item: "fulfillment data", schema: bytes32(0)}),
             paymentUid  // Reference the escrow for non-tierable pattern
         );
 

--- a/contracts/test/unit/obligations/escrow/non-tierable/ERC20EscrowObligation.t.sol
+++ b/contracts/test/unit/obligations/escrow/non-tierable/ERC20EscrowObligation.t.sol
@@ -193,7 +193,7 @@ contract ERC20EscrowObligationTest is Test {
 
         vm.prank(seller);
         bytes32 fulfillmentUid = stringObligation.doObligation(
-            StringObligation.ObligationData({item: "fulfillment data"}),
+            StringObligation.ObligationData({item: "fulfillment data", schema: bytes32(0)}),
             paymentUid
         );
 
@@ -245,7 +245,7 @@ contract ERC20EscrowObligationTest is Test {
 
         vm.prank(seller);
         bytes32 fulfillmentUid = stringObligation.doObligation(
-            StringObligation.ObligationData({item: "fulfillment data"}),
+            StringObligation.ObligationData({item: "fulfillment data", schema: bytes32(0)}),
             paymentUid
         );
 

--- a/contracts/test/unit/obligations/escrow/non-tierable/ERC721EscrowObligation.t.sol
+++ b/contracts/test/unit/obligations/escrow/non-tierable/ERC721EscrowObligation.t.sol
@@ -184,7 +184,7 @@ contract ERC721EscrowObligationTest is Test {
 
         vm.prank(seller);
         bytes32 fulfillmentUid = stringObligation.doObligation(
-            StringObligation.ObligationData({item: "fulfillment data"}),
+            StringObligation.ObligationData({item: "fulfillment data", schema: bytes32(0)}),
             paymentUid
         );
 
@@ -231,7 +231,7 @@ contract ERC721EscrowObligationTest is Test {
 
         vm.prank(seller);
         bytes32 fulfillmentUid = stringObligation.doObligation(
-            StringObligation.ObligationData({item: "fulfillment data"}),
+            StringObligation.ObligationData({item: "fulfillment data", schema: bytes32(0)}),
             paymentUid
         );
 

--- a/contracts/test/unit/obligations/escrow/non-tierable/NativeTokenEscrowObligation.t.sol
+++ b/contracts/test/unit/obligations/escrow/non-tierable/NativeTokenEscrowObligation.t.sol
@@ -147,7 +147,7 @@ contract NativeTokenEscrowObligationTest is Test {
         // Create fulfillment (string obligation)
         vm.prank(seller);
         bytes32 fulfillmentUid = stringObligation.doObligation(
-            StringObligation.ObligationData({item: "hello"}),
+            StringObligation.ObligationData({item: "hello", schema: bytes32(0)}),
             escrowUid
         );
 
@@ -192,7 +192,7 @@ contract NativeTokenEscrowObligationTest is Test {
         // Create wrong fulfillment
         vm.prank(seller);
         bytes32 fulfillmentUid = stringObligation.doObligation(
-            StringObligation.ObligationData({item: "goodbye"}),
+            StringObligation.ObligationData({item: "goodbye", schema: bytes32(0)}),
             escrowUid
         );
 
@@ -452,7 +452,7 @@ contract NativeTokenEscrowObligationTest is Test {
         // Create valid fulfillment
         vm.prank(seller);
         bytes32 fulfillmentUid = stringObligation.doObligation(
-            StringObligation.ObligationData({item: "hello"}),
+            StringObligation.ObligationData({item: "hello", schema: bytes32(0)}),
             wrongSchemaEscrowUid
         );
 
@@ -507,7 +507,7 @@ contract NativeTokenEscrowObligationTest is Test {
         // Create fulfillment from reverting receiver
         vm.prank(address(revertingReceiver));
         bytes32 fulfillmentUid = stringObligation.doObligation(
-            StringObligation.ObligationData({item: "hello"}),
+            StringObligation.ObligationData({item: "hello", schema: bytes32(0)}),
             escrowUid
         );
 

--- a/contracts/test/unit/obligations/escrow/tierable/AttestationEscrowObligation.t.sol
+++ b/contracts/test/unit/obligations/escrow/tierable/AttestationEscrowObligation.t.sol
@@ -93,7 +93,7 @@ contract AttestationEscrowObligationTierableTest is Test {
         StringObligation stringObligation = new StringObligation(eas, schemaRegistry);
         vm.prank(attester);
         bytes32 fulfillmentUid = stringObligation.doObligation(
-            StringObligation.ObligationData({item: "fulfillment"}),
+            StringObligation.ObligationData({item: "fulfillment", schema: bytes32(0)}),
             bytes32(0)
         );
 

--- a/contracts/test/unit/obligations/escrow/tierable/AttestationEscrowObligation2.t.sol
+++ b/contracts/test/unit/obligations/escrow/tierable/AttestationEscrowObligation2.t.sol
@@ -92,7 +92,7 @@ contract AttestationEscrowObligation2TierableTest is Test {
         StringObligation stringObligation = new StringObligation(eas, schemaRegistry);
         vm.prank(attester);
         bytes32 fulfillmentUid = stringObligation.doObligation(
-            StringObligation.ObligationData({item: "fulfillment"}),
+            StringObligation.ObligationData({item: "fulfillment", schema: bytes32(0)}),
             bytes32(0)
         );
 

--- a/contracts/test/unit/obligations/escrow/tierable/ERC1155EscrowObligation.t.sol
+++ b/contracts/test/unit/obligations/escrow/tierable/ERC1155EscrowObligation.t.sol
@@ -102,7 +102,7 @@ contract ERC1155EscrowObligationTierableTest is Test {
         StringObligation stringObligation = new StringObligation(eas, schemaRegistry);
         vm.prank(seller);
         bytes32 fulfillmentUid = stringObligation.doObligation(
-            StringObligation.ObligationData({item: "fulfillment"}),
+            StringObligation.ObligationData({item: "fulfillment", schema: bytes32(0)}),
             bytes32(0)
         );
 

--- a/contracts/test/unit/obligations/escrow/tierable/ERC20EscrowObligation.t.sol
+++ b/contracts/test/unit/obligations/escrow/tierable/ERC20EscrowObligation.t.sol
@@ -141,7 +141,7 @@ contract ERC20EscrowObligationTierableTest is Test {
 
         vm.prank(seller);
         bytes32 fulfillmentUid = stringObligation.doObligation(
-            StringObligation.ObligationData({item: "fulfillment data"}),
+            StringObligation.ObligationData({item: "fulfillment data", schema: bytes32(0)}),
             bytes32(0) // Note: NOT referencing paymentUid - this is the key difference for tierable
         );
 
@@ -206,7 +206,7 @@ contract ERC20EscrowObligationTierableTest is Test {
 
         vm.prank(seller);
         bytes32 fulfillmentUid = stringObligation.doObligation(
-            StringObligation.ObligationData({item: "fulfillment data"}),
+            StringObligation.ObligationData({item: "fulfillment data", schema: bytes32(0)}),
             bytes32(0) // Not referencing any specific payment
         );
 
@@ -264,7 +264,7 @@ contract ERC20EscrowObligationTierableTest is Test {
 
         vm.prank(seller);
         bytes32 fulfillmentUid = stringObligation.doObligation(
-            StringObligation.ObligationData({item: "fulfillment data"}),
+            StringObligation.ObligationData({item: "fulfillment data", schema: bytes32(0)}),
             bytes32(0)
         );
 

--- a/contracts/test/unit/obligations/escrow/tierable/ERC721EscrowObligation.t.sol
+++ b/contracts/test/unit/obligations/escrow/tierable/ERC721EscrowObligation.t.sol
@@ -102,7 +102,7 @@ contract ERC721EscrowObligationTierableTest is Test {
         StringObligation stringObligation = new StringObligation(eas, schemaRegistry);
         vm.prank(seller);
         bytes32 fulfillmentUid = stringObligation.doObligation(
-            StringObligation.ObligationData({item: "fulfillment"}),
+            StringObligation.ObligationData({item: "fulfillment", schema: bytes32(0)}),
             bytes32(0)
         );
 

--- a/contracts/test/unit/obligations/escrow/tierable/NativeTokenEscrowObligation.t.sol
+++ b/contracts/test/unit/obligations/escrow/tierable/NativeTokenEscrowObligation.t.sol
@@ -81,7 +81,7 @@ contract NativeTokenEscrowObligationTierableTest is Test {
         StringObligation stringObligation = new StringObligation(eas, schemaRegistry);
         vm.prank(seller);
         bytes32 fulfillmentUid = stringObligation.doObligation(
-            StringObligation.ObligationData({item: "fulfillment"}),
+            StringObligation.ObligationData({item: "fulfillment", schema: bytes32(0)}),
             bytes32(0)
         );
 

--- a/contracts/test/unit/obligations/escrow/tierable/TokenBundleEscrowObligation.t.sol
+++ b/contracts/test/unit/obligations/escrow/tierable/TokenBundleEscrowObligation.t.sol
@@ -146,7 +146,7 @@ contract TokenBundleEscrowObligationTierableTest is Test {
         StringObligation stringObligation = new StringObligation(eas, schemaRegistry);
         vm.prank(seller);
         bytes32 fulfillmentUid = stringObligation.doObligation(
-            StringObligation.ObligationData({item: "fulfillment"}),
+            StringObligation.ObligationData({item: "fulfillment", schema: bytes32(0)}),
             bytes32(0)
         );
 


### PR DESCRIPTION
- adds commit-reveal arbiter/obligation with fixed bond and non-reentrant bond reclaim
- tags general-purpose obligations with schema
- updates examples/tests
- adds unit coverage for commit->reveal->bond reclaim.

Tests:
```
forge build
forge test test/unit/obligations/CommitRevealObligation.t.sol
```