### PR TITLE
Add MCP documentation server

### DIFF
--- a/contracts/src/obligations/CommitRevealObligation.sol
+++ b/contracts/src/obligations/CommitRevealObligation.sol
@@ -1,0 +1,177 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.26;
+
+import {Attestation} from "@eas/Common.sol";
+import {IEAS} from "@eas/IEAS.sol";
+import {ISchemaRegistry} from "@eas/ISchemaRegistry.sol";
+import {BaseObligation} from "../BaseObligation.sol";
+import {IArbiter} from "../IArbiter.sol";
+import {ArbiterUtils} from "../ArbiterUtils.sol";
+import {ReentrancyGuard} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
+
+/// @title CommitRevealObligation
+/// @notice Obligation with built-in commit–reveal anti-front‑running checks.
+/// The attestation data is self contained (payload + salt), and the arbiter
+/// verifies that a matching commit exists and was made in an earlier block.
+contract CommitRevealObligation is BaseObligation, IArbiter, ReentrancyGuard {
+    using ArbiterUtils for Attestation;
+
+    /// @dev Data stored inside the fulfillment attestation.
+    struct ObligationData {
+        bytes payload; // arbitrary self-contained data the fulfiller reveals
+        bytes32 salt;  // fulfiller-chosen salt to harden the commitment
+        bytes32 schema; // arbitrary tag describing the payload format
+    }
+
+    /// @dev Per-escrow commitment details for a fulfiller.
+    struct CommitInfo {
+        bytes32 commitment;
+        uint64 commitBlock;
+    }
+
+    /// @notice commitments[escrowUid][claimer] => commit information.
+    mapping(bytes32 => mapping(address => CommitInfo)) public commitments;
+    /// @notice bondClaimed[obligationUid] => bond already returned.
+    mapping(bytes32 => bool) public bondClaimed;
+
+    event Committed(bytes32 indexed escrowUid, address indexed claimer, bytes32 commitment);
+    event BondReclaimed(bytes32 indexed obligationUid, address indexed claimer, uint256 amount);
+
+    error CommitmentMissing(bytes32 escrowUid, address claimer);
+    error CommitmentTooRecent(bytes32 escrowUid, address claimer);
+    error CommitmentMismatch(bytes32 escrowUid, address claimer);
+    error BondAlreadyClaimed(bytes32 obligationUid);
+    error NoBondToReclaim(bytes32 escrowUid, address claimer);
+
+    /// @notice Fixed bond amount required for each commit.
+    uint256 public immutable bondAmount;
+
+    constructor(IEAS _eas, ISchemaRegistry _schemaRegistry, uint256 _bondAmount)
+        BaseObligation(_eas, _schemaRegistry, "bytes payload, bytes32 salt, bytes32 schema", true)
+    {
+        bondAmount = _bondAmount;
+    }
+
+    // ---------------------------------------------------------------------
+    // Attestation (reveal) path
+    // ---------------------------------------------------------------------
+
+    /// @notice Creates a fulfillment attestation containing the payload and salt.
+    /// @param data Revealed data (must match a prior commit) and salt.
+    /// @param refUID Escrow attestation UID being fulfilled.
+    function doObligation(ObligationData calldata data, bytes32 refUID) external returns (bytes32 uid_) {
+        bytes memory encodedData = abi.encode(data);
+        uid_ = _doObligationForRaw(encodedData, 0, msg.sender, refUID);
+    }
+
+    // ---------------------------------------------------------------------
+    // Commit phase helpers
+    // ---------------------------------------------------------------------
+
+    /// @notice Records a commitment for a given escrow UID and claimer, locking the fixed bond.
+    /// @param escrowUid UID of the escrow attestation this commitment targets.
+    /// @param commitment keccak256(abi.encode(escrowUid, claimer, keccak256(abi.encode(data)))).
+    /// @dev msg.value must equal `bondAmount` and is held as a bond reclaimable after a valid reveal.
+    function commit(bytes32 escrowUid, bytes32 commitment) external payable {
+        require(commitment != bytes32(0), "empty commitment");
+        require(msg.value == bondAmount, "incorrect bond");
+
+        commitments[escrowUid][msg.sender] = CommitInfo({
+            commitment: commitment,
+            commitBlock: uint64(block.number)
+        });
+
+        emit Committed(escrowUid, msg.sender, commitment);
+    }
+
+    /// @notice Pure helper to compute the commitment expected by this contract.
+    function computeCommitment(bytes32 escrowUid, address claimer, ObligationData calldata data)
+        external
+        pure
+        returns (bytes32)
+    {
+        return keccak256(abi.encode(escrowUid, claimer, keccak256(abi.encode(data))));
+    }
+
+    // ---------------------------------------------------------------------
+    // Arbiter logic (called from escrow contracts)
+    // ---------------------------------------------------------------------
+
+    /// @inheritdoc IArbiter
+    function checkObligation(
+        Attestation memory obligation,
+        bytes memory /* demand (unused) */,
+        bytes32 fulfilling
+    ) public view override returns (bool) {
+        // Basic attestation sanity checks (schema + expiry + revocation)
+        obligation._checkIntrinsic(ATTESTATION_SCHEMA);
+
+        // Lookup the prior commitment made by the fulfiller for this escrow
+        CommitInfo memory info = commitments[fulfilling][obligation.recipient];
+        if (info.commitment == bytes32(0)) {
+            revert CommitmentMissing(fulfilling, obligation.recipient);
+        }
+
+        // Enforce commit happened in an earlier block to block same-block frontruns
+        if (info.commitBlock >= block.number) {
+            revert CommitmentTooRecent(fulfilling, obligation.recipient);
+        }
+
+        // Recompute commitment from the revealed data and compare
+        bytes32 revealedCommitment = keccak256(
+            abi.encode(fulfilling, obligation.recipient, keccak256(obligation.data))
+        );
+
+        if (revealedCommitment != info.commitment) {
+            revert CommitmentMismatch(fulfilling, obligation.recipient);
+        }
+
+        return true;
+    }
+
+    // ---------------------------------------------------------------------
+    // Bond reclaim
+    // ---------------------------------------------------------------------
+
+    /// @notice Returns the bond associated with a fulfilled attestation to its claimer.
+    /// @param obligationUid UID of the fulfillment attestation (reveal).
+    function reclaimBond(bytes32 obligationUid) external nonReentrant returns (uint256 amount) {
+        Attestation memory obligation = _getAttestation(obligationUid);
+
+        address claimer = obligation.recipient;
+        if (bondClaimed[obligationUid]) revert BondAlreadyClaimed(obligationUid);
+
+        bytes32 escrowUid = obligation.refUID;
+        CommitInfo memory info = commitments[escrowUid][claimer];
+        if (info.commitment == bytes32(0)) revert CommitmentMissing(escrowUid, claimer);
+
+        // Ensure commitment matches the revealed data
+        bytes32 revealedCommitment = keccak256(
+            abi.encode(escrowUid, claimer, keccak256(obligation.data))
+        );
+        if (revealedCommitment != info.commitment) revert CommitmentMismatch(escrowUid, claimer);
+
+        amount = bondAmount;
+        if (amount == 0) revert NoBondToReclaim(escrowUid, claimer);
+
+        bondClaimed[obligationUid] = true;
+
+        (bool success, ) = claimer.call{value: amount}("");
+        require(success, "bond transfer failed");
+
+        emit BondReclaimed(obligationUid, claimer, amount);
+    }
+
+    // ---------------------------------------------------------------------
+    // Convenience getters
+    // ---------------------------------------------------------------------
+
+    function getObligationData(bytes32 uid) external view returns (ObligationData memory) {
+        Attestation memory attestation = _getAttestation(uid);
+        return abi.decode(attestation.data, (ObligationData));
+    }
+
+    function decodeObligationData(bytes calldata data) external pure returns (ObligationData memory) {
+        return abi.decode(data, (ObligationData));
+    }
+}

