### PR TITLE
Revise READMEs with audit terminology and updated examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 # Alkahest
 
-**Contract library and SDKs for validated peer-to-peer escrow**
+**Contract library and SDKs for conditional peer-to-peer escrow**
 
 ![Solidity](https://img.shields.io/badge/solidity-0.8.27-blue.svg)
 ![Python](https://img.shields.io/badge/python-3.10+-blue.svg)
@@ -13,13 +13,17 @@
 
 </div>
 
-Alkahest is a library and ecosystem for peer-to-peer exchange.
+Alkahest is a library and ecosystem of contracts for conditional peer-to-peer escrow. It contains three main types of contracts:
 
-Statements represent obligations within a peer-to-peer agreement, while validators represent conditions under which statements are considered valid.
-
-These compose with each other to eventually enable trading anything for anything else, with flexible per-deal assurance guarantees.
+- **Escrow contracts** conditionally guarantee an on-chain action (usually a token transfer)
+- **Arbiter contracts** represent the conditions on which escrows are released, and can be composed via AllArbiter and AnyArbiter
+- **Obligation contracts** produce [EAS](https://attest.org/) attestations that represent the fulfillments to escrows, and which are checked by arbiter contracts. Escrow contracts are also obligation contracts.
 
 Learn more at [Alkahest Docs](https://www.arkhai.io/docs).
+
+## Security
+
+Alkahest has been audited by [Zellic](https://www.zellic.io/). The full audit report is available [here](https://github.com/Zellic/publications/blob/master/Arkhai%20Alkahest%20-%20Zellic%20Audit%20Report.pdf).
 
 ## Repository Structure
 
@@ -65,13 +69,13 @@ Each SDK has its own setup and usage instructions:
 
 Comprehensive guides and tutorials are available in the [docs/](docs/) directory:
 
-- **[Escrow Flow (pt 1 - Token Trading)](<docs/Escrow%20Flow%20(pt%201%20-%20Token%20Trading).md>)** - Learn how to trade tokens using escrow
-- **[Escrow Flow (pt 2 - Job Trading)](<docs/Escrow%20Flow%20(pt%202%20-%20Job%20Trading).md>)** - Trade computational work for tokens
-- **[Escrow Flow (pt 3 - Composing Demands)](<docs/Escrow%20Flow%20(pt%203%20-%20Composing%20Demands).md>)** - Combine multiple obligations
-- **[Writing Arbiters (pt 1 - On-chain Arbiters)](<docs/Writing%20Arbiters%20(pt%201%20-%20On-chain%20Arbiters).md>)** - Create on-chain validation logic
-- **[Writing Arbiters (pt 2 - Off-chain Oracles)](<docs/Writing%20Arbiters%20(pt%202%20-%20Off-chain%20Oracles)%20(Python).md>)** - Build off-chain oracles (Python, Rust, TypeScript variants)
+- **[Escrow Flow (pt 1 - Token Trading)](<docs/Escrow%20Flow%20(pt%201%20-%20Token%20Trading).md>)** - Trade tokens for tokens using escrow and payment obligations
+- **[Escrow Flow (pt 2 - Job Trading)](<docs/Escrow%20Flow%20(pt%202%20-%20Job%20Trading).md>)** - Escrow with off-chain validation via TrustedOracleArbiter
+- **[Escrow Flow (pt 3 - Composing Demands)](<docs/Escrow%20Flow%20(pt%203%20-%20Composing%20Demands).md>)** - Composing arbiter conditions with AllArbiter and AnyArbiter
+- **[Writing Arbiters (pt 1 - On-chain Arbiters)](<docs/Writing%20Arbiters%20(pt%201%20-%20On-chain%20Arbiters).md>)** - Create custom on-chain validation logic
+- **[Writing Arbiters (pt 2 - Off-chain Oracles)](<docs/Writing%20Arbiters%20(pt%202%20-%20Off-chain%20Oracles)%20(Python).md>)** - Build off-chain oracle validators ([Python](<docs/Writing%20Arbiters%20(pt%202%20-%20Off-chain%20Oracles)%20(Python).md>), [Rust](<docs/Writing%20Arbiters%20(pt%202%20-%20Off-chain%20Oracles)%20(Rust).md>), [TypeScript](<docs/Writing%20Arbiters%20(pt%202%20-%20Off-chain%20Oracles)%20(TypeScript).md>))
 - **[Writing Escrow Contracts](docs/Writing%20Escrow%20Contracts.md)** - Create custom escrow obligations
-- **[Writing Fulfillment Contracts](docs/Writing%20Fulfillment%20Contracts.md)** - Create custom payment obligations
+- **[Writing Fulfillment Contracts](docs/Writing%20Fulfillment%20Contracts.md)** - Create custom fulfillment obligations
 
 ## Development
 

--- a/sdks/py/README.md
+++ b/sdks/py/README.md
@@ -1,33 +1,58 @@
 # alkahest-py
 
-## usage
+Python SDK for [Alkahest](https://github.com/arkhai-io/alkahest), a library and ecosystem of contracts for conditional peer-to-peer escrow. This is a PyO3 wrapper around the [Rust SDK](../rs/), providing Python bindings for all Alkahest functionality.
 
-1. `pip install alkahest-py`
+## Installation
 
-2. import the module and create an AlkahestClient instance
+```bash
+pip install alkahest-py
+```
+
+## Usage
 
 ```python
+import asyncio
 from alkahest_py import AlkahestClient
 
 client = AlkahestClient(
-        "0xprivatekey",
-        "https://rpc_url.com"
+    "0xYOUR_PRIVATE_KEY",
+    "https://your-rpc-url.com",
 )
 
 async def main():
-    hash =  client.erc20.approve(
+    # Approve the barter utils contract to spend tokens
+    tx_hash = await client.erc20.util.approve(
         {"address": "0x036CbD53842c5426634e7929541eC2318f3dCF7e", "value": 100},
-        "escrow",
+        "barter",
     )
+    print(tx_hash)
 
-    print(hash)
+    # Create an escrow: deposit 100 token A, demanding 200 token B
+    escrow = await client.erc20.barter.buy_erc20_for_erc20(
+        {"address": "0x...", "value": 100},  # bid
+        {"address": "0x...", "value": 200},  # ask
+        0,  # no expiration
+    )
+    print(escrow["log"]["uid"])
 
-if __name__ == "__main__":
-    asyncio.run(main())
+asyncio.run(main())
 ```
 
-3. for more extensive API docs, `git clone https://github.com/CoopHive/alkahest-py` and run `cargo doc --open`. most functions are in the submodules Erc20Client, Erc721Client etc. the [alkahest-rs docs](https://docs.rs/alkahest-rs/latest/alkahest_rs/) might be more useful than the alkahest-py docs, since many rust types get wrangled into python strings. FixedBytes<32> and Address are strings starting with "0x" in python, but Bytes is python bytes (b"..."). structs (ArbiterData, Erc20Data) are dictionaries with item names matching the struct's fields. ApprovalPurpose can be "escrow" or "payment".
+Defaults to Base Sepolia addresses. Pass a custom `DefaultExtensionConfig` as the third argument for other networks (e.g., Filecoin Calibration).
 
-note that ArbiterData ({"arbiter": "0x...", "demand": b"..."}) expects demand as abi encoded bytes. for arbiters that aren't explicitly supported, you'll have to manually encode the Solidity struct, e.g. with [eth_abi](https://eth-abi.readthedocs.io/en/latest/encoding.html). passing a dictionary matching the solidity struct's format isn't supported.
+## API Notes
 
-see alkahest_py/test.py for a usage example.
+The Python SDK wraps the Rust SDK via PyO3. Some type conventions differ from Rust:
+
+- `FixedBytes<32>` and `Address` are Python strings starting with `"0x"`
+- `Bytes` is Python `bytes` (e.g., `b"..."`)
+- Structs like `ArbiterData` and `Erc20Data` are dictionaries with field names matching the Rust struct (e.g., `{"arbiter": "0x...", "demand": b"..."}`)
+- `ApprovalPurpose` is a string: `"escrow"`, `"payment"`, or `"barter"`
+
+For arbiter demands not explicitly supported by the SDK, you'll need to manually ABI-encode the Solidity struct, e.g. with [eth_abi](https://eth-abi.readthedocs.io/en/latest/encoding.html).
+
+## API Reference
+
+Since this is a PyO3 wrapper, the most detailed API documentation is in the [Rust SDK docs](https://docs.rs/alkahest-rs/latest/alkahest_rs/). For Python-specific patterns, see the test files in `alkahest_py/` (e.g., `alkahest_py/erc20/test_buy_erc20_for_erc20.py`).
+
+See the [docs](../../docs/) for guides on escrow flows, composing arbiters, and building oracle validators.

--- a/sdks/rs/README.md
+++ b/sdks/rs/README.md
@@ -1,293 +1,160 @@
-
 # alkahest-rs
 
-## usage
+Rust SDK for [Alkahest](https://github.com/arkhai-io/alkahest), a library and ecosystem of contracts for conditional peer-to-peer escrow. Built on [alloy](https://github.com/alloy-rs/alloy).
 
-1. `cargo add alkahest-rs`
+## Installation
 
-2. initialize a client with a private key and RPC URL (websockets only; i.e. wss://...). only Base Sepolia is supported for now.
-
-```rust
-use alkahest_rs::AlkahestClient;
-use std::env;
-
-pub async fn main() {
-        let client = AlkahestClient::new(
-            env::var("PRIVKEY")?.as_str(),
-            env::var("RPC_URL")?.as_str(),
-            None,
-        )
-        .await?;
-}
+```bash
+cargo add alkahest-rs
 ```
 
-## examples
+## Usage
 
-### trade erc20 for erc20
+Initialize a client with a private key and RPC URL. Defaults to Base Sepolia addresses; Filecoin Calibration is also supported via `DefaultExtensionConfig`.
 
 ```rust
+use alkahest_rs::DefaultAlkahestClient;
+use alloy::signers::local::PrivateKeySigner;
+use std::env;
 
 #[tokio::main]
-async fn trade_erc20_for_erc20() -> Result<()> {
-    let client_buyer = AlkahestClient::new(
-        env::var("PRIVKEY_ALICE")?.as_str(),
-        env::var("RPC_URL")?.as_str(),
-        None,
+async fn main() -> eyre::Result<()> {
+    let signer: PrivateKeySigner = env::var("PRIVKEY")?.parse()?;
+    let client = DefaultAlkahestClient::with_base_extensions(
+        signer,
+        env::var("RPC_URL")?,
+        None, // uses Base Sepolia addresses by default
     )
     .await?;
-
-    let client_seller = AlkahestClient::new(
-        env::var("PRIVKEY_BOB")?.as_str(),
-        env::var("RPC_URL")?.as_str(),
-        None,
-    )
-    .await?;
-
-    let usdc = address!("0x036CbD53842c5426634e7929541eC2318f3dCF7e");
-    let eurc = address!("0x808456652fdb597867f38412077A9182bf77359F");
-
-    client_buyer
-        .erc20
-        .approve(
-            Erc20Data {
-                address: usdc,
-                value: 10.try_into()?,
-            },
-            ApprovalPurpose::Escrow,
-        )
-    .await?;
-
-    // buy 10 eurc for 10 usdc
-    let receipt = client_buyer
-        .erc20
-        .buy_erc20_for_erc20(
-            Erc20Data {
-                address: usdc,
-                value: 10.try_into()?,
-            },
-            Erc20Data {
-                address: eurc,
-                value: 10.try_into()?,
-            },
-            0,
-        )
-    .await?;
-
-    let attested = AlkahestClient::get_attested_event(receipt)?;
-    println!("{:?}", attested);
-
-    client_seller
-        .erc20
-        .approve(
-            Erc20Data {
-                address: eurc,
-                value: 10.try_into()?,
-            },
-            ApprovalPurpose::Payment,
-        )
-    .await?;
-
-    let receipt = client_seller
-        .erc20
-        .pay_erc20_for_erc20(attested.uid)
-    .await?;
-    println!("{:?}", receipt);
 
     Ok(())
 }
 ```
-### trade erc20 for custom demand
+
+## Examples
+
+### Trade ERC20 for ERC20
+
+Uses barter utils to combine escrow creation and payment fulfillment into simple calls.
+
 ```rust
+use alkahest_rs::{DefaultAlkahestClient, types::Erc20Data, extensions::HasErc20};
+use alloy::primitives::{address, U256};
 
 #[tokio::main]
-async fn trade_erc20_for_custom() -> Result<()> {
-    let client_buyer = AlkahestClient::new(
-        env::var("PRIVKEY_ALICE")?.as_str(),
-        env::var("RPC_URL")?.as_str(),
-        None,
-    )
-    .await?;
+async fn main() -> eyre::Result<()> {
+    // ... initialize alice_client and bob_client as above
 
-    let client_seller = AlkahestClient::new(
-        env::var("PRIVKEY_BOB")?.as_str(),
-        env::var("RPC_URL")?.as_str(),
-        None,
-    )
-    .await?;
-    // the example will use JobResultObligation to demand a string to be capitalized
-    // but JobResultObligation is generic enough to represent much more (a db query, a Dockerfile...)
-    // see https://github.com/CoopHive/alkahest-mocks/blob/main/src/Statements/JobResultObligation.sol
-    //
-    // for custom cases, you'll have to implement your own arbiter
-    //
-    // in the example, we'll use RecipientArbiter and TrivialArbiter
-    // to make sure the result is from a particular trusted party,
-    // without actually validating the result
-    // see https://github.com/CoopHive/alkahest-mocks/blob/main/src/Validators/RecipientArbiter.sol
-    // and https://github.com/CoopHive/alkahest-mocks/blob/main/src/Validators/TrivialArbiter.sol
+    let usdc = address!("036CbD53842c5426634e7929541eC2318f3dCF7e");
+    let eurc = address!("808456652fdb597867f38412077A9182bf77359F");
 
-    // construct custom demand. note that this could be anything, and is determined by the arbiter.
-    // since our base arbiter is TrivialArbiter, which doesn't actually decode DemandData,
-    // the format doesn't matter. though the seller and buyer do still have to agree on it
-    // so that the seller can properly fulfill the demand.
-    sol! {
-        struct ResultDemandData {
+    // Alice: approve barter utils and deposit 10 USDC, demanding 10 EURC
+    alice_client.erc20().util().approve(
+        &Erc20Data { address: usdc, value: U256::from(10) },
+        alkahest_rs::types::ApprovalPurpose::BarterUtils,
+    ).await?;
+
+    let receipt = alice_client.erc20().barter().buy_erc20_for_erc20(
+        &Erc20Data { address: usdc, value: U256::from(10) },
+        &Erc20Data { address: eurc, value: U256::from(10) },
+        0, // no expiration
+    ).await?;
+    let escrow = DefaultAlkahestClient::get_attested_event(receipt)?;
+
+    // Bob: approve barter utils and fulfill the escrow by paying 10 EURC
+    bob_client.erc20().util().approve(
+        &Erc20Data { address: eurc, value: U256::from(10) },
+        alkahest_rs::types::ApprovalPurpose::BarterUtils,
+    ).await?;
+
+    bob_client.erc20().barter().pay_erc20_for_erc20(escrow.uid).await?;
+
+    Ok(())
+}
+```
+
+### Trade ERC20 for custom demand
+
+Uses TrustedOracleArbiter to delegate fulfillment validation to an off-chain oracle, and StringObligation for the fulfillment.
+
+```rust
+use alkahest_rs::{
+    DefaultAlkahestClient,
+    types::{Erc20Data, ArbiterData, ApprovalPurpose},
+    extensions::{HasErc20, HasStringObligation, HasArbiters},
+};
+use alloy::primitives::{address, U256, FixedBytes, Bytes};
+use alloy::sol_types::SolValue;
+
+#[tokio::main]
+async fn main() -> eyre::Result<()> {
+    // ... initialize alice_client, bob_client, charlie_client
+
+    let usdc = address!("036CbD53842c5426634e7929541eC2318f3dCF7e");
+
+    // Encode the inner demand (application-specific; agreed upon by buyer and seller)
+    alloy::sol! {
+        struct QueryDemand {
             string query;
         }
     }
-    let base_demand = ResultDemandData {
-        query: "hello world".to_string(),
-    }
-        .abi_encode();
+    let inner_demand = QueryDemand { query: "capitalize hello world".into() }.abi_encode();
 
-    // we use RecipientArbiter to wrap the base demand. This actually does decode DemandData,
-    // and we use the DemandData format it defines,
-    // to demand that only our trusted seller can fulfill the demand.
-    // if the baseDemand were something other than TrivialArbiter,
-    // it would be an additional check on the fulfillment.
-    // many arbiters can be stacked according to this pattern.
-    sol! {
-        struct TrustedPartyDemandData {
-            address creator;
-            address baseArbiter;
-            bytes baseDemand;
-        }
-    }
+    // Encode the TrustedOracleArbiter demand, naming Charlie as the oracle
+    let demand = alkahest_rs::contracts::arbiters::TrustedOracleArbiter::DemandData {
+        oracle: charlie_address,
+        data: inner_demand.into(),
+    }.abi_encode();
 
-    let trival_arbiter = address!("0x8fdbf9C22Ce0B83aFEe8da63F14467663D150b5d");
-    let demand = TrustedPartyDemandData {
-        creator: client_seller.address,
-        baseArbiter: trival_arbiter,
-        baseDemand: base_demand.into(),
-    }
-        .abi_encode();
-
-    // approve escrow contract to spend tokens
-    let usdc = address!("0x036CbD53842c5426634e7929541eC2318f3dCF7e");
-    client_buyer
-        .erc20
-        .approve(
-            Erc20Data {
-                address: usdc,
-                value: 10.try_into()?,
-            },
-            ApprovalPurpose::Escrow,
-        )
-    .await?;
-
-    // make escrow with generic escrow function,
-    // passing in RecipientArbiter's address and our custom demand,
-    // and no expiration
-    let recipient_arbiter = address!("0x82FaE516dE4912C382FBF7D9D6d0194b7f532738");
-    let escrow = client_buyer
-        .erc20
-        .buy_with_erc20(
-            Erc20Data {
-                address: usdc,
-                value: 10.try_into()?,
-            },
-            ArbiterData {
-                arbiter: trusted_party_arbiter,
+    // Alice: deposit USDC into escrow with the custom demand
+    let (_, escrow_receipt) = alice_client.erc20().escrow().non_tierable()
+        .approve_and_create(
+            &Erc20Data { address: usdc, value: U256::from(100) },
+            &ArbiterData {
+                arbiter: alice_client.arbiters().addresses.trusted_oracle_arbiter,
                 demand: demand.into(),
             },
-            0,
-        )
-    .await?;
-    let escrow = AlkahestClient::get_attested_event(escrow)?;
-    println!("escrow: {escrow:?}");
+            (std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)?
+                .as_secs() + 86400) as u64,
+        ).await?;
+    let escrow = DefaultAlkahestClient::get_attested_event(escrow_receipt)?;
 
-    // now the seller manually decodes the statement and demand
-    // and creates a StringResultObligation
-    // and manually collects payment
-    let buy_statement = client_seller
-        .attestation
-        .get_attestation(escrow.uid)
-    .await?;
-    let buy_statement = contracts::ERC20EscrowObligation::StatementData::abi_decode(
-        buy_statement.data.as_ref(),
-        true,
-    )?;
-    let decoded_demand =
-    TrustedPartyDemandData::abi_decode(buy_statement.demand.as_ref(), true)?;
-    let decoded_base_demand =
-    ResultDemandData::abi_decode(decoded_demand.baseDemand.as_ref(), true);
+    // Bob: fulfill the demand with a StringObligation attestation
+    let fulfillment_receipt = bob_client.string_obligation()
+        .do_obligation(
+            "HELLO WORLD".into(), // the computed result
+            None,                 // schema (optional)
+            Some(escrow.uid),     // reference to the escrow being fulfilled
+        ).await?;
+    let fulfillment = DefaultAlkahestClient::get_attested_event(fulfillment_receipt)?;
 
-    // uppercase string for the example;
-    // this could be anything as agreed upon between buyer and seller
-    // (running a Docker job, executing a DB query...)
-    // as long as the job "spec" is agreed upon between buyer and seller,
-    // and the "query" is contained in the demand
-    let result = decoded_base_demand?.query.to_uppercase();
-    println!("result: {}", result);
+    // Charlie: arbitrate (or use oracle().listen_and_arbitrate_sync for automatic polling)
+    // ... Charlie validates and submits decision via TrustedOracleArbiter
 
-    // manually make result statement
-    sol!(
-        #[allow(missing_docs)]
-        #[sol(rpc)]
-        #[derive(Debug)]
-        JobResultObligation,
-        "src/contracts/JobResultObligation.json"
-    );
+    // Bob: collect the escrow
+    bob_client.erc20().escrow().non_tierable()
+        .collect(escrow.uid, fulfillment.uid).await?;
 
-    // JobResultObligation.StatementData:
-    // struct StatementData {
-    //     string result;
-    // }
-    //
-    // JobResultObligation.makeStatement
-    // function makeStatement(
-    //     StatementData calldata data,
-    //     bytes32 refUID
-    // ) public returns (bytes32)
-    let job_result_obligation = address!("0x823a06994B4e817a5127c042dBd2742CcFdF2076");
-    let job_result_obligation =
-    JobResultObligation::new(job_result_obligation, &client_seller.wallet_provider);
-
-    let result = job_result_obligation
-        .makeStatement(
-            JobResultObligation::StatementData {
-                result: result.to_string(),
-            },
-            FixedBytes::<32>::ZERO,
-        )
-        .send()
-        .await?
-        .get_receipt()
-    .await?;
-    let result = AlkahestClient::get_attested_event(result)?;
-    println!("result: {result:?}");
-
-    // and collect the payment from escrow
-    let collection = client_seller
-        .erc20
-        .collect_payment(escrow.uid, result.uid)
-    .await?;
-    println!("collection: {collection:?}");
-
-    // meanwhile, the buyer can wait for fulfillment of her escrow.
-    // if called after fulfillment, like in this case, it will
-    // return the fulfilling statement immediately
-    let fulfillment = client_buyer
-        .wait_for_fulfillment(
-            client_buyer.erc20.addresses.escrow_obligation,
-            escrow.uid,
-            None,
-        )
-    .await?;
-
-    // and extract the result from the fulfillment statement
-    let fulfillment = client_buyer
-        .attestation
-        .get_attestation(fulfillment.fulfillment)
-    .await?;
-
-    let result =
-    JobResultObligation::StatementData::abi_decode(fulfillment.data.as_ref(), true);
-    println!("result: {}", result?.result);
+    // Alice: wait for fulfillment (useful if running concurrently)
+    let result = alice_client.wait_for_fulfillment(
+        alice_client.erc20().addresses.escrow_obligation_nontierable,
+        escrow.uid,
+        None,
+    ).await?;
 
     Ok(())
 }
-
 ```
 
-see [tests](https://github.com/CoopHive/alkahest-rs/blob/a5d4c56e70c00ffa82738567e7c4cd579ca1ab32/src/clients/erc20.rs#L843) for full example.
+See the [docs](../../docs/) for more detailed guides, including composing arbiters and building off-chain oracle validators.
+
+## Development
+
+### Running Tests
+
+Tests run against an Anvil fork:
+
+```bash
+cargo test
+```


### PR DESCRIPTION
## Summary
- Replaced old "statements/validators" terminology with escrow/arbiter/obligation from the Zellic audit codebase intro across all READMEs
- Added Security section linking to the [Zellic audit report](https://github.com/Zellic/publications/blob/master/Arkhai%20Alkahest%20-%20Zellic%20Audit%20Report.pdf)
- Fixed Payment Obligations description (they are fulfillment contracts, not escrows)
- Updated contracts/README with missing contracts (tierable escrows, confirmation arbiters, CommitRevealObligation, StringObligation, all barter utils)
- Rewrote SDK code examples (TS, Rust, Python) to use current APIs, removed stale CoopHive links
- Improved integration test descriptions

## Test plan
- [ ] Verify all contract file paths in contracts/README resolve correctly
- [ ] Verify links to audit report, docs, and deployment files work
- [ ] Spot-check SDK code examples against actual API signatures

🤖 Generated with [Claude Code](https://claude.com/claude-code)