--- a/contracts/src/obligations/StringObligation.sol
+++ b/contracts/src/obligations/StringObligation.sol
@@ -9,12 +9,13 @@ import {BaseObligation} from "../BaseObligation.sol";
 contract StringObligation is BaseObligation {
     struct ObligationData {
         string item;
+        bytes32 schema; // arbitrary tag describing the payload format
     }
 
     constructor(
         IEAS _eas,
         ISchemaRegistry _schemaRegistry
-    ) BaseObligation(_eas, _schemaRegistry, "string item", true) {}
+    ) BaseObligation(_eas, _schemaRegistry, "string item, bytes32 schema", true) {}
 
     function doObligation(
         ObligationData calldata data,

--- a/contracts/src/obligations/example/ApiCallExample1.sol
+++ b/contracts/src/obligations/example/ApiCallExample1.sol
@@ -108,8 +108,7 @@ contract ApiCallExample1 {
         bytes32 escrowUid
     ) external returns (bytes32 fulfillmentUid) {
         // Submit the result via StringObligation with reference to the escrow
-        StringObligation.ObligationData memory resultData = StringObligation
-            .ObligationData({item: apiResult});
+        StringObligation.ObligationData memory resultData = StringObligation.ObligationData({item: apiResult, schema: bytes32(0)});
 
         fulfillmentUid = stringObligation.doObligation(resultData, escrowUid);
 

--- a/contracts/test/gas/EscrowCommitRevealOracleGas.t.sol
+++ b/contracts/test/gas/EscrowCommitRevealOracleGas.t.sol
@@ -1,0 +1,254 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.26;
+
+import "forge-std/Test.sol";
+import {IEAS} from "@eas/IEAS.sol";
+import {ISchemaRegistry} from "@eas/ISchemaRegistry.sol";
+import {CommitRevealObligation} from "@src/obligations/CommitRevealObligation.sol";
+import {TrustedOracleArbiter} from "@src/arbiters/TrustedOracleArbiter.sol";
+import {ERC20EscrowObligation} from "@src/obligations/escrow/non-tierable/ERC20EscrowObligation.sol";
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import {EASDeployer} from "@test/utils/EASDeployer.sol";
+
+contract MockToken is ERC20 {
+    constructor() ERC20("Mock Token", "MOCK") {
+        _mint(msg.sender, 1_000_000e18);
+    }
+
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+}
+
+contract EscrowCommitRevealOracleGasTest is Test {
+    IEAS internal eas;
+    ISchemaRegistry internal schemaRegistry;
+    CommitRevealObligation internal commitReveal;
+    TrustedOracleArbiter internal trustedOracleArbiter;
+    ERC20EscrowObligation internal erc20Escrow;
+    MockToken internal paymentToken;
+
+    address internal alice;
+    address internal bob;
+    address internal charlie;
+
+    uint256 internal constant PAYMENT_AMOUNT = 100e18;
+    uint256 internal constant BOND = 0.1 ether;
+    uint256 internal constant PAYLOAD_SIZE = 64;
+
+    function setUp() public {
+        EASDeployer easDeployer = new EASDeployer();
+        (eas, schemaRegistry) = easDeployer.deployEAS();
+
+        commitReveal = new CommitRevealObligation(eas, schemaRegistry, BOND, 1 hours, address(0));
+        trustedOracleArbiter = new TrustedOracleArbiter(eas);
+        erc20Escrow = new ERC20EscrowObligation(eas, schemaRegistry);
+
+        paymentToken = new MockToken();
+
+        alice = makeAddr("alice");
+        bob = makeAddr("bob");
+        charlie = makeAddr("charlie");
+
+        paymentToken.mint(alice, PAYMENT_AMOUNT * 10);
+        vm.deal(alice, 10 ether);
+        vm.deal(bob, 10 ether);
+        vm.deal(charlie, 10 ether);
+    }
+
+    function _innerDemand() internal pure returns (bytes memory) {
+        return abi.encode("QUERY");
+    }
+
+    function _escrowData(bytes memory demand) internal view returns (ERC20EscrowObligation.ObligationData memory) {
+        return ERC20EscrowObligation.ObligationData({
+            token: address(paymentToken),
+            amount: PAYMENT_AMOUNT,
+            arbiter: address(trustedOracleArbiter),
+            demand: demand
+        });
+    }
+
+    function _commitData() internal pure returns (CommitRevealObligation.ObligationData memory) {
+        bytes memory payload = new bytes(PAYLOAD_SIZE);
+        return CommitRevealObligation.ObligationData({
+            payload: payload,
+            salt: bytes32("salt"),
+            schema: bytes32("schema")
+        });
+    }
+
+    function _commitDataWithSize(uint256 payloadSize)
+        internal
+        pure
+        returns (CommitRevealObligation.ObligationData memory)
+    {
+        bytes memory payload = new bytes(payloadSize);
+        return CommitRevealObligation.ObligationData({
+            payload: payload,
+            salt: bytes32("salt"),
+            schema: bytes32("schema")
+        });
+    }
+
+
+    function _createEscrow() internal returns (bytes32 escrowUid, bytes memory innerDemand) {
+        innerDemand = _innerDemand();
+        bytes memory demand = abi.encode(TrustedOracleArbiter.DemandData({oracle: charlie, data: innerDemand}));
+        ERC20EscrowObligation.ObligationData memory escrowData = _escrowData(demand);
+
+        vm.startPrank(alice);
+        paymentToken.approve(address(erc20Escrow), PAYMENT_AMOUNT);
+        escrowUid = erc20Escrow.doObligation(escrowData, uint64(block.timestamp + 1 days));
+        vm.stopPrank();
+    }
+
+    function _setupEscrowAndCommit()
+        internal
+        returns (bytes32 escrowUid, bytes memory innerDemand, CommitRevealObligation.ObligationData memory data)
+    {
+        (escrowUid, innerDemand) = _createEscrow();
+        data = _commitData();
+
+        bytes32 commitment = commitReveal.computeCommitment(escrowUid, bob, data);
+        vm.deal(bob, BOND);
+        vm.prank(bob);
+        commitReveal.commit{value: BOND}(commitment);
+    }
+
+    function _setupEscrowCommitReveal()
+        internal
+        returns (bytes32 escrowUid, bytes32 fulfillmentUid, bytes memory innerDemand)
+    {
+        CommitRevealObligation.ObligationData memory data;
+        (escrowUid, innerDemand, data) = _setupEscrowAndCommit();
+
+        vm.roll(block.number + 1);
+        vm.prank(bob);
+        fulfillmentUid = commitReveal.doObligation(data, escrowUid);
+    }
+
+    // ---------------------------------------------------------------------
+    // Gas measurements (one measured call per test)
+    // ---------------------------------------------------------------------
+
+    function testGas_Escrower_Approve() public {
+        vm.prank(alice);
+        paymentToken.approve(address(erc20Escrow), PAYMENT_AMOUNT);
+    }
+
+    function testGas_Escrower_CreateEscrow() public {
+        bytes memory innerDemand = _innerDemand();
+        bytes memory demand = abi.encode(TrustedOracleArbiter.DemandData({oracle: charlie, data: innerDemand}));
+        ERC20EscrowObligation.ObligationData memory escrowData = _escrowData(demand);
+
+        vm.pauseGasMetering();
+        vm.prank(alice);
+        paymentToken.approve(address(erc20Escrow), PAYMENT_AMOUNT);
+        vm.resumeGasMetering();
+
+        vm.prank(alice);
+        erc20Escrow.doObligation(escrowData, uint64(block.timestamp + 1 days));
+    }
+
+    function testGas_Fulfiller_Commit() public {
+        vm.pauseGasMetering();
+        (bytes32 escrowUid, ) = _createEscrow();
+        CommitRevealObligation.ObligationData memory data = _commitData();
+        bytes32 commitment = commitReveal.computeCommitment(escrowUid, bob, data);
+        vm.deal(bob, BOND);
+        vm.resumeGasMetering();
+
+        vm.prank(bob);
+        commitReveal.commit{value: BOND}(commitment);
+    }
+
+    function testGas_Fulfiller_Reveal() public {
+        vm.pauseGasMetering();
+        (bytes32 escrowUid, , CommitRevealObligation.ObligationData memory data) = _setupEscrowAndCommit();
+        vm.roll(block.number + 1);
+        vm.resumeGasMetering();
+
+        vm.prank(bob);
+        commitReveal.doObligation(data, escrowUid);
+    }
+
+    function testGas_Fulfiller_RequestArbitration() public {
+        vm.pauseGasMetering();
+        (bytes32 escrowUid, bytes32 fulfillmentUid, bytes memory innerDemand) = _setupEscrowCommitReveal();
+        escrowUid;
+        vm.resumeGasMetering();
+
+        vm.prank(bob);
+        trustedOracleArbiter.requestArbitration(fulfillmentUid, charlie, innerDemand);
+    }
+
+    function testGas_Oracle_Arbitrate() public {
+        vm.pauseGasMetering();
+        (, bytes32 fulfillmentUid, bytes memory innerDemand) = _setupEscrowCommitReveal();
+        vm.resumeGasMetering();
+
+        vm.prank(charlie);
+        trustedOracleArbiter.arbitrate(fulfillmentUid, innerDemand, true);
+    }
+
+    function testGas_Fulfiller_CollectEscrow() public {
+        vm.pauseGasMetering();
+        (bytes32 escrowUid, bytes32 fulfillmentUid, bytes memory innerDemand) = _setupEscrowCommitReveal();
+        vm.prank(charlie);
+        trustedOracleArbiter.arbitrate(fulfillmentUid, innerDemand, true);
+        vm.resumeGasMetering();
+
+        vm.prank(bob);
+        erc20Escrow.collectEscrow(escrowUid, fulfillmentUid);
+    }
+
+    function testGas_Fulfiller_ReclaimBond() public {
+        vm.pauseGasMetering();
+        (, bytes32 fulfillmentUid, ) = _setupEscrowCommitReveal();
+        vm.resumeGasMetering();
+
+        vm.prank(bob);
+        commitReveal.reclaimBond(fulfillmentUid);
+    }
+
+    function _measureRevealWithPayload(uint256 payloadSize) internal {
+        vm.pauseGasMetering();
+        (bytes32 escrowUid, ) = _createEscrow();
+        CommitRevealObligation.ObligationData memory data = _commitDataWithSize(payloadSize);
+        bytes32 commitment = commitReveal.computeCommitment(escrowUid, bob, data);
+        vm.deal(bob, BOND);
+        vm.prank(bob);
+        commitReveal.commit{value: BOND}(commitment);
+        vm.roll(block.number + 1);
+        vm.resumeGasMetering();
+
+        vm.prank(bob);
+        commitReveal.doObligation(data, escrowUid);
+    }
+
+    function testGas_Payload_0() public {
+        _measureRevealWithPayload(0);
+    }
+
+    function testGas_Payload_32() public {
+        _measureRevealWithPayload(32);
+    }
+
+    function testGas_Payload_128() public {
+        _measureRevealWithPayload(128);
+    }
+
+    function testGas_Payload_512() public {
+        _measureRevealWithPayload(512);
+    }
+
+    function testGas_Payload_2048() public {
+        _measureRevealWithPayload(2048);
+    }
+
+    function testGas_Payload_4096() public {
+        _measureRevealWithPayload(4096);
+    }
+
+}

--- a/contracts/test/integration/ApiCallExample1.t.sol
+++ b/contracts/test/integration/ApiCallExample1.t.sol
@@ -133,8 +133,7 @@ contract ApiCallExample1Test is Test {
 
         // Step 2: Bob submits API result using StringObligation
         vm.startPrank(bob);
-        StringObligation.ObligationData memory resultData = StringObligation
-            .ObligationData({item: API_RESULT});
+        StringObligation.ObligationData memory resultData = StringObligation.ObligationData({item: API_RESULT, schema: bytes32(0)});
 
         bytes32 fulfillmentUid = stringObligation.doObligation(
             resultData,
@@ -204,7 +203,7 @@ contract ApiCallExample1Test is Test {
         // Bob submits result
         vm.prank(bob);
         bytes32 fulfillmentUid = stringObligation.doObligation(
-            StringObligation.ObligationData({item: API_RESULT}),
+            StringObligation.ObligationData({item: API_RESULT, schema: bytes32(0)}),
             escrowUid
         );
 
@@ -260,7 +259,7 @@ contract ApiCallExample1Test is Test {
         // Bob submits wrong result
         vm.prank(bob);
         bytes32 fulfillmentUid = stringObligation.doObligation(
-            StringObligation.ObligationData({item: "wrong result"}),
+            StringObligation.ObligationData({item: "wrong result", schema: bytes32(0)}),
             escrowUid
         );
 

--- a/contracts/test/integration/AttestationEscrowObligation.t.sol
+++ b/contracts/test/integration/AttestationEscrowObligation.t.sol
@@ -117,7 +117,7 @@ contract AttestationEscrowObligationTest is Test {
 
         vm.prank(bob);
         bytes32 fulfillmentId = stringObligation.doObligation(
-            StringObligation.ObligationData({item: "Test demand"}),
+            StringObligation.ObligationData({item: "Test demand", schema: bytes32(0)}),
             escrowId  // Reference the escrow for non-tierable pattern
         );
 

--- a/contracts/test/integration/ERC8004.t.sol
+++ b/contracts/test/integration/ERC8004.t.sol
@@ -172,7 +172,7 @@ contract ERC8004IntegrationTest is Test {
         // === Step 2: Bob creates a fulfillment obligation ===
         vm.prank(bob);
         bytes32 fulfillmentUid = fulfillmentObligation.doObligation(
-            StringObligation.ObligationData({item: "<fullfillment data>"}),
+            StringObligation.ObligationData({item: "<fullfillment data>", schema: bytes32(0)}),
             escrowUid // Reference the escrow
         );
 
@@ -282,7 +282,7 @@ contract ERC8004IntegrationTest is Test {
         // === Step 2: Bob creates a fulfillment obligation ===
         vm.prank(bob);
         bytes32 fulfillmentUid = fulfillmentObligation.doObligation(
-            StringObligation.ObligationData({item: "<fulfillment data>"}),
+            StringObligation.ObligationData({item: "<fulfillment data>", schema: bytes32(0)}),
             escrowUid
         );
 
@@ -356,7 +356,7 @@ contract ERC8004IntegrationTest is Test {
         // === Step 2: Bob creates a fulfillment obligation ===
         vm.prank(bob);
         bytes32 fulfillmentUid = fulfillmentObligation.doObligation(
-            StringObligation.ObligationData({item: "<fulfillment data>"}),
+            StringObligation.ObligationData({item: "<fulfillment data>", schema: bytes32(0)}),
             escrowUid
         );
 
@@ -427,7 +427,7 @@ contract ERC8004IntegrationTest is Test {
         // === Step 2: Bob creates a fulfillment obligation ===
         vm.prank(bob);
         bytes32 fulfillmentUid = fulfillmentObligation.doObligation(
-            StringObligation.ObligationData({item: "<fulfillment data>"}),
+            StringObligation.ObligationData({item: "<fulfillment data>", schema: bytes32(0)}),
             escrowUid
         );
 

--- a/contracts/test/integration/MajorityVoteArbiter.t.sol
+++ b/contracts/test/integration/MajorityVoteArbiter.t.sol
@@ -72,7 +72,7 @@ contract MajorityVoteArbiterTest is Test {
         // Register a test schema
         vm.prank(attester);
         testSchema = schemaRegistry.register(
-            "string item",
+            "string item, bytes32 schema",
             ISchemaResolver(address(0)),
             true // revocable
         );

--- a/contracts/test/integration/StringCapitalizer.t.sol
+++ b/contracts/test/integration/StringCapitalizer.t.sol
@@ -45,8 +45,7 @@ contract StringCapitalizerTest is Test {
             .DemandData({query: "hello world"});
 
         // Create an obligation with the capitalized result
-        StringObligation.ObligationData memory obligationData = StringObligation
-            .ObligationData({item: "HELLO WORLD"});
+        StringObligation.ObligationData memory obligationData = StringObligation.ObligationData({item: "HELLO WORLD", schema: bytes32(0)});
 
         // Create the attestation as bob
         vm.prank(bob);
@@ -74,8 +73,7 @@ contract StringCapitalizerTest is Test {
             .DemandData({query: "hello world"});
 
         // Create an obligation with incorrectly capitalized result
-        StringObligation.ObligationData memory obligationData = StringObligation
-            .ObligationData({item: "Hello World"}); // Only first letters capitalized
+        StringObligation.ObligationData memory obligationData = StringObligation.ObligationData({item: "Hello World", schema: bytes32(0)}); // Only first letters capitalized
 
         // Create the attestation as bob
         vm.prank(bob);
@@ -103,8 +101,7 @@ contract StringCapitalizerTest is Test {
             .DemandData({query: "HeLLo WoRLd 123!"});
 
         // Create an obligation with correctly capitalized result
-        StringObligation.ObligationData memory obligationData = StringObligation
-            .ObligationData({item: "HELLO WORLD 123!"}); // All letters uppercase, others unchanged
+        StringObligation.ObligationData memory obligationData = StringObligation.ObligationData({item: "HELLO WORLD 123!", schema: bytes32(0)}); // All letters uppercase, others unchanged
 
         // Create the attestation as bob
         vm.prank(bob);
@@ -135,8 +132,7 @@ contract StringCapitalizerTest is Test {
             .DemandData({query: "test123@email.com"});
 
         // Create an obligation with correctly capitalized result
-        StringObligation.ObligationData memory obligationData = StringObligation
-            .ObligationData({item: "TEST123@EMAIL.COM"});
+        StringObligation.ObligationData memory obligationData = StringObligation.ObligationData({item: "TEST123@EMAIL.COM", schema: bytes32(0)});
 
         // Create the attestation as bob
         vm.prank(bob);
@@ -167,8 +163,7 @@ contract StringCapitalizerTest is Test {
             .DemandData({query: "hello"});
 
         // Create an obligation with different length string
-        StringObligation.ObligationData memory obligationData = StringObligation
-            .ObligationData({item: "HELLO WORLD"}); // Different length
+        StringObligation.ObligationData memory obligationData = StringObligation.ObligationData({item: "HELLO WORLD", schema: bytes32(0)}); // Different length
 
         // Create the attestation as bob
         vm.prank(bob);
@@ -194,7 +189,7 @@ contract StringCapitalizerTest is Test {
         // First create an escrow attestation to reference
         vm.prank(alice);
         bytes32 escrowUID = stringObligation.doObligation(
-            StringObligation.ObligationData({item: "request"}),
+            StringObligation.ObligationData({item: "request", schema: bytes32(0)}),
             bytes32(0)
         );
 
@@ -203,8 +198,7 @@ contract StringCapitalizerTest is Test {
             .DemandData({query: "hello"});
 
         // Create an obligation with correct capitalization and reference
-        StringObligation.ObligationData memory obligationData = StringObligation
-            .ObligationData({item: "HELLO"});
+        StringObligation.ObligationData memory obligationData = StringObligation.ObligationData({item: "HELLO", schema: bytes32(0)});
 
         // Create the attestation with reference UID
         vm.prank(bob);
@@ -255,7 +249,7 @@ contract StringCapitalizerTest is Test {
             recipient: bob,
             attester: alice,
             revocable: true,
-            data: abi.encode(StringObligation.ObligationData({item: "HELLO"}))
+            data: abi.encode(StringObligation.ObligationData({item: "HELLO", schema: bytes32(0)}))
         });
 
         // The arbiter should revert when checking revoked attestations
@@ -287,7 +281,7 @@ contract StringCapitalizerTest is Test {
             recipient: bob,
             attester: alice,
             revocable: true,
-            data: abi.encode(StringObligation.ObligationData({item: "HELLO"}))
+            data: abi.encode(StringObligation.ObligationData({item: "HELLO", schema: bytes32(0)}))
         });
 
         // The arbiter should revert when checking expired attestations
@@ -312,8 +306,7 @@ contract StringCapitalizerTest is Test {
         StringCapitalizer.DemandData memory demand = StringCapitalizer
             .DemandData({query: input});
 
-        StringObligation.ObligationData memory obligationData = StringObligation
-            .ObligationData({item: output});
+        StringObligation.ObligationData memory obligationData = StringObligation.ObligationData({item: output, schema: bytes32(0)});
 
         // Create the attestation
         vm.prank(bob);

--- a/contracts/test/integration/VoteEscrowObligation.t.sol
+++ b/contracts/test/integration/VoteEscrowObligation.t.sol
@@ -128,7 +128,7 @@ contract VoteEscrowObligationTest is Test {
 
         // Create fulfillment attestation via StringObligation
         bytes32 fulfillmentUid = stringObligation.doObligation(
-            StringObligation.ObligationData({item: "Vote for proposal 42"}),
+            StringObligation.ObligationData({item: "Vote for proposal 42", schema: bytes32(0)}),
             escrowUid  // Reference the escrow for non-tierable pattern
         );
         assertNotEq(
@@ -381,7 +381,7 @@ contract VoteEscrowObligationTest is Test {
         // Fulfill and collect
         vm.startPrank(bob);
         bytes32 fulfillmentUid = stringObligation.doObligation(
-            StringObligation.ObligationData({item: "Test vote"}),
+            StringObligation.ObligationData({item: "Test vote", schema: bytes32(0)}),
             escrowUid  // Reference the escrow for non-tierable pattern
         );
 
@@ -418,7 +418,7 @@ contract VoteEscrowObligationTest is Test {
         // First collection should work
         vm.startPrank(bob);
         bytes32 fulfillmentUid = stringObligation.doObligation(
-            StringObligation.ObligationData({item: "Vote once"}),
+            StringObligation.ObligationData({item: "Vote once", schema: bytes32(0)}),
             escrowUid  // Reference the escrow for non-tierable pattern
         );
         voteEscrow.collectEscrowRaw(escrowUid, fulfillmentUid);
@@ -433,7 +433,7 @@ contract VoteEscrowObligationTest is Test {
         // Second collection should fail because vote was already cast
         vm.startPrank(bob);
         bytes32 secondFulfillmentUid = stringObligation.doObligation(
-            StringObligation.ObligationData({item: "Vote once"}),
+            StringObligation.ObligationData({item: "Vote once", schema: bytes32(0)}),
             secondEscrowUid  // Reference the second escrow for non-tierable pattern
         );
 

--- a/contracts/test/unit/arbiters/TrustedOracleArbiter.t.sol
+++ b/contracts/test/unit/arbiters/TrustedOracleArbiter.t.sol
@@ -30,7 +30,7 @@ contract TrustedOracleArbiterTest is Test {
 
         // Register a test schema
         testSchema = schemaRegistry.register(
-            "string item",
+            "string item, bytes32 schema",
             ISchemaResolver(address(0)),
             true
         );

--- a/contracts/test/unit/arbiters/confirmation/ExclusiveRevocableConfirmationArbiter.t.sol
+++ b/contracts/test/unit/arbiters/confirmation/ExclusiveRevocableConfirmationArbiter.t.sol
@@ -26,7 +26,7 @@ contract ExclusiveRevocableConfirmationArbiterTest is Test {
 
         // Register a test schema
         testSchema = schemaRegistry.register(
-            "string item",
+            "string item, bytes32 schema",
             ISchemaResolver(address(0)),
             true
         );

--- a/contracts/test/unit/arbiters/confirmation/ExclusiveUnrevocableConfirmationArbiter.t.sol
+++ b/contracts/test/unit/arbiters/confirmation/ExclusiveUnrevocableConfirmationArbiter.t.sol
@@ -26,7 +26,7 @@ contract ExclusiveUnrevocableConfirmationArbiterTest is Test {
 
         // Register a test schema
         testSchema = schemaRegistry.register(
-            "string item",
+            "string item, bytes32 schema",
             ISchemaResolver(address(0)),
             true
         );

--- a/contracts/test/unit/arbiters/confirmation/NonexclusiveRevocableConfirmationArbiter.t.sol
+++ b/contracts/test/unit/arbiters/confirmation/NonexclusiveRevocableConfirmationArbiter.t.sol
@@ -26,7 +26,7 @@ contract NonexclusiveRevocableConfirmationArbiterTest is Test {
 
         // Register a test schema
         testSchema = schemaRegistry.register(
-            "string item",
+            "string item, bytes32 schema",
             ISchemaResolver(address(0)),
             true
         );

--- a/contracts/test/unit/arbiters/confirmation/NonexclusiveUnrevocableConfirmationArbiter.t.sol
+++ b/contracts/test/unit/arbiters/confirmation/NonexclusiveUnrevocableConfirmationArbiter.t.sol
@@ -26,7 +26,7 @@ contract NonexclusiveUnrevocableConfirmationArbiterTest is Test {
 
         // Register a test schema
         testSchema = schemaRegistry.register(
-            "string item",
+            "string item, bytes32 schema",
             ISchemaResolver(address(0)),
             true
         );

--- a/contracts/test/unit/obligations/CommitRevealObligation.t.sol
+++ b/contracts/test/unit/obligations/CommitRevealObligation.t.sol
@@ -48,7 +48,7 @@ contract CommitRevealObligationTest is Test {
         bytes32 escrowUid = _makeEscrow();
         CommitRevealObligation.ObligationData memory data = _obligationData();
 
-        bytes32 commitment = obligation.computeCommitment(claimer, data);
+        bytes32 commitment = obligation.computeCommitment(escrowUid, claimer, data);
 
         // Commit with bond
         vm.deal(claimer, BOND);
@@ -94,7 +94,7 @@ contract CommitRevealObligationTest is Test {
         bytes32 fulfillmentUid = obligation.doObligation(data, escrowUid);
         Attestation memory fulfillment = eas.getAttestation(fulfillmentUid);
 
-        bytes32 commitment = obligation.computeCommitment(claimer, data);
+        bytes32 commitment = obligation.computeCommitment(escrowUid, claimer, data);
         vm.expectRevert(
             abi.encodeWithSelector(
                 CommitRevealObligation.CommitmentMissing.selector,
@@ -109,7 +109,7 @@ contract CommitRevealObligationTest is Test {
         bytes32 escrowUid = _makeEscrow();
         CommitRevealObligation.ObligationData memory data = _obligationData();
 
-        bytes32 commitment = obligation.computeCommitment(claimer, data);
+        bytes32 commitment = obligation.computeCommitment(escrowUid, claimer, data);
 
         vm.deal(claimer, BOND);
         vm.prank(claimer);
@@ -133,7 +133,7 @@ contract CommitRevealObligationTest is Test {
     function testPoc_MultipleReclaimsSameCommitmentReverts() public {
         bytes32 escrowUid = _makeEscrow();
         CommitRevealObligation.ObligationData memory data = _obligationData();
-        bytes32 commitment = obligation.computeCommitment(claimer, data);
+        bytes32 commitment = obligation.computeCommitment(escrowUid, claimer, data);
 
         vm.deal(claimer, BOND);
         vm.prank(claimer);
@@ -173,8 +173,8 @@ contract CommitRevealObligationTest is Test {
             schema: bytes32("schema-tag")
         });
 
-        bytes32 commitmentOld = obligation.computeCommitment(claimer, dataOld);
-        bytes32 commitmentNew = obligation.computeCommitment(claimer, dataNew);
+        bytes32 commitmentOld = obligation.computeCommitment(escrowUid, claimer, dataOld);
+        bytes32 commitmentNew = obligation.computeCommitment(escrowUid, claimer, dataNew);
 
         vm.deal(claimer, 2 * BOND);
         vm.startPrank(claimer);

--- a/contracts/test/unit/obligations/CommitRevealObligation.t.sol
+++ b/contracts/test/unit/obligations/CommitRevealObligation.t.sol
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.26;
+
+import "forge-std/Test.sol";
+import {IEAS, Attestation, AttestationRequest, AttestationRequestData} from "@eas/IEAS.sol";
+import {ISchemaRegistry} from "@eas/ISchemaRegistry.sol";
+import {CommitRevealObligation} from "@src/obligations/CommitRevealObligation.sol";
+import {NativeTokenEscrowObligation} from "@src/obligations/escrow/non-tierable/NativeTokenEscrowObligation.sol";
+import {EASDeployer} from "@test/utils/EASDeployer.sol";
+
+contract CommitRevealObligationTest is Test {
+    CommitRevealObligation public obligation;
+    NativeTokenEscrowObligation public nativeEscrow;
+    IEAS public eas;
+    ISchemaRegistry public schemaRegistry;
+
+    address internal claimer;
+    uint256 internal constant BOND = 0.1 ether;
+
+    function setUp() public {
+        EASDeployer easDeployer = new EASDeployer();
+        (eas, schemaRegistry) = easDeployer.deployEAS();
+
+        obligation = new CommitRevealObligation(eas, schemaRegistry, BOND);
+        nativeEscrow = new NativeTokenEscrowObligation(eas, schemaRegistry);
+        claimer = makeAddr("claimer");
+    }
+
+    function _obligationData() internal pure returns (CommitRevealObligation.ObligationData memory) {
+        return CommitRevealObligation.ObligationData({
+            payload: bytes("payload"),
+            salt: bytes32("salt"),
+            schema: bytes32("schema-tag")
+        });
+    }
+
+    function _makeEscrow() internal returns (bytes32 escrowUid) {
+        NativeTokenEscrowObligation.ObligationData memory escrowData = NativeTokenEscrowObligation
+            .ObligationData({
+                arbiter: address(obligation), // not used in these tests but consistent with flow
+                demand: "",
+                amount: 0
+            });
+        escrowUid = nativeEscrow.doObligation{value: 0}(escrowData, 0);
+    }
+
+    function testCommitRevealAndReclaimBond() public {
+        bytes32 escrowUid = _makeEscrow();
+        CommitRevealObligation.ObligationData memory data = _obligationData();
+
+        bytes32 commitment = obligation.computeCommitment(escrowUid, claimer, data);
+
+        // Commit with bond
+        vm.deal(claimer, BOND);
+        vm.prank(claimer);
+        obligation.commit{value: BOND}(escrowUid, commitment);
+
+        // Ensure reveal occurs in a later block
+        vm.roll(block.number + 1);
+
+        // Reveal (fulfillment attestation)
+        vm.prank(claimer);
+        bytes32 fulfillmentUid = obligation.doObligation(data, escrowUid);
+
+        // Arbiter check should pass
+        Attestation memory fulfillment = eas.getAttestation(fulfillmentUid);
+        assertTrue(obligation.checkObligation(fulfillment, "", escrowUid));
+
+        // Reclaim bond (any caller can trigger; funds to claimer)
+        address caller = makeAddr("anyone");
+        uint256 claimerBalanceBefore = claimer.balance;
+        vm.prank(caller);
+        uint256 returned = obligation.reclaimBond(fulfillmentUid);
+
+        assertEq(returned, BOND, "returned bond amount");
+        assertEq(claimer.balance, claimerBalanceBefore + BOND, "claimer received bond");
+
+        // Second reclaim should revert
+        vm.prank(caller);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                CommitRevealObligation.BondAlreadyClaimed.selector,
+                fulfillmentUid
+            )
+        );
+        obligation.reclaimBond(fulfillmentUid);
+    }
+
+    function testCheckObligationRevertsWithoutCommit() public {
+        bytes32 escrowUid = _makeEscrow();
+        CommitRevealObligation.ObligationData memory data = _obligationData();
+
+        vm.prank(claimer);
+        bytes32 fulfillmentUid = obligation.doObligation(data, escrowUid);
+        Attestation memory fulfillment = eas.getAttestation(fulfillmentUid);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                CommitRevealObligation.CommitmentMissing.selector,
+                escrowUid,
+                claimer
+            )
+        );
+        obligation.checkObligation(fulfillment, "", escrowUid);
+    }
+
+    function testCheckObligationRevertsIfSameBlock() public {
+        bytes32 escrowUid = _makeEscrow();
+        CommitRevealObligation.ObligationData memory data = _obligationData();
+
+        bytes32 commitment = obligation.computeCommitment(escrowUid, claimer, data);
+
+        vm.deal(claimer, BOND);
+        vm.prank(claimer);
+        obligation.commit{value: BOND}(escrowUid, commitment);
+
+        // Reveal in the same block (no vm.roll)
+        vm.prank(claimer);
+        bytes32 fulfillmentUid = obligation.doObligation(data, escrowUid);
+        Attestation memory fulfillment = eas.getAttestation(fulfillmentUid);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                CommitRevealObligation.CommitmentTooRecent.selector,
+                escrowUid,
+                claimer
+            )
+        );
+        obligation.checkObligation(fulfillment, "", escrowUid);
+    }
+}

--- a/contracts/test/unit/obligations/StringObligation.t.sol
+++ b/contracts/test/unit/obligations/StringObligation.t.sol
@@ -30,13 +30,12 @@ contract StringObligationTest is Test {
         // Verify schema details
         SchemaRecord memory schema = stringObligation.getSchema();
         assertEq(schema.uid, schemaId, "Schema UID should match");
-        assertEq(schema.schema, "string item", "Schema string should match");
+        assertEq(schema.schema, "string item, bytes32 schema", "Schema string should match");
     }
 
     function testDoObligation() public {
         // Setup test data
-        StringObligation.ObligationData memory data = StringObligation
-            .ObligationData({item: "Test String Data"});
+        StringObligation.ObligationData memory data = StringObligation.ObligationData({item: "Test String Data", schema: bytes32(0)});
 
         // Make an obligation
         vm.prank(testUser);

--- a/contracts/test/unit/obligations/escrow/non-tierable/AttestationEscrowObligation.t.sol
+++ b/contracts/test/unit/obligations/escrow/non-tierable/AttestationEscrowObligation.t.sol
@@ -173,7 +173,7 @@ contract AttestationEscrowObligationTest is Test {
 
         vm.startPrank(attester);
         fulfillmentUid = stringObligation.doObligation(
-            StringObligation.ObligationData({item: "fulfillment data"}),
+            StringObligation.ObligationData({item: "fulfillment data", schema: bytes32(0)}),
             escrowUid  // Reference the escrow for non-tierable pattern
         );
         vm.stopPrank();
@@ -243,7 +243,7 @@ contract AttestationEscrowObligationTest is Test {
         // Create a fulfillment attestation
         vm.startPrank(attester);
         bytes32 fulfillmentUid = stringObligation.doObligation(
-            StringObligation.ObligationData({item: "fulfillment data"}),
+            StringObligation.ObligationData({item: "fulfillment data", schema: bytes32(0)}),
             escrowUid
         );
 

--- a/contracts/test/unit/obligations/escrow/non-tierable/AttestationEscrowObligation2.t.sol
+++ b/contracts/test/unit/obligations/escrow/non-tierable/AttestationEscrowObligation2.t.sol
@@ -228,8 +228,7 @@ contract AttestationEscrowObligation2Test is Test {
 
         // Create a fulfillment attestation from the attester using StringObligation
         vm.prank(attester);
-        StringObligation.ObligationData memory stringData = StringObligation
-            .ObligationData({item: "fulfillment data"});
+        StringObligation.ObligationData memory stringData = StringObligation.ObligationData({item: "fulfillment data", schema: bytes32(0)});
 
         bytes32 fulfillmentUid = stringObligation.doObligation(
             stringData,
@@ -295,8 +294,7 @@ contract AttestationEscrowObligation2Test is Test {
 
         // Create a fulfillment attestation from the attester using StringObligation
         vm.prank(attester);
-        StringObligation.ObligationData memory stringData = StringObligation
-            .ObligationData({item: "fulfillment data"});
+        StringObligation.ObligationData memory stringData = StringObligation.ObligationData({item: "fulfillment data", schema: bytes32(0)});
 
         bytes32 fulfillmentUid = stringObligation.doObligation(
             stringData,
@@ -417,8 +415,7 @@ contract AttestationEscrowObligation2Test is Test {
         // Create a fulfillment attestation using StringObligation
         // Note: fulfillment doesn't reference anything since the escrow doesn't exist yet
         vm.prank(attester);
-        StringObligation.ObligationData memory stringData = StringObligation
-            .ObligationData({item: "fulfillment data"});
+        StringObligation.ObligationData memory stringData = StringObligation.ObligationData({item: "fulfillment data", schema: bytes32(0)});
 
         bytes32 fulfillmentUid = stringObligation.doObligation(
             stringData,

--- a/contracts/test/unit/obligations/escrow/non-tierable/ERC1155EscrowObligation.t.sol
+++ b/contracts/test/unit/obligations/escrow/non-tierable/ERC1155EscrowObligation.t.sol
@@ -201,7 +201,7 @@ contract ERC1155EscrowObligationTest is Test {
 
         vm.prank(seller);
         bytes32 fulfillmentUid = stringObligation.doObligation(
-            StringObligation.ObligationData({item: "fulfillment data"}),
+            StringObligation.ObligationData({item: "fulfillment data", schema: bytes32(0)}),
             paymentUid  // Reference the escrow for non-tierable pattern
         );
 
@@ -254,7 +254,7 @@ contract ERC1155EscrowObligationTest is Test {
 
         vm.prank(seller);
         bytes32 fulfillmentUid = stringObligation.doObligation(
-            StringObligation.ObligationData({item: "fulfillment data"}),
+            StringObligation.ObligationData({item: "fulfillment data", schema: bytes32(0)}),
             paymentUid  // Reference the escrow for non-tierable pattern
         );
 

--- a/contracts/test/unit/obligations/escrow/non-tierable/ERC20EscrowObligation.t.sol
+++ b/contracts/test/unit/obligations/escrow/non-tierable/ERC20EscrowObligation.t.sol
@@ -193,7 +193,7 @@ contract ERC20EscrowObligationTest is Test {
 
         vm.prank(seller);
         bytes32 fulfillmentUid = stringObligation.doObligation(
-            StringObligation.ObligationData({item: "fulfillment data"}),
+            StringObligation.ObligationData({item: "fulfillment data", schema: bytes32(0)}),
             paymentUid
         );
 
@@ -245,7 +245,7 @@ contract ERC20EscrowObligationTest is Test {
 
         vm.prank(seller);
         bytes32 fulfillmentUid = stringObligation.doObligation(
-            StringObligation.ObligationData({item: "fulfillment data"}),
+            StringObligation.ObligationData({item: "fulfillment data", schema: bytes32(0)}),
             paymentUid
         );
 

--- a/contracts/test/unit/obligations/escrow/non-tierable/ERC721EscrowObligation.t.sol
+++ b/contracts/test/unit/obligations/escrow/non-tierable/ERC721EscrowObligation.t.sol
@@ -184,7 +184,7 @@ contract ERC721EscrowObligationTest is Test {
 
         vm.prank(seller);
         bytes32 fulfillmentUid = stringObligation.doObligation(
-            StringObligation.ObligationData({item: "fulfillment data"}),
+            StringObligation.ObligationData({item: "fulfillment data", schema: bytes32(0)}),
             paymentUid
         );
 
@@ -231,7 +231,7 @@ contract ERC721EscrowObligationTest is Test {
 
         vm.prank(seller);
         bytes32 fulfillmentUid = stringObligation.doObligation(
-            StringObligation.ObligationData({item: "fulfillment data"}),
+            StringObligation.ObligationData({item: "fulfillment data", schema: bytes32(0)}),
             paymentUid
         );
 

--- a/contracts/test/unit/obligations/escrow/non-tierable/NativeTokenEscrowObligation.t.sol
+++ b/contracts/test/unit/obligations/escrow/non-tierable/NativeTokenEscrowObligation.t.sol
@@ -147,7 +147,7 @@ contract NativeTokenEscrowObligationTest is Test {
         // Create fulfillment (string obligation)
         vm.prank(seller);
         bytes32 fulfillmentUid = stringObligation.doObligation(
-            StringObligation.ObligationData({item: "hello"}),
+            StringObligation.ObligationData({item: "hello", schema: bytes32(0)}),
             escrowUid
         );
 
@@ -192,7 +192,7 @@ contract NativeTokenEscrowObligationTest is Test {
         // Create wrong fulfillment
         vm.prank(seller);
         bytes32 fulfillmentUid = stringObligation.doObligation(
-            StringObligation.ObligationData({item: "goodbye"}),
+            StringObligation.ObligationData({item: "goodbye", schema: bytes32(0)}),
             escrowUid
         );
 
@@ -452,7 +452,7 @@ contract NativeTokenEscrowObligationTest is Test {
         // Create valid fulfillment
         vm.prank(seller);
         bytes32 fulfillmentUid = stringObligation.doObligation(
-            StringObligation.ObligationData({item: "hello"}),
+            StringObligation.ObligationData({item: "hello", schema: bytes32(0)}),
             wrongSchemaEscrowUid
         );
 
@@ -507,7 +507,7 @@ contract NativeTokenEscrowObligationTest is Test {
         // Create fulfillment from reverting receiver
         vm.prank(address(revertingReceiver));
         bytes32 fulfillmentUid = stringObligation.doObligation(
-            StringObligation.ObligationData({item: "hello"}),
+            StringObligation.ObligationData({item: "hello", schema: bytes32(0)}),
             escrowUid
         );
 

--- a/contracts/test/unit/obligations/escrow/tierable/AttestationEscrowObligation.t.sol
+++ b/contracts/test/unit/obligations/escrow/tierable/AttestationEscrowObligation.t.sol
@@ -93,7 +93,7 @@ contract AttestationEscrowObligationTierableTest is Test {
         StringObligation stringObligation = new StringObligation(eas, schemaRegistry);
         vm.prank(attester);
         bytes32 fulfillmentUid = stringObligation.doObligation(
-            StringObligation.ObligationData({item: "fulfillment"}),
+            StringObligation.ObligationData({item: "fulfillment", schema: bytes32(0)}),
             bytes32(0)
         );
 

--- a/contracts/test/unit/obligations/escrow/tierable/AttestationEscrowObligation2.t.sol
+++ b/contracts/test/unit/obligations/escrow/tierable/AttestationEscrowObligation2.t.sol
@@ -92,7 +92,7 @@ contract AttestationEscrowObligation2TierableTest is Test {
         StringObligation stringObligation = new StringObligation(eas, schemaRegistry);
         vm.prank(attester);
         bytes32 fulfillmentUid = stringObligation.doObligation(
-            StringObligation.ObligationData({item: "fulfillment"}),
+            StringObligation.ObligationData({item: "fulfillment", schema: bytes32(0)}),
             bytes32(0)
         );
 

--- a/contracts/test/unit/obligations/escrow/tierable/ERC1155EscrowObligation.t.sol
+++ b/contracts/test/unit/obligations/escrow/tierable/ERC1155EscrowObligation.t.sol
@@ -102,7 +102,7 @@ contract ERC1155EscrowObligationTierableTest is Test {
         StringObligation stringObligation = new StringObligation(eas, schemaRegistry);
         vm.prank(seller);
         bytes32 fulfillmentUid = stringObligation.doObligation(
-            StringObligation.ObligationData({item: "fulfillment"}),
+            StringObligation.ObligationData({item: "fulfillment", schema: bytes32(0)}),
             bytes32(0)
         );
 

--- a/contracts/test/unit/obligations/escrow/tierable/ERC20EscrowObligation.t.sol
+++ b/contracts/test/unit/obligations/escrow/tierable/ERC20EscrowObligation.t.sol
@@ -141,7 +141,7 @@ contract ERC20EscrowObligationTierableTest is Test {
 
         vm.prank(seller);
         bytes32 fulfillmentUid = stringObligation.doObligation(
-            StringObligation.ObligationData({item: "fulfillment data"}),
+            StringObligation.ObligationData({item: "fulfillment data", schema: bytes32(0)}),
             bytes32(0) // Note: NOT referencing paymentUid - this is the key difference for tierable
         );
 
@@ -206,7 +206,7 @@ contract ERC20EscrowObligationTierableTest is Test {
 
         vm.prank(seller);
         bytes32 fulfillmentUid = stringObligation.doObligation(
-            StringObligation.ObligationData({item: "fulfillment data"}),
+            StringObligation.ObligationData({item: "fulfillment data", schema: bytes32(0)}),
             bytes32(0) // Not referencing any specific payment
         );
 
@@ -264,7 +264,7 @@ contract ERC20EscrowObligationTierableTest is Test {
 
         vm.prank(seller);
         bytes32 fulfillmentUid = stringObligation.doObligation(
-            StringObligation.ObligationData({item: "fulfillment data"}),
+            StringObligation.ObligationData({item: "fulfillment data", schema: bytes32(0)}),
             bytes32(0)
         );
 

--- a/contracts/test/unit/obligations/escrow/tierable/ERC721EscrowObligation.t.sol
+++ b/contracts/test/unit/obligations/escrow/tierable/ERC721EscrowObligation.t.sol
@@ -102,7 +102,7 @@ contract ERC721EscrowObligationTierableTest is Test {
         StringObligation stringObligation = new StringObligation(eas, schemaRegistry);
         vm.prank(seller);
         bytes32 fulfillmentUid = stringObligation.doObligation(
-            StringObligation.ObligationData({item: "fulfillment"}),
+            StringObligation.ObligationData({item: "fulfillment", schema: bytes32(0)}),
             bytes32(0)
         );
 

--- a/contracts/test/unit/obligations/escrow/tierable/NativeTokenEscrowObligation.t.sol
+++ b/contracts/test/unit/obligations/escrow/tierable/NativeTokenEscrowObligation.t.sol
@@ -81,7 +81,7 @@ contract NativeTokenEscrowObligationTierableTest is Test {
         StringObligation stringObligation = new StringObligation(eas, schemaRegistry);
         vm.prank(seller);
         bytes32 fulfillmentUid = stringObligation.doObligation(
-            StringObligation.ObligationData({item: "fulfillment"}),
+            StringObligation.ObligationData({item: "fulfillment", schema: bytes32(0)}),
             bytes32(0)
         );
 

--- a/contracts/test/unit/obligations/escrow/tierable/TokenBundleEscrowObligation.t.sol
+++ b/contracts/test/unit/obligations/escrow/tierable/TokenBundleEscrowObligation.t.sol
@@ -146,7 +146,7 @@ contract TokenBundleEscrowObligationTierableTest is Test {
         StringObligation stringObligation = new StringObligation(eas, schemaRegistry);
         vm.prank(seller);
         bytes32 fulfillmentUid = stringObligation.doObligation(
-            StringObligation.ObligationData({item: "fulfillment"}),
+            StringObligation.ObligationData({item: "fulfillment", schema: bytes32(0)}),
             bytes32(0)
         );
 

--- a/docs/mcp-server/.gitignore
+++ b/docs/mcp-server/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+dist/
+generated/
+*.log
+bun.lockb

--- a/docs/mcp-server/README.md
+++ b/docs/mcp-server/README.md
@@ -1,0 +1,135 @@
+# Alkahest Docs MCP Server
+
+An MCP (Model Context Protocol) server that provides intelligent documentation access for the Alkahest protocol. Goes beyond static docs by extracting structured knowledge from contracts, SDK, and deployments.
+
+## Features
+
+- **Smart Search**: Full-text search across contracts, SDK modules, and guides
+- **Contract Documentation**: Detailed info including functions, events, errors, schemas, and deployed addresses
+- **SDK Documentation**: Client method listings with hierarchical module structure
+- **Deployment Info**: Contract addresses per chain (Base Sepolia, Filecoin Calibration, Monad)
+- **Guide Access**: Documentation guides with code examples
+
+## Quick Setup (Copy-Paste)
+
+**Claude Code:**
+```bash
+claude mcp add alkahest-docs -- npx alkahest-mcp
+```
+
+**Cursor / Windsurf / Other MCP Clients:**
+```bash
+npx @anthropic-ai/mcp-cli add alkahest-docs -- npx alkahest-mcp
+```
+
+### Manual Config
+
+**Claude Desktop** (`~/Library/Application Support/Claude/claude_desktop_config.json`):
+```json
+{
+  "mcpServers": {
+    "alkahest-docs": {
+      "command": "npx",
+      "args": ["alkahest-mcp"]
+    }
+  }
+}
+```
+
+**Claude Code** (`~/.claude/settings.json`):
+```json
+{
+  "mcpServers": {
+    "alkahest-docs": {
+      "command": "npx",
+      "args": ["alkahest-mcp"]
+    }
+  }
+}
+```
+
+## Development
+
+```bash
+cd docs/mcp-server
+bun install
+bun run generate  # Extract documentation data
+bun run build     # Compile TypeScript
+bun run dev       # Run in dev mode
+```
+
+## Available Tools
+
+### `search_docs`
+Search across all documentation.
+
+```json
+{
+  "query": "ERC20 escrow",
+  "type": "contract",  // optional: contract, sdk, guide, all
+  "limit": 10         // optional
+}
+```
+
+### `get_contract`
+Get detailed contract documentation.
+
+```json
+{
+  "name": "ERC20EscrowObligation"
+}
+```
+
+### `list`
+List contracts or SDK modules by category.
+
+```json
+{
+  "type": "contract",
+  "category": "arbiter"  // optional: arbiter, escrow, payment, utils
+}
+```
+
+### `get_deployment`
+Get contract addresses for a chain.
+
+```json
+{
+  "chain": "base-sepolia"
+}
+```
+
+### `get_sdk_method`
+Get SDK module documentation.
+
+```json
+{
+  "module": "erc20"
+}
+```
+
+### `get_guide`
+Get a documentation guide.
+
+```json
+{
+  "topic": "token trading"
+}
+```
+
+## Architecture
+
+```
+docs/mcp-server/
+├── scripts/           # Data extraction
+│   ├── generate.ts    # Main generation script
+│   ├── parse-solidity.ts
+│   ├── parse-sdk.ts
+│   ├── parse-deployments.ts
+│   └── parse-guides.ts
+├── src/
+│   ├── index.ts       # MCP server
+│   ├── data/          # Data loading
+│   └── search/        # Search engine
+└── generated/         # Build output (gitignored)
+```

--- a/docs/mcp-server/bun.lock
+++ b/docs/mcp-server/bun.lock
@@ -1,0 +1,280 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "@alkahest/docs-mcp-server",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.0.0",
+        "@solidity-parser/parser": "^0.18.0",
+        "lunr": "^2.3.9",
+        "marked": "^12.0.0",
+      },
+      "devDependencies": {
+        "@types/lunr": "^2.3.7",
+        "@types/node": "^20.0.0",
+        "tsx": "^4.0.0",
+        "typescript": "^5.0.0",
+      },
+    },
+  },
+  "packages": {
+    "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.2", "", { "os": "aix", "cpu": "ppc64" }, "sha512-GZMB+a0mOMZs4MpDbj8RJp4cw+w1WV5NYD6xzgvzUJ5Ek2jerwfO2eADyI6ExDSUED+1X8aMbegahsJi+8mgpw=="],
+
+    "@esbuild/android-arm": ["@esbuild/android-arm@0.27.2", "", { "os": "android", "cpu": "arm" }, "sha512-DVNI8jlPa7Ujbr1yjU2PfUSRtAUZPG9I1RwW4F4xFB1Imiu2on0ADiI/c3td+KmDtVKNbi+nffGDQMfcIMkwIA=="],
+
+    "@esbuild/android-arm64": ["@esbuild/android-arm64@0.27.2", "", { "os": "android", "cpu": "arm64" }, "sha512-pvz8ZZ7ot/RBphf8fv60ljmaoydPU12VuXHImtAs0XhLLw+EXBi2BLe3OYSBslR4rryHvweW5gmkKFwTiFy6KA=="],
+
+    "@esbuild/android-x64": ["@esbuild/android-x64@0.27.2", "", { "os": "android", "cpu": "x64" }, "sha512-z8Ank4Byh4TJJOh4wpz8g2vDy75zFL0TlZlkUkEwYXuPSgX8yzep596n6mT7905kA9uHZsf/o2OJZubl2l3M7A=="],
+
+    "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.27.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-davCD2Zc80nzDVRwXTcQP/28fiJbcOwvdolL0sOiOsbwBa72kegmVU0Wrh1MYrbuCL98Omp5dVhQFWRKR2ZAlg=="],
+
+    "@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.27.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-ZxtijOmlQCBWGwbVmwOF/UCzuGIbUkqB1faQRf5akQmxRJ1ujusWsb3CVfk/9iZKr2L5SMU5wPBi1UWbvL+VQA=="],
+
+    "@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.27.2", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-lS/9CN+rgqQ9czogxlMcBMGd+l8Q3Nj1MFQwBZJyoEKI50XGxwuzznYdwcav6lpOGv5BqaZXqvBSiB/kJ5op+g=="],
+
+    "@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.27.2", "", { "os": "freebsd", "cpu": "x64" }, "sha512-tAfqtNYb4YgPnJlEFu4c212HYjQWSO/w/h/lQaBK7RbwGIkBOuNKQI9tqWzx7Wtp7bTPaGC6MJvWI608P3wXYA=="],
+
+    "@esbuild/linux-arm": ["@esbuild/linux-arm@0.27.2", "", { "os": "linux", "cpu": "arm" }, "sha512-vWfq4GaIMP9AIe4yj1ZUW18RDhx6EPQKjwe7n8BbIecFtCQG4CfHGaHuh7fdfq+y3LIA2vGS/o9ZBGVxIDi9hw=="],
+
+    "@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.27.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-hYxN8pr66NsCCiRFkHUAsxylNOcAQaxSSkHMMjcpx0si13t1LHFphxJZUiGwojB1a/Hd5OiPIqDdXONia6bhTw=="],
+
+    "@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.27.2", "", { "os": "linux", "cpu": "ia32" }, "sha512-MJt5BRRSScPDwG2hLelYhAAKh9imjHK5+NE/tvnRLbIqUWa+0E9N4WNMjmp/kXXPHZGqPLxggwVhz7QP8CTR8w=="],
+
+    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.27.2", "", { "os": "linux", "cpu": "none" }, "sha512-lugyF1atnAT463aO6KPshVCJK5NgRnU4yb3FUumyVz+cGvZbontBgzeGFO1nF+dPueHD367a2ZXe1NtUkAjOtg=="],
+
+    "@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.27.2", "", { "os": "linux", "cpu": "none" }, "sha512-nlP2I6ArEBewvJ2gjrrkESEZkB5mIoaTswuqNFRv/WYd+ATtUpe9Y09RnJvgvdag7he0OWgEZWhviS1OTOKixw=="],
+
+    "@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.27.2", "", { "os": "linux", "cpu": "ppc64" }, "sha512-C92gnpey7tUQONqg1n6dKVbx3vphKtTHJaNG2Ok9lGwbZil6DrfyecMsp9CrmXGQJmZ7iiVXvvZH6Ml5hL6XdQ=="],
+
+    "@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.27.2", "", { "os": "linux", "cpu": "none" }, "sha512-B5BOmojNtUyN8AXlK0QJyvjEZkWwy/FKvakkTDCziX95AowLZKR6aCDhG7LeF7uMCXEJqwa8Bejz5LTPYm8AvA=="],
+
+    "@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.27.2", "", { "os": "linux", "cpu": "s390x" }, "sha512-p4bm9+wsPwup5Z8f4EpfN63qNagQ47Ua2znaqGH6bqLlmJ4bx97Y9JdqxgGZ6Y8xVTixUnEkoKSHcpRlDnNr5w=="],
+
+    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.27.2", "", { "os": "linux", "cpu": "x64" }, "sha512-uwp2Tip5aPmH+NRUwTcfLb+W32WXjpFejTIOWZFw/v7/KnpCDKG66u4DLcurQpiYTiYwQ9B7KOeMJvLCu/OvbA=="],
+
+    "@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.27.2", "", { "os": "none", "cpu": "arm64" }, "sha512-Kj6DiBlwXrPsCRDeRvGAUb/LNrBASrfqAIok+xB0LxK8CHqxZ037viF13ugfsIpePH93mX7xfJp97cyDuTZ3cw=="],
+
+    "@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.27.2", "", { "os": "none", "cpu": "x64" }, "sha512-HwGDZ0VLVBY3Y+Nw0JexZy9o/nUAWq9MlV7cahpaXKW6TOzfVno3y3/M8Ga8u8Yr7GldLOov27xiCnqRZf0tCA=="],
+
+    "@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.27.2", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-DNIHH2BPQ5551A7oSHD0CKbwIA/Ox7+78/AWkbS5QoRzaqlev2uFayfSxq68EkonB+IKjiuxBFoV8ESJy8bOHA=="],
+
+    "@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.27.2", "", { "os": "openbsd", "cpu": "x64" }, "sha512-/it7w9Nb7+0KFIzjalNJVR5bOzA9Vay+yIPLVHfIQYG/j+j9VTH84aNB8ExGKPU4AzfaEvN9/V4HV+F+vo8OEg=="],
+
+    "@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.27.2", "", { "os": "none", "cpu": "arm64" }, "sha512-LRBbCmiU51IXfeXk59csuX/aSaToeG7w48nMwA6049Y4J4+VbWALAuXcs+qcD04rHDuSCSRKdmY63sruDS5qag=="],
+
+    "@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.27.2", "", { "os": "sunos", "cpu": "x64" }, "sha512-kMtx1yqJHTmqaqHPAzKCAkDaKsffmXkPHThSfRwZGyuqyIeBvf08KSsYXl+abf5HDAPMJIPnbBfXvP2ZC2TfHg=="],
+
+    "@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.27.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-Yaf78O/B3Kkh+nKABUF++bvJv5Ijoy9AN1ww904rOXZFLWVc5OLOfL56W+C8F9xn5JQZa3UX6m+IktJnIb1Jjg=="],
+
+    "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.27.2", "", { "os": "win32", "cpu": "ia32" }, "sha512-Iuws0kxo4yusk7sw70Xa2E2imZU5HoixzxfGCdxwBdhiDgt9vX9VUCBhqcwY7/uh//78A1hMkkROMJq9l27oLQ=="],
+
+    "@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.2", "", { "os": "win32", "cpu": "x64" }, "sha512-sRdU18mcKf7F+YgheI/zGf5alZatMUTKj/jNS6l744f9u3WFu4v7twcUI9vu4mknF4Y9aDlblIie0IM+5xxaqQ=="],
+
+    "@hono/node-server": ["@hono/node-server@1.19.9", "", { "peerDependencies": { "hono": "^4" } }, "sha512-vHL6w3ecZsky+8P5MD+eFfaGTyCeOHUIFYMGpQGbrBTSmNNoxv0if69rEZ5giu36weC5saFuznL411gRX7bJDw=="],
+
+    "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.26.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-Y5RmPncpiDtTXDbLKswIJzTqu2hyBKxTNsgKqKclDbhIgg1wgtf1fRuvxgTnRfcnxtvvgbIEcqUOzZrJ6iSReg=="],
+
+    "@solidity-parser/parser": ["@solidity-parser/parser@0.18.0", "", {}, "sha512-yfORGUIPgLck41qyN7nbwJRAx17/jAIXCTanHOJZhB6PJ1iAk/84b/xlsVKFSyNyLXIj0dhppoE0+CRws7wlzA=="],
+
+    "@types/lunr": ["@types/lunr@2.3.7", "", {}, "sha512-Tb/kUm38e8gmjahQzdCKhbdsvQ9/ppzHFfsJ0dMs3ckqQsRj+P5IkSAwFTBrBxdyr3E/LoMUUrZngjDYAjiE3A=="],
+
+    "@types/node": ["@types/node@20.19.31", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-5jsi0wpncvTD33Sh1UCgacK37FFwDn+EG7wCmEvs62fCvBL+n8/76cAYDok21NF6+jaVWIqKwCZyX7Vbu8eB3A=="],
+
+    "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
+
+    "ajv": ["ajv@8.17.1", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g=="],
+
+    "ajv-formats": ["ajv-formats@3.0.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ=="],
+
+    "body-parser": ["body-parser@2.2.2", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^1.0.5", "debug": "^4.4.3", "http-errors": "^2.0.0", "iconv-lite": "^0.7.0", "on-finished": "^2.4.1", "qs": "^6.14.1", "raw-body": "^3.0.1", "type-is": "^2.0.1" } }, "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA=="],
+
+    "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
+
+    "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
+
+    "call-bound": ["call-bound@1.0.4", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "get-intrinsic": "^1.3.0" } }, "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg=="],
+
+    "content-disposition": ["content-disposition@1.0.1", "", {}, "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q=="],
+
+    "content-type": ["content-type@1.0.5", "", {}, "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="],
+
+    "cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
+
+    "cookie-signature": ["cookie-signature@1.2.2", "", {}, "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="],
+
+    "cors": ["cors@2.8.6", "", { "dependencies": { "object-assign": "^4", "vary": "^1" } }, "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw=="],
+
+    "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
+
+    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
+
+    "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
+
+    "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
+
+    "encodeurl": ["encodeurl@2.0.0", "", {}, "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="],
+
+    "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
+
+    "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
+
+    "es-object-atoms": ["es-object-atoms@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA=="],
+
+    "esbuild": ["esbuild@0.27.2", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.2", "@esbuild/android-arm": "0.27.2", "@esbuild/android-arm64": "0.27.2", "@esbuild/android-x64": "0.27.2", "@esbuild/darwin-arm64": "0.27.2", "@esbuild/darwin-x64": "0.27.2", "@esbuild/freebsd-arm64": "0.27.2", "@esbuild/freebsd-x64": "0.27.2", "@esbuild/linux-arm": "0.27.2", "@esbuild/linux-arm64": "0.27.2", "@esbuild/linux-ia32": "0.27.2", "@esbuild/linux-loong64": "0.27.2", "@esbuild/linux-mips64el": "0.27.2", "@esbuild/linux-ppc64": "0.27.2", "@esbuild/linux-riscv64": "0.27.2", "@esbuild/linux-s390x": "0.27.2", "@esbuild/linux-x64": "0.27.2", "@esbuild/netbsd-arm64": "0.27.2", "@esbuild/netbsd-x64": "0.27.2", "@esbuild/openbsd-arm64": "0.27.2", "@esbuild/openbsd-x64": "0.27.2", "@esbuild/openharmony-arm64": "0.27.2", "@esbuild/sunos-x64": "0.27.2", "@esbuild/win32-arm64": "0.27.2", "@esbuild/win32-ia32": "0.27.2", "@esbuild/win32-x64": "0.27.2" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw=="],
+
+    "escape-html": ["escape-html@1.0.3", "", {}, "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="],
+
+    "etag": ["etag@1.8.1", "", {}, "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="],
+
+    "eventsource": ["eventsource@3.0.7", "", { "dependencies": { "eventsource-parser": "^3.0.1" } }, "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA=="],
+
+    "eventsource-parser": ["eventsource-parser@3.0.6", "", {}, "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg=="],
+
+    "express": ["express@5.2.1", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.1", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "depd": "^2.0.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw=="],
+
+    "express-rate-limit": ["express-rate-limit@8.2.1", "", { "dependencies": { "ip-address": "10.0.1" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-PCZEIEIxqwhzw4KF0n7QF4QqruVTcF73O5kFKUnGOyjbCCgizBBiFaYpd/fnBLUMPw/BWw9OsiN7GgrNYr7j6g=="],
+
+    "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
+
+    "fast-uri": ["fast-uri@3.1.0", "", {}, "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA=="],
+
+    "finalhandler": ["finalhandler@2.1.1", "", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA=="],
+
+    "forwarded": ["forwarded@0.2.0", "", {}, "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="],
+
+    "fresh": ["fresh@2.0.0", "", {}, "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="],
+
+    "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
+
+    "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
+
+    "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
+
+    "get-tsconfig": ["get-tsconfig@4.13.1", "", { "dependencies": { "resolve-pkg-maps": "^1.0.0" } }, "sha512-EoY1N2xCn44xU6750Sx7OjOIT59FkmstNc3X6y5xpz7D5cBtZRe/3pSlTkDJgqsOk3WwZPkWfonhhUJfttQo3w=="],
+
+    "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
+
+    "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
+
+    "hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
+
+    "hono": ["hono@4.11.7", "", {}, "sha512-l7qMiNee7t82bH3SeyUCt9UF15EVmaBvsppY2zQtrbIhl/yzBTny+YUxsVjSjQ6gaqaeVtZmGocom8TzBlA4Yw=="],
+
+    "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
+
+    "iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
+
+    "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
+
+    "ip-address": ["ip-address@10.0.1", "", {}, "sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA=="],
+
+    "ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
+
+    "is-promise": ["is-promise@4.0.0", "", {}, "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="],
+
+    "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
+
+    "jose": ["jose@6.1.3", "", {}, "sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ=="],
+
+    "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
+
+    "json-schema-typed": ["json-schema-typed@8.0.2", "", {}, "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA=="],
+
+    "lunr": ["lunr@2.3.9", "", {}, "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow=="],
+
+    "marked": ["marked@12.0.2", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-qXUm7e/YKFoqFPYPa3Ukg9xlI5cyAtGmyEIzMfW//m6kXwCy2Ps9DYf5ioijFKQ8qyuscrHoY04iJGctu2Kg0Q=="],
+
+    "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
+
+    "media-typer": ["media-typer@1.1.0", "", {}, "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw=="],
+
+    "merge-descriptors": ["merge-descriptors@2.0.0", "", {}, "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g=="],
+
+    "mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
+
+    "mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
+
+    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
+
+    "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
+
+    "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
+
+    "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
+
+    "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
+
+    "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
+
+    "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
+
+    "path-to-regexp": ["path-to-regexp@8.3.0", "", {}, "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA=="],
+
+    "pkce-challenge": ["pkce-challenge@5.0.1", "", {}, "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="],
+
+    "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
+
+    "qs": ["qs@6.14.1", "", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ=="],
+
+    "range-parser": ["range-parser@1.2.1", "", {}, "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="],
+
+    "raw-body": ["raw-body@3.0.2", "", { "dependencies": { "bytes": "~3.1.2", "http-errors": "~2.0.1", "iconv-lite": "~0.7.0", "unpipe": "~1.0.0" } }, "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA=="],
+
+    "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
+
+    "resolve-pkg-maps": ["resolve-pkg-maps@1.0.0", "", {}, "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw=="],
+
+    "router": ["router@2.2.0", "", { "dependencies": { "debug": "^4.4.0", "depd": "^2.0.0", "is-promise": "^4.0.0", "parseurl": "^1.3.3", "path-to-regexp": "^8.0.0" } }, "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ=="],
+
+    "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
+
+    "send": ["send@1.2.1", "", { "dependencies": { "debug": "^4.4.3", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "fresh": "^2.0.0", "http-errors": "^2.0.1", "mime-types": "^3.0.2", "ms": "^2.1.3", "on-finished": "^2.4.1", "range-parser": "^1.2.1", "statuses": "^2.0.2" } }, "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ=="],
+
+    "serve-static": ["serve-static@2.2.1", "", { "dependencies": { "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "parseurl": "^1.3.3", "send": "^1.2.0" } }, "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw=="],
+
+    "setprototypeof": ["setprototypeof@1.2.0", "", {}, "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="],
+
+    "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
+
+    "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
+
+    "side-channel": ["side-channel@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.3", "side-channel-list": "^1.0.0", "side-channel-map": "^1.0.1", "side-channel-weakmap": "^1.0.2" } }, "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw=="],
+
+    "side-channel-list": ["side-channel-list@1.0.0", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.3" } }, "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA=="],
+
+    "side-channel-map": ["side-channel-map@1.0.1", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3" } }, "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA=="],
+
+    "side-channel-weakmap": ["side-channel-weakmap@1.0.2", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3", "side-channel-map": "^1.0.1" } }, "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A=="],
+
+    "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
+
+    "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
+
+    "tsx": ["tsx@4.21.0", "", { "dependencies": { "esbuild": "~0.27.0", "get-tsconfig": "^4.7.5" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "bin": { "tsx": "dist/cli.mjs" } }, "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw=="],
+
+    "type-is": ["type-is@2.0.1", "", { "dependencies": { "content-type": "^1.0.5", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw=="],
+
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
+
+    "unpipe": ["unpipe@1.0.0", "", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
+
+    "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
+
+    "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
+
+    "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
+
+    "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
+
+    "zod-to-json-schema": ["zod-to-json-schema@3.25.1", "", { "peerDependencies": { "zod": "^3.25 || ^4" } }, "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA=="],
+  }
+}

--- a/docs/mcp-server/package.json
+++ b/docs/mcp-server/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "alkahest-mcp",
+  "version": "0.1.0",
+  "description": "MCP server for Alkahest documentation",
+  "type": "module",
+  "main": "dist/index.js",
+  "bin": {
+    "alkahest-docs-mcp": "./dist/index.js"
+  },
+  "scripts": {
+    "generate": "bun run scripts/generate.ts",
+    "build": "bun run generate && tsc",
+    "start": "node dist/index.js",
+    "dev": "bun run src/index.ts"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.0.0",
+    "@solidity-parser/parser": "^0.18.0",
+    "lunr": "^2.3.9",
+    "marked": "^12.0.0"
+  },
+  "devDependencies": {
+    "@types/lunr": "^2.3.7",
+    "@types/node": "^20.0.0",
+    "tsx": "^4.0.0",
+    "typescript": "^5.0.0"
+  },
+  "files": [
+    "dist",
+    "generated"
+  ]
+}

--- a/docs/mcp-server/scripts/generate.ts
+++ b/docs/mcp-server/scripts/generate.ts
@@ -1,0 +1,127 @@
+import { writeFileSync, mkdirSync, existsSync } from "fs";
+import { join } from "path";
+import lunr from "lunr";
+import { parseSolidityContracts } from "./parse-solidity.js";
+import { parseDeployments } from "./parse-deployments.js";
+import { parseSDK } from "./parse-sdk.js";
+import { parseGuides } from "./parse-guides.js";
+import type { SearchDocument } from "../src/data/types.js";
+
+const GENERATED_DIR = join(import.meta.dir, "../generated");
+
+// Ensure generated directory exists
+if (!existsSync(GENERATED_DIR)) {
+  mkdirSync(GENERATED_DIR, { recursive: true });
+}
+
+console.log("Generating documentation data...\n");
+
+// Parse all sources
+const [contracts, deployments, { modules: sdkModules, types: sdkTypes }, guides] = await Promise.all([
+  parseSolidityContracts(),
+  parseDeployments(),
+  parseSDK(),
+  parseGuides(),
+]);
+
+// Merge deployment addresses into contracts
+for (const contract of contracts) {
+  const deployedAddresses: Record<string, string> = {};
+  for (const deployment of deployments) {
+    const contractEntry = deployment.contracts[contract.name];
+    if (contractEntry) {
+      deployedAddresses[deployment.chainName] = contractEntry.address;
+    }
+  }
+  (contract as any).deployedAddresses = deployedAddresses;
+}
+
+// Build search index
+console.log("\nBuilding search index...");
+const searchDocs: SearchDocument[] = [];
+
+// Add contracts to search
+for (const contract of contracts) {
+  searchDocs.push({
+    id: `contract:${contract.name}`,
+    type: "contract",
+    title: contract.name,
+    content: [
+      contract.description || "",
+      contract.category,
+      contract.subcategory || "",
+      contract.schema || "",
+      contract.structs.map((s) => `${s.name} ${s.fields.map((f) => f.name).join(" ")}`).join(" "),
+      contract.functions.map((f) => f.name).join(" "),
+    ].join(" "),
+    category: contract.category,
+    path: contract.path,
+  });
+}
+
+// Add SDK modules to search
+for (const module of sdkModules) {
+  searchDocs.push({
+    id: `sdk:${module.name}`,
+    type: "sdk",
+    title: module.name,
+    content: [
+      module.description || "",
+      module.correspondingContract || "",
+      module.methods.map((m) => `${m.name} ${m.description || ""}`).join(" "),
+    ].join(" "),
+    path: module.path,
+  });
+}
+
+// Add guides to search
+for (const guide of guides) {
+  searchDocs.push({
+    id: `guide:${guide.path}`,
+    type: "guide",
+    title: guide.title,
+    content: [
+      guide.sections.map((s) => `${s.title} ${s.content}`).join(" "),
+      guide.referencedContracts.join(" "),
+    ].join(" "),
+    path: guide.path,
+  });
+}
+
+// Build lunr index
+const searchIndex = lunr(function () {
+  this.ref("id");
+  this.field("title", { boost: 10 });
+  this.field("content");
+  this.field("category");
+
+  for (const doc of searchDocs) {
+    this.add(doc);
+  }
+});
+
+// Write all generated files
+console.log("\nWriting generated files...");
+
+writeFileSync(join(GENERATED_DIR, "contracts.json"), JSON.stringify(contracts, null, 2));
+console.log(`  contracts.json (${contracts.length} contracts)`);
+
+writeFileSync(join(GENERATED_DIR, "deployments.json"), JSON.stringify(deployments, null, 2));
+console.log(`  deployments.json (${deployments.length} chains)`);
+
+writeFileSync(
+  join(GENERATED_DIR, "sdk.json"),
+  JSON.stringify({ modules: sdkModules, types: sdkTypes }, null, 2)
+);
+console.log(`  sdk.json (${sdkModules.length} modules, ${sdkTypes.length} types)`);
+
+writeFileSync(join(GENERATED_DIR, "guides.json"), JSON.stringify(guides, null, 2));
+console.log(`  guides.json (${guides.length} guides)`);
+
+writeFileSync(join(GENERATED_DIR, "search-index.json"), JSON.stringify(searchIndex));
+console.log(`  search-index.json (${searchDocs.length} documents)`);
+
+writeFileSync(join(GENERATED_DIR, "search-docs.json"), JSON.stringify(searchDocs, null, 2));
+console.log(`  search-docs.json`);
+
+console.log("\nGeneration complete!");

--- a/docs/mcp-server/scripts/parse-deployments.ts
+++ b/docs/mcp-server/scripts/parse-deployments.ts
@@ -1,0 +1,81 @@
+import { readFileSync, readdirSync } from "fs";
+import { join, basename } from "path";
+import type { ChainDeployment } from "../src/data/types.js";
+
+const DEPLOYMENTS_DIR = join(import.meta.dir, "../../../contracts/deployments");
+
+// Map filenames to chain info
+const CHAIN_INFO: Record<string, { chainName: string; chainId?: number }> = {
+  deployment_base_sepolia: { chainName: "Base Sepolia", chainId: 84532 },
+  deployment_filecoin_calibration: { chainName: "Filecoin Calibration", chainId: 314159 },
+  deployment_monad: { chainName: "Monad Testnet", chainId: 143 },
+};
+
+// Convert camelCase to PascalCase for contract names
+function camelToPascal(str: string): string {
+  return str.charAt(0).toUpperCase() + str.slice(1);
+}
+
+// Parse a deployment JSON file
+function parseDeploymentFile(filePath: string): ChainDeployment | null {
+  const fileName = basename(filePath, ".json");
+
+  // Skip timestamped deployments (e.g., deployment_1742448700)
+  if (/deployment_\d+/.test(fileName)) {
+    return null;
+  }
+
+  const chainInfo = CHAIN_INFO[fileName];
+  if (!chainInfo) {
+    console.warn(`Unknown chain for file: ${fileName}`);
+    return null;
+  }
+
+  try {
+    const content = readFileSync(filePath, "utf-8");
+    const data = JSON.parse(content) as Record<string, string>;
+
+    const contracts: ChainDeployment["contracts"] = {};
+    for (const [key, address] of Object.entries(data)) {
+      // Convert camelCase key to PascalCase contract name
+      const contractName = camelToPascal(key);
+      contracts[contractName] = {
+        address: address.toLowerCase(),
+      };
+    }
+
+    return {
+      chainId: chainInfo.chainId,
+      chainName: chainInfo.chainName,
+      contracts,
+    };
+  } catch (error) {
+    console.error(`Error parsing ${filePath}:`, error);
+    return null;
+  }
+}
+
+// Main export function
+export async function parseDeployments(): Promise<ChainDeployment[]> {
+  const files = readdirSync(DEPLOYMENTS_DIR)
+    .filter((f) => f.startsWith("deployment_") && f.endsWith(".json"))
+    .map((f) => join(DEPLOYMENTS_DIR, f));
+
+  const deployments: ChainDeployment[] = [];
+
+  for (const file of files) {
+    const deployment = parseDeploymentFile(file);
+    if (deployment) {
+      deployments.push(deployment);
+    }
+  }
+
+  console.log(`Parsed ${deployments.length} chain deployments`);
+  return deployments;
+}
+
+// Run directly for testing
+if (import.meta.main) {
+  const deployments = await parseDeployments();
+  console.log(JSON.stringify(deployments, null, 2));
+}

--- a/docs/mcp-server/scripts/parse-guides.ts
+++ b/docs/mcp-server/scripts/parse-guides.ts
@@ -1,0 +1,147 @@
+import { readFileSync, readdirSync } from "fs";
+import { join, basename } from "path";
+import type { GuideDoc, GuideSection } from "../src/data/types.js";
+
+const DOCS_DIR = join(import.meta.dir, "../../");
+
+// Parse a markdown file into sections
+function parseMarkdown(content: string): GuideSection[] {
+  const sections: GuideSection[] = [];
+  const lines = content.split("\n");
+
+  let currentSection: GuideSection | null = null;
+  let currentContent: string[] = [];
+  let inCodeBlock = false;
+  let codeBlockLang = "";
+  let codeBlockContent: string[] = [];
+
+  for (const line of lines) {
+    // Check for code block start/end
+    if (line.startsWith("```")) {
+      if (inCodeBlock) {
+        // End of code block
+        if (currentSection) {
+          currentSection.codeExamples = currentSection.codeExamples || [];
+          currentSection.codeExamples.push({
+            language: codeBlockLang || "text",
+            code: codeBlockContent.join("\n"),
+          });
+        }
+        inCodeBlock = false;
+        codeBlockLang = "";
+        codeBlockContent = [];
+      } else {
+        // Start of code block
+        inCodeBlock = true;
+        codeBlockLang = line.slice(3).trim();
+      }
+      continue;
+    }
+
+    if (inCodeBlock) {
+      codeBlockContent.push(line);
+      continue;
+    }
+
+    // Check for headers
+    const headerMatch = line.match(/^(#{1,3})\s+(.+)$/);
+    if (headerMatch) {
+      // Save previous section
+      if (currentSection) {
+        currentSection.content = currentContent.join("\n").trim();
+        sections.push(currentSection);
+      }
+
+      // Start new section
+      currentSection = {
+        title: headerMatch[2],
+        content: "",
+      };
+      currentContent = [];
+    } else if (currentSection) {
+      currentContent.push(line);
+    } else {
+      // Content before first header
+      currentContent.push(line);
+    }
+  }
+
+  // Save last section
+  if (currentSection) {
+    currentSection.content = currentContent.join("\n").trim();
+    sections.push(currentSection);
+  }
+
+  return sections;
+}
+
+// Extract contract references from content
+function extractContractReferences(content: string): string[] {
+  const refs = new Set<string>();
+
+  // Pattern for contract names (PascalCase ending in common suffixes)
+  const patterns = [
+    /\b([A-Z][a-zA-Z0-9]*(?:Obligation|Arbiter|Utils))\b/g,
+    /\b(ERC20|ERC721|ERC1155|NativeToken|TokenBundle|Attestation)(?:Escrow|Payment|Barter)/g,
+  ];
+
+  for (const pattern of patterns) {
+    let match;
+    while ((match = pattern.exec(content)) !== null) {
+      refs.add(match[1] || match[0]);
+    }
+  }
+
+  return Array.from(refs);
+}
+
+// Parse a single guide file
+function parseGuide(filePath: string): GuideDoc {
+  const content = readFileSync(filePath, "utf-8");
+  const fileName = basename(filePath, ".md");
+
+  // Extract title from first H1 or filename
+  const titleMatch = content.match(/^#\s+(.+)$/m);
+  const title = titleMatch ? titleMatch[1] : fileName;
+
+  const sections = parseMarkdown(content);
+  const referencedContracts = extractContractReferences(content);
+
+  return {
+    title,
+    path: fileName,
+    sections,
+    referencedContracts,
+  };
+}
+
+// Main export function
+export async function parseGuides(): Promise<GuideDoc[]> {
+  const files = readdirSync(DOCS_DIR)
+    .filter((f) => f.endsWith(".md") && !f.startsWith("_"))
+    .map((f) => join(DOCS_DIR, f));
+
+  const guides: GuideDoc[] = [];
+
+  for (const file of files) {
+    try {
+      guides.push(parseGuide(file));
+    } catch (error) {
+      console.error(`Error parsing ${file}:`, error);
+    }
+  }
+
+  console.log(`Parsed ${guides.length} guides`);
+  return guides;
+}
+
+// Run directly for testing
+if (import.meta.main) {
+  const guides = await parseGuides();
+  for (const guide of guides) {
+    console.log(`\n${guide.title}`);
+    console.log(`  Sections: ${guide.sections.length}`);
+    console.log(`  Code examples: ${guide.sections.reduce((sum, s) => sum + (s.codeExamples?.length || 0), 0)}`);
+    console.log(`  Referenced contracts: ${guide.referencedContracts.join(", ")}`);
+  }
+}

--- a/docs/mcp-server/scripts/parse-sdk.ts
+++ b/docs/mcp-server/scripts/parse-sdk.ts
@@ -1,0 +1,381 @@
+import { readFileSync, readdirSync, statSync, existsSync } from "fs";
+import { join, relative, basename, dirname } from "path";
+import type { SDKModuleDoc, SDKMethodDoc, SDKTypeDoc } from "../src/data/types.js";
+
+const SDK_DIR = join(import.meta.dir, "../../../sdks/ts/src");
+const CLIENTS_DIR = join(SDK_DIR, "clients");
+
+// Extract JSDoc comment before a declaration
+function extractJSDoc(content: string, position: number): string | undefined {
+  // Look backwards from position for a JSDoc comment
+  const beforeContent = content.slice(0, position);
+  const match = beforeContent.match(/\/\*\*\s*([\s\S]*?)\s*\*\/\s*$/);
+  if (match) {
+    // Clean up the JSDoc
+    return match[1]
+      .split("\n")
+      .map((line) => line.replace(/^\s*\*\s?/, "").trim())
+      .filter((line) => !line.startsWith("@"))
+      .join(" ")
+      .trim();
+  }
+  return undefined;
+}
+
+// Extract method info from a makeXxxClient return object
+function extractClientMethods(content: string): SDKMethodDoc[] {
+  const methods: SDKMethodDoc[] = [];
+
+  // Find the return block of makeXxxClient functions (handle nested braces)
+  // Find "return {" and extract until the matching closing brace
+  const returnStart = content.indexOf("return {");
+  if (returnStart === -1) return methods;
+
+  // Find the matching closing brace
+  let braceCount = 0;
+  let returnEnd = returnStart;
+  let inBraces = false;
+
+  for (let i = returnStart; i < content.length; i++) {
+    if (content[i] === "{") {
+      braceCount++;
+      inBraces = true;
+    } else if (content[i] === "}") {
+      braceCount--;
+      if (inBraces && braceCount === 0) {
+        returnEnd = i + 1;
+        break;
+      }
+    }
+  }
+
+  const returnContent = content.slice(returnStart, returnEnd);
+
+  // Extract method names with their JSDoc descriptions
+  // Pattern: /** JSDoc */ methodName: async (params) => or methodName,
+  const methodPattern = /(?:\/\*\*\s*([\s\S]*?)\s*\*\/\s*)?(\w+):\s*(?:async\s*)?\([^)]*\)\s*=>/g;
+  let match;
+
+  while ((match = methodPattern.exec(returnContent)) !== null) {
+    const jsdoc = match[1];
+    const methodName = match[2];
+    // Skip internal/utility names
+    if (methodName === "address" || methodName.startsWith("_")) continue;
+
+    // Parse JSDoc description
+    let description: string | undefined;
+    if (jsdoc) {
+      description = jsdoc
+        .split("\n")
+        .map((line) => line.replace(/^\s*\*\s?/, "").trim())
+        .filter((line) => line && !line.startsWith("@"))
+        .join(" ")
+        .trim();
+    }
+
+    methods.push({
+      name: methodName,
+      path: "",
+      description,
+      params: [],
+    });
+  }
+
+  // Also look for methods that are just references (e.g., "methodName," or "methodName: someFunction,")
+  const refPattern = /(\w+),\s*$/gm;
+  while ((match = refPattern.exec(returnContent)) !== null) {
+    const methodName = match[1];
+    // Skip if already added or if internal
+    if (methods.some(m => m.name === methodName)) continue;
+    if (methodName === "address" || methodName.startsWith("_")) continue;
+
+    methods.push({
+      name: methodName,
+      path: "",
+      params: [],
+    });
+  }
+
+  return methods;
+}
+
+// Extract exported types with their descriptions
+function extractTypes(content: string): SDKTypeDoc[] {
+  const types: SDKTypeDoc[] = [];
+
+  // Pattern: export type TypeName = { ... }
+  const typePattern = /(?:\/\*\*[\s\S]*?\*\/\s*)?export\s+type\s+(\w+)\s*=\s*([^;]+);/g;
+  let match;
+
+  while ((match = typePattern.exec(content)) !== null) {
+    const fullMatch = match[0];
+    const typeName = match[1];
+    const typeDefinition = match[2].trim();
+
+    // Extract JSDoc if present
+    const jsdocMatch = fullMatch.match(/\/\*\*\s*([\s\S]*?)\s*\*\//);
+    const description = jsdocMatch
+      ? jsdocMatch[1]
+          .split("\n")
+          .map((line) => line.replace(/^\s*\*\s?/, "").trim())
+          .filter((line) => line && !line.startsWith("@"))
+          .join(" ")
+          .trim()
+      : undefined;
+
+    types.push({
+      name: typeName,
+      definition: typeDefinition.length > 200 ? typeDefinition.slice(0, 200) + "..." : typeDefinition,
+      description,
+    });
+  }
+
+  return types;
+}
+
+// Extract exported functions with their descriptions
+function extractFunctions(content: string): SDKMethodDoc[] {
+  const methods: SDKMethodDoc[] = [];
+
+  // Pattern: export const functionName = (params) => or export function functionName(params)
+  const fnPattern =
+    /(?:\/\*\*[\s\S]*?\*\/\s*)?export\s+(?:const\s+(\w+)\s*=\s*(?:async\s*)?\(([^)]*)\)|function\s+(\w+)\s*\(([^)]*)\))/g;
+  let match;
+
+  while ((match = fnPattern.exec(content)) !== null) {
+    const fullMatch = match[0];
+    const fnName = match[1] || match[3];
+    const paramsStr = match[2] || match[4];
+
+    // Skip makeXxx client factory functions (handled separately)
+    if (fnName.startsWith("make") && fnName.endsWith("Client")) continue;
+    // Skip internal functions
+    if (fnName.startsWith("_") || fnName === "pick") continue;
+
+    // Extract JSDoc if present
+    const jsdocMatch = fullMatch.match(/\/\*\*\s*([\s\S]*?)\s*\*\//);
+    const description = jsdocMatch
+      ? jsdocMatch[1]
+          .split("\n")
+          .map((line) => line.replace(/^\s*\*\s?/, "").trim())
+          .filter((line) => line && !line.startsWith("@"))
+          .join(" ")
+          .trim()
+      : undefined;
+
+    // Parse params
+    const params = paramsStr
+      .split(",")
+      .map((p) => p.trim())
+      .filter((p) => p)
+      .map((p) => {
+        const [name, type] = p.split(":").map((s) => s.trim());
+        return { name: name || "", type: type || "unknown" };
+      });
+
+    methods.push({
+      name: fnName,
+      path: "",
+      description,
+      params,
+    });
+  }
+
+  return methods;
+}
+
+// Parse a single module directory
+function parseModule(modulePath: string, moduleName: string): SDKModuleDoc | null {
+  const indexPath = join(modulePath, "index.ts");
+  if (!existsSync(indexPath)) return null;
+
+  const content = readFileSync(indexPath, "utf-8");
+
+  // Extract client type to determine submodules
+  const clientTypeMatch = content.match(/export\s+type\s+\w+Client\s*=\s*\{([^}]+)\}/);
+  const submodules: string[] = [];
+  if (clientTypeMatch) {
+    const typeContent = clientTypeMatch[1];
+    const submodulePattern = /(\w+):\s*\w+Client/g;
+    let match;
+    while ((match = submodulePattern.exec(typeContent)) !== null) {
+      submodules.push(match[1]);
+    }
+  }
+
+  // Extract types and functions
+  const types = extractTypes(content);
+  const functions = extractFunctions(content);
+
+  // If this module has submodules, we might want to recurse
+  const methods: SDKMethodDoc[] = [...functions];
+
+  // For each submodule, check if there's a directory with more methods
+  for (const sub of submodules) {
+    const subPath = join(modulePath, sub);
+    if (existsSync(subPath) && statSync(subPath).isDirectory()) {
+      const subModule = parseModule(subPath, `${moduleName}.${sub}`);
+      if (subModule) {
+        // Add prefixed methods
+        for (const m of subModule.methods) {
+          methods.push({
+            ...m,
+            name: `${sub}.${m.name}`,
+          });
+        }
+      }
+    } else {
+      // Check for a file like submodule.ts
+      const subFilePath = join(modulePath, `${sub}.ts`);
+      if (existsSync(subFilePath)) {
+        const subContent = readFileSync(subFilePath, "utf-8");
+        const subMethods = extractClientMethods(subContent);
+        for (const m of subMethods) {
+          methods.push({
+            ...m,
+            name: `${sub}.${m.name}`,
+          });
+        }
+      }
+    }
+  }
+
+  // Also check for index.ts client methods
+  const indexMethods = extractClientMethods(content);
+  methods.push(...indexMethods);
+
+  // Determine corresponding contract
+  let correspondingContract: string | undefined;
+  if (moduleName.includes("erc20")) correspondingContract = "ERC20EscrowObligation";
+  else if (moduleName.includes("erc721")) correspondingContract = "ERC721EscrowObligation";
+  else if (moduleName.includes("erc1155")) correspondingContract = "ERC1155EscrowObligation";
+  else if (moduleName.includes("nativeToken")) correspondingContract = "NativeTokenEscrowObligation";
+  else if (moduleName.includes("bundle") || moduleName.includes("tokenBundle"))
+    correspondingContract = "TokenBundleEscrowObligation";
+  else if (moduleName.includes("attestation")) correspondingContract = "AttestationEscrowObligation";
+
+  return {
+    name: moduleName,
+    path: relative(SDK_DIR, modulePath),
+    methods,
+    correspondingContract,
+  };
+}
+
+// Parse the arbiters hierarchy
+function parseArbitersModule(): SDKModuleDoc[] {
+  const modules: SDKModuleDoc[] = [];
+  const arbitersDir = join(CLIENTS_DIR, "arbiters");
+
+  if (!existsSync(arbitersDir)) return modules;
+
+  // Parse the main arbiters categories
+  const categories = ["general", "logical", "attestationProperties", "confirmation"];
+
+  for (const category of categories) {
+    const categoryDir = join(arbitersDir, category);
+    if (!existsSync(categoryDir)) continue;
+
+    const indexPath = join(categoryDir, "index.ts");
+    if (!existsSync(indexPath)) continue;
+
+    const content = readFileSync(indexPath, "utf-8");
+    const methods: SDKMethodDoc[] = [];
+
+    // Look for import statements to find source files with client factories
+    // Pattern: import { makeXxxClient } from "./filename"
+    const importPattern = /import\s*\{\s*make(\w+)Client[^}]*\}\s*from\s*["']\.\/(\w+)["']/g;
+    let match;
+
+    while ((match = importPattern.exec(content)) !== null) {
+      const clientName = match[1];
+      const fileName = match[2];
+
+      // Build the file path
+      const filePath = join(categoryDir, `${fileName}.ts`);
+      if (existsSync(filePath)) {
+        const fileContent = readFileSync(filePath, "utf-8");
+        const fileMethods = extractClientMethods(fileContent);
+
+        // Determine a short name for the arbiter
+        const shortName = clientName.replace(/Arbiter$/, "").toLowerCase();
+
+        for (const m of fileMethods) {
+          methods.push({
+            ...m,
+            name: `${shortName}.${m.name}`,
+          });
+        }
+      }
+    }
+
+    modules.push({
+      name: `arbiters.${category}`,
+      path: relative(SDK_DIR, categoryDir),
+      methods,
+    });
+  }
+
+  return modules;
+}
+
+// Parse the obligations hierarchy
+function parseObligationsModule(): SDKModuleDoc[] {
+  const modules: SDKModuleDoc[] = [];
+  const obligationsDir = join(CLIENTS_DIR, "obligations");
+
+  if (!existsSync(obligationsDir)) return modules;
+
+  const tokenTypes = ["erc20", "erc721", "erc1155", "nativeToken", "tokenBundle", "attestation", "string"];
+
+  for (const tokenType of tokenTypes) {
+    const tokenDir = join(obligationsDir, tokenType);
+    if (!existsSync(tokenDir)) continue;
+
+    const module = parseModule(tokenDir, tokenType);
+    if (module) {
+      modules.push(module);
+    }
+  }
+
+  return modules;
+}
+
+// Parse types.ts for main type definitions
+function parseMainTypes(): SDKTypeDoc[] {
+  const typesPath = join(SDK_DIR, "types.ts");
+  if (!existsSync(typesPath)) return [];
+
+  const content = readFileSync(typesPath, "utf-8");
+  return extractTypes(content);
+}
+
+// Main export function
+export async function parseSDK(): Promise<{ modules: SDKModuleDoc[]; types: SDKTypeDoc[] }> {
+  const modules: SDKModuleDoc[] = [];
+
+  // Parse arbiters
+  modules.push(...parseArbitersModule());
+
+  // Parse obligations
+  modules.push(...parseObligationsModule());
+
+  // Parse main types
+  const types = parseMainTypes();
+
+  console.log(`Parsed ${modules.length} SDK modules and ${types.length} types`);
+  return { modules, types };
+}
+
+// Run directly for testing
+if (import.meta.main) {
+  const { modules, types } = await parseSDK();
+  console.log("\nModules:");
+  for (const mod of modules) {
+    console.log(`  ${mod.name}: ${mod.methods.length} methods`);
+    if (mod.methods.length > 0) {
+      console.log(`    Methods: ${mod.methods.map(m => m.name).join(", ")}`);
+    }
+  }
+  console.log(`\nTypes: ${types.length} total`);
+}

--- a/docs/mcp-server/scripts/parse-solidity.ts
+++ b/docs/mcp-server/scripts/parse-solidity.ts
@@ -1,0 +1,318 @@
+import * as parser from "@solidity-parser/parser";
+import { readFileSync, readdirSync, statSync } from "fs";
+import { join, relative, basename, dirname } from "path";
+import type {
+  ContractDoc,
+  ContractCategory,
+  StructDef,
+  FunctionDef,
+  EventDef,
+  ErrorDef,
+  FunctionParam,
+} from "../src/data/types.js";
+
+const CONTRACTS_DIR = join(import.meta.dir, "../../../contracts/src");
+
+// Recursively get all .sol files
+function getSolidityFiles(dir: string): string[] {
+  const files: string[] = [];
+  const entries = readdirSync(dir);
+
+  for (const entry of entries) {
+    const fullPath = join(dir, entry);
+    const stat = statSync(fullPath);
+
+    if (stat.isDirectory()) {
+      files.push(...getSolidityFiles(fullPath));
+    } else if (entry.endsWith(".sol")) {
+      files.push(fullPath);
+    }
+  }
+
+  return files;
+}
+
+// Determine contract category from path and content
+function categorizeContract(
+  path: string,
+  contractName: string,
+  inherits: string[]
+): { category: ContractCategory; subcategory?: string } {
+  const relativePath = relative(CONTRACTS_DIR, path);
+
+  // Interfaces
+  if (contractName.startsWith("I") && contractName[1] === contractName[1].toUpperCase()) {
+    return { category: "interface" };
+  }
+
+  // Base contracts
+  if (contractName.startsWith("Base")) {
+    return { category: "base" };
+  }
+
+  // Arbiters
+  if (relativePath.startsWith("arbiters/") || contractName.endsWith("Arbiter")) {
+    let subcategory: string | undefined;
+    if (relativePath.includes("logical/")) subcategory = "logical";
+    else if (relativePath.includes("confirmation/")) subcategory = "confirmation";
+    else if (relativePath.includes("attestation-properties/")) subcategory = "attestation-properties";
+    else if (relativePath.includes("example/")) subcategory = "example";
+    return { category: "arbiter", subcategory };
+  }
+
+  // Utils
+  if (relativePath.startsWith("utils/") || contractName.endsWith("Utils")) {
+    return { category: "utils" };
+  }
+
+  // Obligations
+  if (relativePath.startsWith("obligations/")) {
+    if (relativePath.includes("escrow/")) {
+      return { category: "escrow", subcategory: relativePath.includes("tierable/") ? "tierable" : "non-tierable" };
+    }
+    if (relativePath.includes("payment/")) {
+      return { category: "payment" };
+    }
+    return { category: "obligation" };
+  }
+
+  // Check inheritance for hints
+  if (inherits.some((i) => i.includes("Escrow"))) {
+    return { category: "escrow" };
+  }
+  if (inherits.some((i) => i.includes("Payment"))) {
+    return { category: "payment" };
+  }
+  if (inherits.some((i) => i.includes("Arbiter"))) {
+    return { category: "arbiter" };
+  }
+
+  return { category: "obligation" };
+}
+
+// Extract params from AST node
+function extractParams(params: any[]): FunctionParam[] {
+  return params.map((p) => ({
+    name: p.name || "",
+    type: formatType(p.typeName),
+  }));
+}
+
+// Format type from AST
+function formatType(typeName: any): string {
+  if (!typeName) return "unknown";
+
+  switch (typeName.type) {
+    case "ElementaryTypeName":
+      return typeName.name;
+    case "UserDefinedTypeName":
+      return typeName.namePath;
+    case "ArrayTypeName":
+      return `${formatType(typeName.baseTypeName)}[]`;
+    case "Mapping":
+      return `mapping(${formatType(typeName.keyType)} => ${formatType(typeName.valueType)})`;
+    default:
+      return typeName.name || "unknown";
+  }
+}
+
+// Extract struct definition
+function extractStruct(node: any): StructDef {
+  return {
+    name: node.name,
+    fields: node.members.map((m: any) => ({
+      name: m.name,
+      type: formatType(m.typeName),
+    })),
+  };
+}
+
+// Extract function definition
+function extractFunction(node: any): FunctionDef {
+  const visibility = node.visibility || "public";
+  const stateMutability = node.stateMutability;
+
+  return {
+    name: node.name || (node.isConstructor ? "constructor" : "fallback"),
+    visibility: visibility as FunctionDef["visibility"],
+    stateMutability: stateMutability as FunctionDef["stateMutability"],
+    params: extractParams(node.parameters || []),
+    returns: extractParams(node.returnParameters || []),
+  };
+}
+
+// Extract event definition
+function extractEvent(node: any): EventDef {
+  return {
+    name: node.name,
+    params: extractParams(node.parameters || []),
+  };
+}
+
+// Extract error definition
+function extractError(node: any): ErrorDef {
+  return {
+    name: node.name,
+    params: extractParams(node.parameters || []),
+  };
+}
+
+// Extract NatSpec comments
+function extractNatSpec(comments: any[]): {
+  notice?: string;
+  dev?: string;
+  title?: string;
+  params?: Record<string, string>;
+  returns?: Record<string, string>;
+} {
+  if (!comments || comments.length === 0) return {};
+
+  const result: ReturnType<typeof extractNatSpec> = {};
+
+  for (const comment of comments) {
+    if (comment.type !== "NatSpecMultiLine") continue;
+
+    const lines = comment.value.split("\n");
+    for (const line of lines) {
+      const trimmed = line.trim().replace(/^\*\s*/, "");
+
+      if (trimmed.startsWith("@title ")) {
+        result.title = trimmed.slice(7).trim();
+      } else if (trimmed.startsWith("@notice ")) {
+        result.notice = (result.notice ? result.notice + " " : "") + trimmed.slice(8).trim();
+      } else if (trimmed.startsWith("@dev ")) {
+        result.dev = (result.dev ? result.dev + " " : "") + trimmed.slice(5).trim();
+      } else if (trimmed.startsWith("@param ")) {
+        const match = trimmed.slice(7).match(/^(\w+)\s+(.*)/);
+        if (match) {
+          result.params = result.params || {};
+          result.params[match[1]] = match[2];
+        }
+      } else if (trimmed.startsWith("@return ")) {
+        const match = trimmed.slice(8).match(/^(\w+)\s+(.*)/);
+        if (match) {
+          result.returns = result.returns || {};
+          result.returns[match[1]] = match[2];
+        }
+      }
+    }
+  }
+
+  return result;
+}
+
+// Extract schema string from constructor
+function extractSchema(constructorNode: any, source: string): string | undefined {
+  if (!constructorNode) return undefined;
+
+  // Look for string literal in constructor body that looks like a schema
+  // Pattern: "address arbiter, bytes demand, ..."
+  const match = source.match(/"([^"]*address[^"]*,\s*[^"]+)"/);
+  if (match) {
+    return match[1];
+  }
+
+  return undefined;
+}
+
+// Parse a single Solidity file
+function parseFile(filePath: string): ContractDoc[] {
+  const source = readFileSync(filePath, "utf-8");
+  const contracts: ContractDoc[] = [];
+
+  try {
+    const ast = parser.parse(source, {
+      tolerant: true,
+      loc: true,
+      range: true,
+    });
+
+    for (const node of ast.children) {
+      if (node.type !== "ContractDefinition") continue;
+
+      const inherits = (node.baseContracts || []).map((bc: any) => bc.baseName.namePath);
+      const implementsList = inherits.filter((i: string) => i.startsWith("I"));
+
+      const { category, subcategory } = categorizeContract(filePath, node.name, inherits);
+
+      const structs: StructDef[] = [];
+      const functions: FunctionDef[] = [];
+      const events: EventDef[] = [];
+      const errors: ErrorDef[] = [];
+      let constructorNode: any = null;
+
+      for (const subNode of node.subNodes || []) {
+        switch (subNode.type) {
+          case "StructDefinition":
+            structs.push(extractStruct(subNode));
+            break;
+          case "FunctionDefinition":
+            if (subNode.isConstructor) {
+              constructorNode = subNode;
+            }
+            // Only include public/external functions
+            if (["public", "external"].includes(subNode.visibility || "public")) {
+              functions.push(extractFunction(subNode));
+            }
+            break;
+          case "EventDefinition":
+            events.push(extractEvent(subNode));
+            break;
+          case "CustomErrorDefinition":
+            errors.push(extractError(subNode));
+            break;
+        }
+      }
+
+      // Extract NatSpec from contract-level comments
+      const natspec = extractNatSpec((node as any).comments || []);
+      const schema = extractSchema(constructorNode, source);
+
+      contracts.push({
+        name: node.name,
+        path: relative(CONTRACTS_DIR, filePath),
+        category,
+        subcategory,
+        description: natspec.notice || natspec.title,
+        schema,
+        inherits: inherits.filter((i: string) => !i.startsWith("I")),
+        implements: implementsList,
+        structs,
+        functions,
+        events,
+        errors,
+      });
+    }
+  } catch (error) {
+    console.error(`Error parsing ${filePath}:`, error);
+  }
+
+  return contracts;
+}
+
+// Main export function
+export async function parseSolidityContracts(): Promise<ContractDoc[]> {
+  const files = getSolidityFiles(CONTRACTS_DIR);
+  const contracts: ContractDoc[] = [];
+
+  for (const file of files) {
+    contracts.push(...parseFile(file));
+  }
+
+  // Sort by category and name
+  contracts.sort((a, b) => {
+    if (a.category !== b.category) {
+      return a.category.localeCompare(b.category);
+    }
+    return a.name.localeCompare(b.name);
+  });
+
+  console.log(`Parsed ${contracts.length} contracts from ${files.length} files`);
+  return contracts;
+}
+
+// Run directly for testing
+if (import.meta.main) {
+  const contracts = await parseSolidityContracts();
+  console.log(JSON.stringify(contracts.slice(0, 3), null, 2));
+}

--- a/docs/mcp-server/src/data/loader.ts
+++ b/docs/mcp-server/src/data/loader.ts
@@ -1,0 +1,107 @@
+import { readFileSync } from "fs";
+import { join, dirname } from "path";
+import { fileURLToPath } from "url";
+import lunr from "lunr";
+import type {
+  ContractDoc,
+  ChainDeployment,
+  SDKModuleDoc,
+  SDKTypeDoc,
+  GuideDoc,
+  SearchDocument,
+} from "./types.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const GENERATED_DIR = join(__dirname, "../../generated");
+
+// Cache for loaded data
+let contractsCache: ContractDoc[] | null = null;
+let deploymentsCache: ChainDeployment[] | null = null;
+let sdkCache: { modules: SDKModuleDoc[]; types: SDKTypeDoc[] } | null = null;
+let guidesCache: GuideDoc[] | null = null;
+let searchIndexCache: lunr.Index | null = null;
+let searchDocsCache: SearchDocument[] | null = null;
+
+export function loadContracts(): ContractDoc[] {
+  if (!contractsCache) {
+    const data = readFileSync(join(GENERATED_DIR, "contracts.json"), "utf-8");
+    contractsCache = JSON.parse(data);
+  }
+  return contractsCache!;
+}
+
+export function loadDeployments(): ChainDeployment[] {
+  if (!deploymentsCache) {
+    const data = readFileSync(join(GENERATED_DIR, "deployments.json"), "utf-8");
+    deploymentsCache = JSON.parse(data);
+  }
+  return deploymentsCache!;
+}
+
+export function loadSDK(): { modules: SDKModuleDoc[]; types: SDKTypeDoc[] } {
+  if (!sdkCache) {
+    const data = readFileSync(join(GENERATED_DIR, "sdk.json"), "utf-8");
+    sdkCache = JSON.parse(data);
+  }
+  return sdkCache!;
+}
+
+export function loadGuides(): GuideDoc[] {
+  if (!guidesCache) {
+    const data = readFileSync(join(GENERATED_DIR, "guides.json"), "utf-8");
+    guidesCache = JSON.parse(data);
+  }
+  return guidesCache!;
+}
+
+export function loadSearchIndex(): lunr.Index {
+  if (!searchIndexCache) {
+    const data = readFileSync(join(GENERATED_DIR, "search-index.json"), "utf-8");
+    searchIndexCache = lunr.Index.load(JSON.parse(data));
+  }
+  return searchIndexCache!;
+}
+
+export function loadSearchDocs(): SearchDocument[] {
+  if (!searchDocsCache) {
+    const data = readFileSync(join(GENERATED_DIR, "search-docs.json"), "utf-8");
+    searchDocsCache = JSON.parse(data);
+  }
+  return searchDocsCache!;
+}
+
+// Helper to get a contract by name
+export function getContract(name: string): ContractDoc | undefined {
+  const contracts = loadContracts();
+  return contracts.find(
+    (c) => c.name.toLowerCase() === name.toLowerCase()
+  );
+}
+
+// Helper to get deployment for a chain
+export function getDeployment(chainName: string): ChainDeployment | undefined {
+  const deployments = loadDeployments();
+  return deployments.find(
+    (d) => d.chainName.toLowerCase().includes(chainName.toLowerCase())
+  );
+}
+
+// Helper to get a guide by path or title
+export function getGuide(identifier: string): GuideDoc | undefined {
+  const guides = loadGuides();
+  const lower = identifier.toLowerCase();
+  return guides.find(
+    (g) =>
+      g.path.toLowerCase().includes(lower) ||
+      g.title.toLowerCase().includes(lower)
+  );
+}
+
+// Helper to get SDK module by name
+export function getSDKModule(name: string): SDKModuleDoc | undefined {
+  const { modules } = loadSDK();
+  const lower = name.toLowerCase();
+  return modules.find(
+    (m) => m.name.toLowerCase().includes(lower)
+  );
+}

--- a/docs/mcp-server/src/data/types.ts
+++ b/docs/mcp-server/src/data/types.ts
@@ -1,0 +1,135 @@
+// Contract documentation types
+export interface StructField {
+  name: string;
+  type: string;
+  comment?: string;
+}
+
+export interface StructDef {
+  name: string;
+  fields: StructField[];
+}
+
+export interface FunctionParam {
+  name: string;
+  type: string;
+}
+
+export interface FunctionDef {
+  name: string;
+  visibility: "public" | "external" | "internal" | "private";
+  stateMutability?: "pure" | "view" | "payable";
+  params: FunctionParam[];
+  returns: FunctionParam[];
+  natspec?: {
+    notice?: string;
+    dev?: string;
+    params?: Record<string, string>;
+    returns?: Record<string, string>;
+  };
+}
+
+export interface EventDef {
+  name: string;
+  params: FunctionParam[];
+}
+
+export interface ErrorDef {
+  name: string;
+  params: FunctionParam[];
+}
+
+export type ContractCategory =
+  | "arbiter"
+  | "obligation"
+  | "escrow"
+  | "payment"
+  | "utils"
+  | "base"
+  | "interface";
+
+export interface ContractDoc {
+  name: string;
+  path: string;
+  category: ContractCategory;
+  subcategory?: string;
+  description?: string;
+  schema?: string;
+  inherits: string[];
+  implements: string[];
+  structs: StructDef[];
+  functions: FunctionDef[];
+  events: EventDef[];
+  errors: ErrorDef[];
+}
+
+// SDK documentation types
+export interface SDKMethodDoc {
+  name: string;
+  path: string; // e.g., "erc20.escrow.create"
+  description?: string;
+  params: { name: string; type: string; description?: string }[];
+  returns?: { type: string; description?: string };
+  example?: string;
+}
+
+export interface SDKTypeDoc {
+  name: string;
+  definition: string;
+  description?: string;
+  fields?: { name: string; type: string; description?: string }[];
+}
+
+export interface SDKModuleDoc {
+  name: string;
+  path: string;
+  description?: string;
+  methods: SDKMethodDoc[];
+  correspondingContract?: string;
+}
+
+// Deployment types
+export interface ChainDeployment {
+  chainId?: number;
+  chainName: string;
+  contracts: Record<
+    string,
+    {
+      address: string;
+      txHash?: string;
+      blockNumber?: number;
+    }
+  >;
+}
+
+// Guide types
+export interface GuideSection {
+  title: string;
+  content: string;
+  codeExamples?: { language: string; code: string }[];
+}
+
+export interface GuideDoc {
+  title: string;
+  path: string;
+  sections: GuideSection[];
+  referencedContracts: string[];
+}
+
+// Search index types
+export interface SearchDocument {
+  id: string;
+  type: "contract" | "sdk" | "guide" | "deployment";
+  title: string;
+  content: string;
+  category?: string;
+  path?: string;
+}
+
+// Generated data bundle
+export interface GeneratedData {
+  contracts: ContractDoc[];
+  sdk: SDKModuleDoc[];
+  deployments: ChainDeployment[];
+  guides: GuideDoc[];
+}

--- a/docs/mcp-server/src/index.ts
+++ b/docs/mcp-server/src/index.ts
@@ -1,0 +1,485 @@
+#!/usr/bin/env node
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+  ListResourcesRequestSchema,
+  ReadResourceRequestSchema,
+} from "@modelcontextprotocol/sdk/types.js";
+import {
+  loadContracts,
+  loadDeployments,
+  loadSDK,
+  loadGuides,
+  getContract,
+  getDeployment,
+  getGuide,
+  getSDKModule,
+} from "./data/loader.js";
+import { search } from "./search/index.js";
+
+const server = new Server(
+  {
+    name: "alkahest-docs",
+    version: "0.1.0",
+  },
+  {
+    capabilities: {
+      tools: {},
+      resources: {},
+    },
+  }
+);
+
+// List available tools
+server.setRequestHandler(ListToolsRequestSchema, async () => ({
+  tools: [
+    {
+      name: "search_docs",
+      description:
+        "Search Alkahest documentation including contracts, SDK methods, and guides. Use this to find relevant information for a specific topic.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          query: {
+            type: "string",
+            description: "Search query (e.g., 'ERC20 escrow', 'oracle validation', 'token trading')",
+          },
+          type: {
+            type: "string",
+            enum: ["contract", "sdk", "guide", "all"],
+            description: "Filter results by type (default: all)",
+          },
+          limit: {
+            type: "number",
+            description: "Maximum number of results (default: 10)",
+          },
+        },
+        required: ["query"],
+      },
+    },
+    {
+      name: "get_contract",
+      description:
+        "Get detailed documentation for a specific Alkahest smart contract including its functions, events, errors, and deployed addresses.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          name: {
+            type: "string",
+            description: "Contract name (e.g., 'ERC20EscrowObligation', 'TrustedOracleArbiter')",
+          },
+        },
+        required: ["name"],
+      },
+    },
+    {
+      name: "list",
+      description:
+        "List Alkahest contracts or SDK modules by category. Use this to explore available functionality.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          type: {
+            type: "string",
+            enum: ["contract", "sdk"],
+            description: "What to list: 'contract' for smart contracts, 'sdk' for SDK modules",
+          },
+          category: {
+            type: "string",
+            description:
+              "For contracts: 'arbiter', 'escrow', 'payment', 'utils', 'base'. For SDK: 'arbiters', 'erc20', 'erc721', etc.",
+          },
+        },
+        required: ["type"],
+      },
+    },
+    {
+      name: "get_deployment",
+      description: "Get deployed contract addresses for a specific blockchain network.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          chain: {
+            type: "string",
+            description: "Chain name (e.g., 'base-sepolia', 'filecoin', 'monad')",
+          },
+        },
+        required: ["chain"],
+      },
+    },
+    {
+      name: "get_sdk_method",
+      description: "Get documentation for SDK module methods.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          module: {
+            type: "string",
+            description: "Module name (e.g., 'erc20', 'arbiters.general', 'nativeToken')",
+          },
+        },
+        required: ["module"],
+      },
+    },
+    {
+      name: "get_guide",
+      description: "Get a documentation guide by topic.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          topic: {
+            type: "string",
+            description:
+              "Guide topic (e.g., 'escrow', 'token trading', 'arbiters', 'oracle')",
+          },
+        },
+        required: ["topic"],
+      },
+    },
+  ],
+}));
+
+// Handle tool calls
+server.setRequestHandler(CallToolRequestSchema, async (request) => {
+  const { name, arguments: args } = request.params;
+  const toolArgs = args || {};
+
+  try {
+    switch (name) {
+      case "search_docs": {
+        const results = search(toolArgs.query as string, {
+          type: toolArgs.type as any,
+          limit: (toolArgs.limit as number) || 10,
+        });
+
+        if (results.length === 0) {
+          return {
+            content: [
+              {
+                type: "text",
+                text: `No results found for "${toolArgs.query}". Try different keywords or browse with the 'list' tool.`,
+              },
+            ],
+          };
+        }
+
+        const formatted = results.map((r) => ({
+          type: r.type,
+          name: r.title,
+          category: r.category,
+          relevance: Math.round(r.score * 100) / 100,
+        }));
+
+        return {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify(formatted, null, 2),
+            },
+          ],
+        };
+      }
+
+      case "get_contract": {
+        const contract = getContract(toolArgs.name as string);
+        if (!contract) {
+          return {
+            content: [
+              {
+                type: "text",
+                text: `Contract "${toolArgs.name}" not found. Use 'list' with type='contract' to see available contracts.`,
+              },
+            ],
+          };
+        }
+
+        // Format contract info
+        const info = {
+          name: contract.name,
+          category: contract.category,
+          subcategory: contract.subcategory,
+          description: contract.description,
+          path: contract.path,
+          schema: contract.schema,
+          inherits: contract.inherits,
+          implements: contract.implements,
+          deployedAddresses: (contract as any).deployedAddresses,
+          structs: contract.structs,
+          functions: contract.functions.map((f) => ({
+            name: f.name,
+            visibility: f.visibility,
+            stateMutability: f.stateMutability,
+            params: f.params,
+            returns: f.returns,
+          })),
+          events: contract.events,
+          errors: contract.errors,
+        };
+
+        return {
+          content: [{ type: "text", text: JSON.stringify(info, null, 2) }],
+        };
+      }
+
+      case "list": {
+        if (toolArgs.type === "contract") {
+          const contracts = loadContracts();
+          let filtered = contracts;
+
+          if (toolArgs.category) {
+            const cat = (toolArgs.category as string).toLowerCase();
+            filtered = contracts.filter(
+              (c) =>
+                c.category.toLowerCase() === cat ||
+                c.subcategory?.toLowerCase() === cat
+            );
+          }
+
+          const list = filtered.map((c) => ({
+            name: c.name,
+            category: c.category,
+            subcategory: c.subcategory,
+            description: c.description?.slice(0, 100),
+          }));
+
+          return {
+            content: [{ type: "text", text: JSON.stringify(list, null, 2) }],
+          };
+        }
+
+        if (toolArgs.type === "sdk") {
+          const { modules } = loadSDK();
+          let filtered = modules;
+
+          if (toolArgs.category) {
+            const cat = (toolArgs.category as string).toLowerCase();
+            filtered = modules.filter((m) =>
+              m.name.toLowerCase().includes(cat)
+            );
+          }
+
+          const list = filtered.map((m) => ({
+            name: m.name,
+            path: m.path,
+            methodCount: m.methods.length,
+            correspondingContract: m.correspondingContract,
+          }));
+
+          return {
+            content: [{ type: "text", text: JSON.stringify(list, null, 2) }],
+          };
+        }
+
+        return {
+          content: [
+            {
+              type: "text",
+              text: "Invalid type. Use 'contract' or 'sdk'.",
+            },
+          ],
+        };
+      }
+
+      case "get_deployment": {
+        const deployment = getDeployment(toolArgs.chain as string);
+        if (!deployment) {
+          const deployments = loadDeployments();
+          const chains = deployments.map((d) => d.chainName).join(", ");
+          return {
+            content: [
+              {
+                type: "text",
+                text: `Chain "${toolArgs.chain}" not found. Available chains: ${chains}`,
+              },
+            ],
+          };
+        }
+
+        return {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify(
+                {
+                  chainName: deployment.chainName,
+                  chainId: deployment.chainId,
+                  contracts: deployment.contracts,
+                },
+                null,
+                2
+              ),
+            },
+          ],
+        };
+      }
+
+      case "get_sdk_method": {
+        const module = getSDKModule(toolArgs.module as string);
+        if (!module) {
+          const { modules } = loadSDK();
+          const names = modules.map((m) => m.name).join(", ");
+          return {
+            content: [
+              {
+                type: "text",
+                text: `Module "${toolArgs.module}" not found. Available modules: ${names}`,
+              },
+            ],
+          };
+        }
+
+        return {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify(
+                {
+                  name: module.name,
+                  path: module.path,
+                  correspondingContract: module.correspondingContract,
+                  methods: module.methods,
+                },
+                null,
+                2
+              ),
+            },
+          ],
+        };
+      }
+
+      case "get_guide": {
+        const guide = getGuide(toolArgs.topic as string);
+        if (!guide) {
+          const guides = loadGuides();
+          const titles = guides.map((g) => g.title).join("\n  - ");
+          return {
+            content: [
+              {
+                type: "text",
+                text: `Guide for "${toolArgs.topic}" not found. Available guides:\n  - ${titles}`,
+              },
+            ],
+          };
+        }
+
+        // Return guide with full content
+        const output = {
+          title: guide.title,
+          path: guide.path,
+          referencedContracts: guide.referencedContracts,
+          sections: guide.sections.map((s) => ({
+            title: s.title,
+            content: s.content.slice(0, 500) + (s.content.length > 500 ? "..." : ""),
+            codeExamples: s.codeExamples?.length || 0,
+          })),
+        };
+
+        return {
+          content: [{ type: "text", text: JSON.stringify(output, null, 2) }],
+        };
+      }
+
+      default:
+        return {
+          content: [{ type: "text", text: `Unknown tool: ${name}` }],
+          isError: true,
+        };
+    }
+  } catch (error) {
+    return {
+      content: [
+        {
+          type: "text",
+          text: `Error: ${error instanceof Error ? error.message : String(error)}`,
+        },
+      ],
+      isError: true,
+    };
+  }
+});
+
+// List resources
+server.setRequestHandler(ListResourcesRequestSchema, async () => {
+  const guides = loadGuides();
+  const deployments = loadDeployments();
+
+  return {
+    resources: [
+      ...guides.map((g) => ({
+        uri: `alkahest://guides/${g.path}`,
+        name: g.title,
+        description: `Documentation guide: ${g.title}`,
+        mimeType: "text/markdown",
+      })),
+      ...deployments.map((d) => ({
+        uri: `alkahest://deployments/${d.chainName.toLowerCase().replace(/\s+/g, "-")}`,
+        name: `${d.chainName} Deployments`,
+        description: `Contract addresses for ${d.chainName}`,
+        mimeType: "application/json",
+      })),
+    ],
+  };
+});
+
+// Read resources
+server.setRequestHandler(ReadResourceRequestSchema, async (request) => {
+  const { uri } = request.params;
+
+  if (uri.startsWith("alkahest://guides/")) {
+    const path = uri.replace("alkahest://guides/", "");
+    const guide = getGuide(path);
+    if (guide) {
+      // Reconstruct markdown-like content
+      const content = guide.sections
+        .map((s) => {
+          let text = `## ${s.title}\n\n${s.content}`;
+          if (s.codeExamples) {
+            for (const ex of s.codeExamples) {
+              text += `\n\n\`\`\`${ex.language}\n${ex.code}\n\`\`\``;
+            }
+          }
+          return text;
+        })
+        .join("\n\n");
+
+      return {
+        contents: [
+          {
+            uri,
+            mimeType: "text/markdown",
+            text: `# ${guide.title}\n\n${content}`,
+          },
+        ],
+      };
+    }
+  }
+
+  if (uri.startsWith("alkahest://deployments/")) {
+    const chainSlug = uri.replace("alkahest://deployments/", "");
+    const deployment = getDeployment(chainSlug);
+    if (deployment) {
+      return {
+        contents: [
+          {
+            uri,
+            mimeType: "application/json",
+            text: JSON.stringify(deployment, null, 2),
+          },
+        ],
+      };
+    }
+  }
+
+  throw new Error(`Resource not found: ${uri}`);
+});
+
+// Start the server
+async function main() {
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+  console.error("Alkahest Docs MCP Server running on stdio");
+}
+
+main().catch(console.error);

--- a/docs/mcp-server/src/search/index.ts
+++ b/docs/mcp-server/src/search/index.ts
@@ -1,0 +1,54 @@
+import { loadSearchIndex, loadSearchDocs } from "../data/loader.js";
+import type { SearchDocument } from "../data/types.js";
+
+export interface SearchResult {
+  id: string;
+  type: SearchDocument["type"];
+  title: string;
+  score: number;
+  category?: string;
+  path?: string;
+}
+
+export interface SearchOptions {
+  type?: "contract" | "sdk" | "guide" | "all";
+  limit?: number;
+}
+
+export function search(query: string, options: SearchOptions = {}): SearchResult[] {
+  const index = loadSearchIndex();
+  const docs = loadSearchDocs();
+
+  // Perform search
+  let results = index.search(query);
+
+  // Get full documents
+  const docsById = new Map(docs.map((d) => [d.id, d]));
+
+  let searchResults: SearchResult[] = results
+    .map((result) => {
+      const doc = docsById.get(result.ref);
+      if (!doc) return null;
+      return {
+        id: doc.id,
+        type: doc.type,
+        title: doc.title,
+        score: result.score,
+        category: doc.category,
+        path: doc.path,
+      } as SearchResult;
+    })
+    .filter((r): r is SearchResult => r !== null);
+
+  // Filter by type if specified
+  if (options.type && options.type !== "all") {
+    searchResults = searchResults.filter((r) => r.type === options.type);
+  }
+
+  // Apply limit
+  if (options.limit) {
+    searchResults = searchResults.slice(0, options.limit);
+  }
+
+  return searchResults;
+}

--- a/docs/mcp-server/tsconfig.json
+++ b/docs/mcp-server/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022"],
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "generated", "scripts"]
+}


### PR DESCRIPTION
## Summary
- Adds an MCP server (`docs/mcp-server/`) that serves Alkahest documentation with full-text search
- Generation scripts parse Solidity contract sources, SDK docs, deployment records, and guides into searchable JSON
- Supports contract docs, SDK reference, deployment info, and guide lookups via MCP tools

## Test plan
- [ ] Run `bun run generate` to regenerate docs from current sources
- [ ] Run `bun run build` to verify TypeScript compilation
- [ ] Start server and verify search/lookup tools work via MCP client

🤖 Generated with [Claude Code](https://claude.com/claude-code)