### PR TITLE
docs: add agent skills for alkahest-user and alkahest-developer

### DIFF
--- a/docs/skills/alkahest-developer/SKILL.md
+++ b/docs/skills/alkahest-developer/SKILL.md
@@ -1,0 +1,336 @@
+---
+name: alkahest-developer
+description: Help developers write code that interacts with Alkahest escrow contracts using the TypeScript, Rust, or Python SDK
+---
+
+# Alkahest Developer Skill
+
+## When to Use
+
+Use this skill when a developer wants to write code that interacts with Alkahest escrow contracts. This covers:
+
+- Integrating Alkahest into an application
+- Writing bots/agents that create escrows, fulfill obligations, or arbitrate
+- Building custom arbiters or obligation contracts
+- Understanding SDK patterns and APIs
+
+## SDK Overview
+
+| SDK | Language | Package | Foundation |
+|-----|----------|---------|------------|
+| TypeScript | TypeScript/JavaScript | `@alkahest/ts-sdk` | viem |
+| Rust | Rust | `alkahest-rs` | alloy |
+| Python | Python | `alkahest-py` | PyO3 wrapper around Rust SDK |
+
+## Client Setup
+
+### TypeScript
+
+```typescript
+import { createWalletClient, http } from "viem";
+import { privateKeyToAccount } from "viem/accounts";
+import { baseSepolia } from "viem/chains";
+import { makeClient } from "@alkahest/ts-sdk";
+
+const walletClient = createWalletClient({
+  account: privateKeyToAccount("0xPRIVATE_KEY"),
+  chain: baseSepolia,
+  transport: http("https://rpc-url"),
+});
+
+// Full client with all extensions
+const client = makeClient(walletClient);
+
+// Custom addresses (optional)
+const client = makeClient(walletClient, customAddresses);
+
+// Minimal client for custom extension patterns
+const minimal = makeMinimalClient(walletClient);
+const extended = minimal.extend((base) => ({
+  custom: makeErc20Client(base.viemClient, pickErc20Addresses(base.contractAddresses)),
+}));
+```
+
+### Rust
+
+```rust
+use alkahest_rs::AlkahestClient;
+
+// Full client with all extensions (Base Sepolia default)
+let client = AlkahestClient::with_base_extensions(
+    "0xPRIVATE_KEY",
+    "https://rpc-url",
+    None, // uses Base Sepolia addresses
+).await?;
+
+// Custom addresses
+use alkahest_rs::{DefaultExtensionConfig, ETHEREUM_SEPOLIA_ADDRESSES};
+let client = AlkahestClient::with_base_extensions(
+    "0xPRIVATE_KEY",
+    "https://rpc-url",
+    Some(ETHEREUM_SEPOLIA_ADDRESSES),
+).await?;
+
+// Bare client + custom extensions
+let bare = AlkahestClient::new("0xPRIVATE_KEY", "https://rpc-url").await?;
+let extended = bare.extend::<Erc20Module>(Some(erc20_config)).await?;
+```
+
+### Python
+
+```python
+from alkahest_py import PyAlkahestClient
+
+# Full client with all extensions (Base Sepolia default)
+client = PyAlkahestClient("0xPRIVATE_KEY", "https://rpc-url")
+
+# Custom addresses
+from alkahest_py import DefaultExtensionConfig, PyErc20Addresses, ...
+config = DefaultExtensionConfig(erc20_addresses=..., ...)
+client = PyAlkahestClient("0xPRIVATE_KEY", "https://rpc-url", config)
+```
+
+## Core Patterns
+
+### Creating an Escrow
+
+**TypeScript:**
+```typescript
+// 1. Approve token
+await client.erc20.util.approve({ address: TOKEN, value: amount }, "escrow");
+
+// 2. Create escrow
+const { hash, attested } = await client.erc20.escrow.nonTierable.doObligation(
+  client.erc20.escrow.nonTierable.encodeObligationRaw({
+    token: TOKEN, amount, arbiter: ARBITER, demand: DEMAND_BYTES,
+  }),
+);
+const escrowUid = attested.uid;
+```
+
+**Rust:**
+```rust
+// 1. Approve
+client.erc20().approve(&Erc20Data { address: token, value: amount }, ApprovalPurpose::Escrow).await?;
+
+// 2. Create escrow
+let receipt = client.erc20().escrow().non_tierable().make_statement(
+    token, amount, arbiter, demand_bytes, expiration,
+).await?;
+let attested = client.get_attested_event(receipt)?;
+```
+
+**Python:**
+```python
+# 1. Approve
+await client.erc20.util.approve(token_address, amount, "escrow")
+
+# 2. Create escrow
+uid = await client.erc20.escrow.non_tierable.create(
+    token=token_address, amount=amount,
+    arbiter=arbiter_address, demand=demand_bytes,
+    expiration=expiration,
+)
+```
+
+### Fulfilling with StringObligation
+
+**TypeScript:**
+```typescript
+const { attested } = await client.stringObligation.doObligation(
+  "fulfillment content",
+  undefined,  // schema
+  escrowUid,  // refUID
+);
+```
+
+**Rust:**
+```rust
+let receipt = client.string_obligation().do_obligation(
+    "fulfillment content", None, Some(escrow_uid),
+).await?;
+```
+
+**Python:**
+```python
+uid = await client.string_obligation.do_obligation(
+    "fulfillment content",
+    ref_uid=escrow_uid,
+)
+```
+
+### Collecting Escrow
+
+**TypeScript:**
+```typescript
+const { hash } = await client.erc20.escrow.nonTierable.collectObligation(
+  escrowUid,
+  fulfillmentUid,
+);
+```
+
+**Rust:**
+```rust
+let receipt = client.erc20().escrow().non_tierable().collect_payment(
+    escrow_uid, fulfillment_uid,
+).await?;
+```
+
+**Python:**
+```python
+tx_hash = await client.erc20.escrow.non_tierable.collect(escrow_uid, fulfillment_uid)
+```
+
+### Waiting for Fulfillment
+
+**TypeScript:**
+```typescript
+const result = await client.waitForFulfillment(
+  client.contractAddresses.erc20EscrowObligation,
+  escrowUid,
+);
+```
+
+**Rust:**
+```rust
+let log = client.wait_for_fulfillment(
+    client.erc20_address(Erc20Contract::EscrowObligation),
+    escrow_uid,
+    None, // from_block
+).await?;
+```
+
+**Python:**
+```python
+result = await client.wait_for_fulfillment(
+    escrow_contract_address,
+    escrow_uid,
+)
+```
+
+### Encoding Demands
+
+**TypeScript:**
+```typescript
+// Trusted oracle
+const demand = client.arbiters.general.trustedOracle.encodeDemand({
+  oracle: ORACLE, data: "0x",
+});
+
+// Logical composition
+const demand = client.arbiters.logical.all.encodeDemand({
+  arbiters: [ARBITER_A, ARBITER_B],
+  demands: [DEMAND_A, DEMAND_B],
+});
+
+// Attestation properties
+const demand = client.arbiters.attestationProperties.attester.encodeDemand({
+  attester: REQUIRED_ATTESTER,
+});
+```
+
+**Rust:**
+```rust
+// Trusted oracle (ABI encoding)
+use alloy::sol_types::SolValue;
+let demand = TrustedOracleArbiter::DemandData { oracle, data: Bytes::new() }.abi_encode();
+
+// Decode arbiter demand (auto-detects)
+let decoded = client.arbiters().decode_arbiter_demand(arbiter_addr, &demand_bytes)?;
+```
+
+**Python:**
+```python
+# Trusted oracle
+demand = client.arbiters.trusted_oracle.encode_demand(oracle=ORACLE, data=b"")
+
+# Logical composition
+demand = client.arbiters.logical.all.encode(
+    arbiters=[ARBITER_A, ARBITER_B],
+    demands=[DEMAND_A, DEMAND_B],
+)
+```
+
+### Commit-Reveal Pattern
+
+**TypeScript:**
+```typescript
+// 1. Compute commitment
+const commitment = await client.commitReveal.computeCommitment(
+  escrowUid, claimerAddress, { payload, salt, schema },
+);
+// 2. Commit (sends bond as ETH)
+await client.commitReveal.commit(commitment);
+// 3. Wait 1+ blocks, then reveal
+const { attested } = await client.commitReveal.doObligation(
+  { payload, salt, schema }, escrowUid,
+);
+// 4. Reclaim bond
+await client.commitReveal.reclaimBond(attested.uid);
+```
+
+**Rust:**
+```rust
+let commitment = client.commit_reveal().compute_commitment(
+    escrow_uid, claimer, &obligation_data,
+).await?;
+client.commit_reveal().commit(commitment).await?;
+// wait 1+ blocks
+let receipt = client.commit_reveal().do_obligation(&obligation_data, Some(escrow_uid)).await?;
+client.commit_reveal().reclaim_bond(obligation_uid).await?;
+```
+
+**Python:**
+```python
+commitment = await client.commit_reveal.compute_commitment(
+    escrow_uid, claimer, payload, salt, schema,
+)
+await client.commit_reveal.commit(commitment)
+# wait 1+ blocks
+uid = await client.commit_reveal.do_obligation(payload, salt, schema, ref_uid=escrow_uid)
+await client.commit_reveal.reclaim_bond(uid)
+```
+
+## Barter Utilities
+
+Barter utils provide atomic single-transaction token swaps:
+
+**TypeScript:**
+```typescript
+await client.erc20.barter.buyErc20ForErc20(
+  { address: BID_TOKEN, value: bidAmount },
+  { address: ASK_TOKEN, value: askAmount },
+  BigInt(Math.floor(Date.now() / 1000) + 3600),
+);
+```
+
+**Rust:**
+```rust
+client.erc20().barter().buy_erc20_for_erc20(
+    &bid_token, &ask_token, expiration,
+).await?;
+```
+
+## Key Type Differences
+
+| Concept | TypeScript | Rust | Python |
+|---------|-----------|------|--------|
+| Addresses | `` `0x${string}` `` | `Address` | `str` (hex) |
+| Big integers | `bigint` | `U256` | `str` (decimal) |
+| Bytes | `` `0x${string}` `` | `Bytes` / `FixedBytes<32>` | `bytes` / `str` (hex) |
+| Receipts | `{ hash, attested }` | `TransactionReceipt` | `str` (tx hash or uid) |
+| Attestations | `Attestation` object | `IEAS::Attestation` | `PyAttestation` |
+
+## Reference Documentation
+
+- `references/typescript-api.md` — full TS SDK API tree
+- `references/rust-api.md` — full Rust SDK API tree
+- `references/python-api.md` — full Python SDK API tree
+- `references/contracts.md` — contract addresses and data schemas
+- `docs/Escrow Flow (pt 1).md` — token trading walkthrough
+- `docs/Escrow Flow (pt 2).md` — oracle arbitration walkthrough
+- `docs/Escrow Flow (pt 2b).md` — commit-reveal frontrunning protection
+- `docs/Escrow Flow (pt 3).md` — composing demands with logical arbiters
+- `docs/Writing Arbiters/` — custom arbiter development
+- `docs/Writing Contracts/` — custom escrow/obligation development
+- `docs/mcp-server/` — MCP server for looking up contract details

--- a/docs/skills/alkahest-developer/references/contracts.md
+++ b/docs/skills/alkahest-developer/references/contracts.md
@@ -1,0 +1,271 @@
+# Alkahest Contract Reference
+
+## Escrow Obligation Types
+
+Each escrow locks assets in a contract until an arbiter validates fulfillment.
+
+| Type | Contract | ObligationData fields |
+|------|----------|----------------------|
+| ERC20 | `ERC20EscrowObligation` | `token: address`, `amount: uint256`, `arbiter: address`, `demand: bytes` |
+| ERC721 | `ERC721EscrowObligation` | `token: address`, `tokenId: uint256`, `arbiter: address`, `demand: bytes` |
+| ERC1155 | `ERC1155EscrowObligation` | `token: address`, `tokenId: uint256`, `amount: uint256`, `arbiter: address`, `demand: bytes` |
+| Native Token | `NativeTokenEscrowObligation` | `amount: uint256`, `arbiter: address`, `demand: bytes` |
+| Token Bundle | `TokenBundleEscrowObligation` | `nativeAmount: uint256`, `erc20Tokens: address[]`, `erc20Amounts: uint256[]`, `erc721Tokens: address[]`, `erc721TokenIds: uint256[]`, `erc1155Tokens: address[]`, `erc1155TokenIds: uint256[]`, `erc1155Amounts: uint256[]`, `arbiter: address`, `demand: bytes` |
+| Attestation (v1) | `AttestationEscrowObligation` | `attestation: AttestationRequest`, `arbiter: address`, `demand: bytes` |
+| Attestation (v2) | `AttestationEscrowObligation2` | `attestation: AttestationRequest`, `arbiter: address`, `demand: bytes` |
+
+### Escrow lifecycle
+
+1. `doObligation(data, expirationTime)` — lock assets, create EAS attestation
+2. Fulfiller creates fulfillment attestation with `refUID` pointing to escrow
+3. `collectEscrow(escrowUid, fulfillmentUid)` — arbiter validates, releases assets
+4. `reclaimExpired(uid)` — reclaim assets after expiration (buyer only)
+
+## Payment Obligation Types
+
+Payments transfer assets immediately upon attestation creation (no escrow hold).
+
+| Type | Contract | ObligationData fields |
+|------|----------|----------------------|
+| ERC20 | `ERC20PaymentObligation` | `token: address`, `amount: uint256`, `payee: address` |
+| ERC721 | `ERC721PaymentObligation` | `token: address`, `tokenId: uint256`, `payee: address` |
+| ERC1155 | `ERC1155PaymentObligation` | `token: address`, `tokenId: uint256`, `amount: uint256`, `payee: address` |
+| Native Token | `NativeTokenPaymentObligation` | `amount: uint256`, `payee: address` |
+| Token Bundle | `TokenBundlePaymentObligation` | `nativeAmount: uint256`, `erc20Tokens: address[]`, `erc20Amounts: uint256[]`, `erc721Tokens: address[]`, `erc721TokenIds: uint256[]`, `erc1155Tokens: address[]`, `erc1155TokenIds: uint256[]`, `erc1155Amounts: uint256[]`, `payee: address` |
+
+## Fulfillment Obligation Types
+
+| Type | Contract | ObligationData fields |
+|------|----------|----------------------|
+| String | `StringObligation` | `item: string`, `schema: bytes32` |
+| Commit-Reveal | `CommitRevealObligation` | `payload: bytes`, `salt: bytes32`, `schema: bytes32` |
+
+### CommitRevealObligation details
+
+- `commit(commitment)` — submit hash commitment with ETH bond
+- `doObligation(data, refUID)` — reveal fulfillment data
+- `computeCommitment(refUID, claimer, data)` — compute expected commitment hash
+- `reclaimBond(obligationUid)` — reclaim bond after valid reveal
+- `slashBond(commitment)` — slash bond if reveal deadline passes
+- Commitment hash: `keccak256(abi.encode(refUID, claimer, keccak256(abi.encode(obligationData))))`
+- Built-in `IArbiter` implementation verifies commitment exists in an earlier block
+
+## Barter Utilities
+
+Barter utils combine escrow + payment into atomic single-transaction swaps.
+
+| Contract | Supported swaps |
+|----------|----------------|
+| `ERC20BarterUtils` | ERC20↔ERC20, ERC20↔ERC721, ERC20↔ERC1155, ERC20↔Bundle, ERC20↔ETH (with permit support) |
+| `NativeTokenBarterUtils` | ETH↔ERC20, ETH↔ERC721, ETH↔ERC1155, ETH↔Bundle, ETH↔ETH |
+| `TokenBundleBarterUtils` | Bundle↔Bundle (with multi-permit support) |
+
+## Contract Addresses
+
+### Base Sepolia
+
+| Contract | Address |
+|----------|---------|
+| EAS | `0x4200000000000000000000000000000000000021` |
+| EAS Schema Registry | `0x4200000000000000000000000000000000000020` |
+| **ERC20** | |
+| ERC20EscrowObligation | `0x1Fe964348Ec42D9Bb1A072503ce8b4744266FF43` |
+| ERC20PaymentObligation | `0x8d13d7542E64D9Da29AB66B6E9b4a6583C64b3F6` |
+| ERC20BarterUtils | `0x946Ef4E912897B4A24b9250513dfeE3fc4303Dde` |
+| **ERC721** | |
+| ERC721EscrowObligation | `0x7675a56b2880EF059cFC725E715E1139D689c07B` |
+| ERC721PaymentObligation | `0x9Daf829f183cA46ad2146F489E7d14335C9B59a9` |
+| ERC721BarterUtils | `0x707f280Fa738b4cc175A369d450f2f603094cbAf` |
+| **ERC1155** | |
+| ERC1155EscrowObligation | `0xB8A3107DA5428a34f818ea4229233fBAe59C16F2` |
+| ERC1155PaymentObligation | `0x6f71429bD940Bf3345780a8E5F5cf3BcdffE80C1` |
+| ERC1155BarterUtils | `0x4E4F0F883B1fEC20F219E0c8D2ec0061FE3c1328` |
+| **Native Token** | |
+| NativeTokenEscrowObligation | `0x8a1172D32B8cEf14094cF1E7d6F3d1A36D949FDe` |
+| NativeTokenPaymentObligation | `0xAB1E9714fbD4f9B5546e891B7Ba392b08c44c37A` |
+| NativeTokenBarterUtils | `0xaaB70Cfc37C5E73e185E2976609A82Ba22A4310d` |
+| **Token Bundle** | |
+| TokenBundleEscrowObligation | `0x38e8E5684aFB24A88cD9B276032bCBD19C4b9d6e` |
+| TokenBundlePaymentObligation | `0xFa5446475De31fa3c6457E2b62EA5a8F8172Cd29` |
+| TokenBundleBarterUtils | `0x47C033F49D5A1559AC48f27571204a29b8E728b8` |
+| **Attestation** | |
+| AttestationEscrowObligation | `0x9D133Cbd51270a2A410465F82dAFFD6c1C87322D` |
+| AttestationEscrowObligation2 | `0xa076e9ca47f192E6AfB67817608E382074CF0Dcf` |
+| AttestationBarterUtils | `0x84D390BCd90d5f65D14ff66f6860DCa45e776666` |
+| **Fulfillment** | |
+| StringObligation | `0x544873C22A3228798F91a71C4ef7a9bFe96E7CE0` |
+| CommitRevealObligation | `0x447b11ce03237f0C674eF7F16c913c3B2e8ef494` |
+| **Arbiters** | |
+| TrivialArbiter | `0x50EDa6c29C740bfbA6875422287025D985b96b7b` |
+| TrustedOracleArbiter | `0x3664b11BcCCeCA27C21BBAB43548961eD14d4D6D` |
+| AllArbiter | `0x0D95c1Cd62cd9C7cCCB237a3Ae08aA61Ed83381f` |
+| AnyArbiter | `0xaaC3465f340C7A2841A120F81Ce6744cda00d263` |
+| IntrinsicsArbiter | `0x24aAFec3f86CAd330600dD2397DEB8498D44bfd9` |
+| IntrinsicsArbiter2 | `0x51a28Ad45BE6eb6fd6D76af56a7D62ECd99547C7` |
+| ERC8004Arbiter | `0x67B23406dd9e9EA884B3d14746ef73106b1C35d6` |
+| ExclusiveRevocableConfirmationArbiter | `0xBA0e678f4F1a62f5d737F9289B7e1F2F8580DD8D` |
+| ExclusiveUnrevocableConfirmationArbiter | `0x141Bfd94A1C2B2728dF693657d1C7589b06A139E` |
+| NonexclusiveRevocableConfirmationArbiter | `0xB78A1870C5412EBa6042a5b1dE895E8f879AbeC6` |
+| NonexclusiveUnrevocableConfirmationArbiter | `0x74FaFAAEa1bA879E73Cd7e38ec6F3ff86554D4B7` |
+| RecipientArbiter | `0xE6CB55B60b6B47B45de05df75B48D656E4bD3730` |
+| AttesterArbiter | `0xB0d19784373EC5FDd2E44A2b594B10FE9bBecC94` |
+| SchemaArbiter | `0xc15Ef82Adf03820dA8a0705200602107a06652BE` |
+| UidArbiter | `0x0Be4E6D777D5C1AE3DDF338AF2398A279571511b` |
+| RefUidArbiter | `0xdEc95668f431639AAE975CfA9101Bb2A5b5803F6` |
+| RevocableArbiter | `0x550eF7e901F612914651f3c92c0798eBab037AF6` |
+| TimeAfterArbiter | `0xd88274b04194bebA06B32D3F67265e4b530F4C4d` |
+| TimeBeforeArbiter | `0xEC177a4FA6c42B1EA2bbEC70F3FFaE2aCD94e4aF` |
+| TimeEqualArbiter | `0x0E16A9f94aD457214d5e8AdD30c64D8c6FD4a416` |
+| ExpirationTimeAfterArbiter | `0x05Ae296859454612a9a346B2EeBE6915319993Ec` |
+| ExpirationTimeBeforeArbiter | `0x698008cC7F4714D331Aa27278BfE6B74FA925cF7` |
+| ExpirationTimeEqualArbiter | `0x4d05EA86C2C0af7CA94dc71Da45aba9368e664e4` |
+
+### Sepolia
+
+| Contract | Address |
+|----------|---------|
+| EAS | `0xC2679fBD37d54388Ce493F1DB75320D236e1815e` |
+| EAS Schema Registry | `0x0a7E2Ff54e76B8E6659aedc9103FB21c038050D0` |
+| ERC20EscrowObligation | `0xB2c808911E84E80156101983897Da7c80e13cB47` |
+| ERC20PaymentObligation | `0xb822aA07F55a8B75Ee133ede1f21C4E49DE7952f` |
+| ERC20BarterUtils | `0x5bf7c8b0d60d05af0a3De531EB876De271E80dbc` |
+| ERC721EscrowObligation | `0x2A7df117e45D93d34a7893CC3aE8B105Ae0B561C` |
+| ERC721PaymentObligation | `0x59A9c929778Ad2cC4D5DB6151bDEf0F9Fa7A068C` |
+| ERC721BarterUtils | `0xEB0C0c41F708B8b3556a6F44a1a015a6832C2d2C` |
+| ERC1155EscrowObligation | `0xf04d9CA943f57353A3A735494E503280C1cD5e77` |
+| ERC1155PaymentObligation | `0x52748DD0E39eD6eA9f626179b5eb512302adA7D9` |
+| ERC1155BarterUtils | `0x52De4B30721b3E3660A79da7491a9B2F8a9cB1D5` |
+| NativeTokenEscrowObligation | `0x9bA50DB048d1E5db034377abf97F92496D027C71` |
+| NativeTokenPaymentObligation | `0xf60db64506E366a0A6c1f4cF9D849Adc7bB886D6` |
+| NativeTokenBarterUtils | `0xA42032D8BFeE2302cC6F80ff51D283Ffc5a4081f` |
+| TokenBundleEscrowObligation | `0x677Aa9e1CD9D05f57FbCa2327155EA7479ec7Ac3` |
+| TokenBundlePaymentObligation | `0x36Fcf1Ddee838a94B1358285A11e8bbbb90eD9A1` |
+| TokenBundleBarterUtils | `0xA7EacA68Bffc9443eA08fd58633Eeed3f5EE8A92` |
+| AttestationEscrowObligation | `0x6eb7792D821f32914Be75901F1b4269B13Efad2e` |
+| AttestationEscrowObligation2 | `0x1A7c6F951e0a33F4910dbe56a200Eb413AEca17b` |
+| AttestationBarterUtils | `0x5E6602F080E9B37267aa52306c699ae54Cd71056` |
+| StringObligation | `0xC51C938f5497be8157DAf8CCc3Eb11Afb8b752C0` |
+| CommitRevealObligation | `0x9fD6D7A3B4e4b5dD75c50F5f16Deba46162127C3` |
+| TrivialArbiter | `0x594E79466b6ac01C6416C929e428264a4bdF0C92` |
+| TrustedOracleArbiter | `0x3B2a812E3eb3B729D40d866Da16c2BB2b6cDd2f2` |
+| AllArbiter | `0x847F69d27E4F1A8a115aCa3F4358B079706dc9CE` |
+| AnyArbiter | `0xe968dFA581B8aBb94eC5F24d0b56163DE69511fD` |
+| IntrinsicsArbiter | `0xaabdDAa76651d20922d1F561f924a40F6fE7710c` |
+| IntrinsicsArbiter2 | `0xF486f9a62eeb085e99828e1D706bBA5dfC1bD1fD` |
+| ERC8004Arbiter | `0x367fEd55E65bd0FCCF8F966A04989AB61E1b5A49` |
+| ExclusiveRevocableConfirmationArbiter | `0x941044D43F9d75dfA8Ad24880B9B9cAD6e116a66` |
+| ExclusiveUnrevocableConfirmationArbiter | `0x16aeE626D398B547eDD5fa4BdAA638524C92921d` |
+| NonexclusiveRevocableConfirmationArbiter | `0xe483EDA58b5f9Eba06A1ad0151dA5e4a5fFC8300` |
+| NonexclusiveUnrevocableConfirmationArbiter | `0x01666d869918aDDDED1B30eF2d36f3C990F09BDE` |
+| RecipientArbiter | `0xF1C9E20078A13816ACdDF3153e2eAaDd93Fd6E57` |
+| AttesterArbiter | `0x6CC4068d471E96A1669097918e18017f5764f72a` |
+| SchemaArbiter | `0x913eAdD13dcCdeD9CD5518075083b6C7A9574A8c` |
+| UidArbiter | `0xae4fa2D5d7EDD6Aaf697dC0c98EDb921F0fEc058` |
+| RefUidArbiter | `0xE9ee2c57B18283b66d342D33d63C55f1427f9e9B` |
+| RevocableArbiter | `0xeda25079f76ef93c54cC042116Be8D88E49D3439` |
+| TimeAfterArbiter | `0x0ea9e144FfDc6456E5cE8d1f75c686112e8f29c5` |
+| TimeBeforeArbiter | `0x68A6e6022ab9984Ee1A9A6cee384FF2aE8be5264` |
+| TimeEqualArbiter | `0x208385Fb349c01af2CfA8C6b86F633F6642718e2` |
+| ExpirationTimeAfterArbiter | `0x309509db364526C7aE202eA9ED94a398a0819d38` |
+| ExpirationTimeBeforeArbiter | `0xFAf8a07709dB9f90d0A0415876CfE00D904cd40B` |
+| ExpirationTimeEqualArbiter | `0x7c782ac7741BB78DB7491Ee222af0a04f7f2bc0b` |
+
+### Filecoin Calibration
+
+| Contract | Address |
+|----------|---------|
+| EAS | `0x3c79a0225380fB6F3CB990FfC4E3D5aF4546b524` |
+| EAS Schema Registry | `0x2BB94a4E6eC0D81dE7f81007b572Ac09A5BE37b4` |
+| ERC20EscrowObligation | `0x6bcec91a89a63d50368bce54cb9ed0399992c18b` |
+| ERC20PaymentObligation | `0x33f6f558c1fcac597f2b635bc50554055ff98165` |
+| ERC20BarterUtils | `0xb5800e34602154ce92c5eb0e7cb455306d7d590e` |
+| ERC721EscrowObligation | `0x99f5335b95e1c0be4c218a59aae26efc50d5673f` |
+| ERC721PaymentObligation | `0x5b6bff4dc108c58b97721330666f56c8028c097c` |
+| ERC721BarterUtils | `0x797a737defb8cae0a30324ecfa52eaab9c0a5fd6` |
+| ERC1155EscrowObligation | `0xf9dbc74553faecac775201113198085c4d572805` |
+| ERC1155PaymentObligation | `0x4cb076af47f0f3909ebafd88cbc0c4cc8dee17dd` |
+| ERC1155BarterUtils | `0x850d8df3ff0149bd5a9191a958b287b25564716b` |
+| NativeTokenEscrowObligation | `0x7490102a8b821c70679508426823f26c9bab4714` |
+| NativeTokenPaymentObligation | `0xd511278d5b9e5f8f9b99d01ea326b8232c133be5` |
+| NativeTokenBarterUtils | `0x3c07027874650794eae300c603f066af182ea86a` |
+| TokenBundleEscrowObligation | `0x902ac1997bd29a037263e0d80952c80d69d9afd4` |
+| TokenBundlePaymentObligation | `0xc1b02efec19a171ecbb7c8ad54b9617e80fdf40f` |
+| TokenBundleBarterUtils | `0xfca2c2df4023a0a418bf354b5bfff1ebfe0520a9` |
+| AttestationEscrowObligation | `0xd59c6c6cb025e76a0a1e706c62a9df38b04694e2` |
+| AttestationEscrowObligation2 | `0xa22b4d9fe7a746d44be1e724bb1a26593bca2c1b` |
+| AttestationBarterUtils | `0xcda1e1ea425e31a789feffc8e3d90f839ff49c9f` |
+| StringObligation | `0x66c3f78258823b9b899ab14b11e1dcf978c060d7` |
+| CommitRevealObligation | `0x32889Ee549d61Ed5D14f2D499fCc809a4feC0dD8` |
+| TrivialArbiter | `0xd56bd862e7bebd0bd7356603e9e52b32c241e2ae` |
+| TrustedOracleArbiter | `0x61dc9c2d757a1c9d0d38a281288d9ef918e77baa` |
+| AllArbiter | `0x49026902790a8ecb427f335ca0d097c7c5795d13` |
+| AnyArbiter | `0xb6890a8cb8cdefce11edc0314125b750f48bff1b` |
+| IntrinsicsArbiter | `0x81dc8f2c5677b02afcafef34fa7e75d55dfaef20` |
+| IntrinsicsArbiter2 | `0x7b20a4b25af2a2637c240622d6c3875dea609a64` |
+| ERC8004Arbiter | `0x3c1E21911C609714dBc0Ab90800c7aD8817B8e83` |
+| ExclusiveRevocableConfirmationArbiter | `0xa740634e718c8727853d1e69963303d5cb8ea44c` |
+| ExclusiveUnrevocableConfirmationArbiter | `0xb3d71c6f96cdd41e56dd9870b232225c379f2890` |
+| NonexclusiveRevocableConfirmationArbiter | `0x831b40ae79d391c7d56209802b9745fe0743dbf5` |
+| NonexclusiveUnrevocableConfirmationArbiter | `0xfeaa2fa295d1453ba382b7ee0e3f66c489a6d9bb` |
+| RecipientArbiter | `0xe0d55949e6e1590f26ef37a1d01df52fbb1b2fce` |
+| AttesterArbiter | `0xe571d48d05962c57c95e48b8a7375466d1d02487` |
+| SchemaArbiter | `0x9d5817ff5519f45bf8ed6c3ada638b874dbcb540` |
+| UidArbiter | `0xaa9aef96068f2be679ae8781a4fc33ff4798758f` |
+| RefUidArbiter | `0x546526311e6639399fdc583df84eee8b123d79d5` |
+| RevocableArbiter | `0xe8d45cf2471882730a7e0ac142966df07ae148d4` |
+| TimeAfterArbiter | `0x2725a6869b42edfd155889098408ccb3b1ed060e` |
+| TimeBeforeArbiter | `0x014aa3dc53004b50bc13aa1d85a83bcca5c0671a` |
+| TimeEqualArbiter | `0x1c21a8fb4f69adb0ccdd22d8c125f8689bf227af` |
+| ExpirationTimeAfterArbiter | `0xbd90af50fb667724338eb8da541f923f1822ac3c` |
+| ExpirationTimeBeforeArbiter | `0xbcce130337f2d8029982a14471d8686afcef20ff` |
+| ExpirationTimeEqualArbiter | `0x98d5bc7593143e55e9949da97603126cae0bfd7f` |
+
+### Ethereum Mainnet
+
+| Contract | Address |
+|----------|---------|
+| EAS | `0xA1207F3BBa224E2c9c3c6D5aF63D0eb1582Ce587` |
+| EAS Schema Registry | `0xA7b39296258348C78294F95B872b282326A97BDF` |
+| ERC20EscrowObligation | `0xB2c808911E84E80156101983897Da7c80e13cB47` |
+| ERC20PaymentObligation | `0xb822aA07F55a8B75Ee133ede1f21C4E49DE7952f` |
+| ERC20BarterUtils | `0x5bf7c8b0d60d05af0a3De531EB876De271E80dbc` |
+| ERC721EscrowObligation | `0x2A7df117e45D93d34a7893CC3aE8B105Ae0B561C` |
+| ERC721PaymentObligation | `0x59A9c929778Ad2cC4D5DB6151bDEf0F9Fa7A068C` |
+| ERC721BarterUtils | `0xEB0C0c41F708B8b3556a6F44a1a015a6832C2d2C` |
+| ERC1155EscrowObligation | `0xf04d9CA943f57353A3A735494E503280C1cD5e77` |
+| ERC1155PaymentObligation | `0x52748DD0E39eD6eA9f626179b5eb512302adA7D9` |
+| ERC1155BarterUtils | `0x52De4B30721b3E3660A79da7491a9B2F8a9cB1D5` |
+| NativeTokenEscrowObligation | `0x9bA50DB048d1E5db034377abf97F92496D027C71` |
+| NativeTokenPaymentObligation | `0xf60db64506E366a0A6c1f4cF9D849Adc7bB886D6` |
+| NativeTokenBarterUtils | `0xA42032D8BFeE2302cC6F80ff51D283Ffc5a4081f` |
+| TokenBundleEscrowObligation | `0x677Aa9e1CD9D05f57FbCa2327155EA7479ec7Ac3` |
+| TokenBundlePaymentObligation | `0x36Fcf1Ddee838a94B1358285A11e8bbbb90eD9A1` |
+| TokenBundleBarterUtils | `0xA7EacA68Bffc9443eA08fd58633Eeed3f5EE8A92` |
+| AttestationEscrowObligation | `0x6eb7792D821f32914Be75901F1b4269B13Efad2e` |
+| AttestationEscrowObligation2 | `0x1A7c6F951e0a33F4910dbe56a200Eb413AEca17b` |
+| AttestationBarterUtils | `0x5E6602F080E9B37267aa52306c699ae54Cd71056` |
+| StringObligation | `0xC51C938f5497be8157DAf8CCc3Eb11Afb8b752C0` |
+| CommitRevealObligation | `0x05d9Aa2A6AE38619b864Ff7f87A8f94301ecAB42` |
+| TrivialArbiter | `0x594E79466b6ac01C6416C929e428264a4bdF0C92` |
+| TrustedOracleArbiter | `0x3B2a812E3eb3B729D40d866Da16c2BB2b6cDd2f2` |
+| AllArbiter | `0x847F69d27E4F1A8a115aCa3F4358B079706dc9CE` |
+| AnyArbiter | `0xe968dFA581B8aBb94eC5F24d0b56163DE69511fD` |
+| IntrinsicsArbiter | `0xaabdDAa76651d20922d1F561f924a40F6fE7710c` |
+| IntrinsicsArbiter2 | `0xF486f9a62eeb085e99828e1D706bBA5dfC1bD1fD` |
+| ERC8004Arbiter | `0xBE7fE4d7CEb2140eeBdf01e12D198AEBAdC1F54D` |
+| ExclusiveRevocableConfirmationArbiter | `0x941044D43F9d75dfA8Ad24880B9B9cAD6e116a66` |
+| ExclusiveUnrevocableConfirmationArbiter | `0x16aeE626D398B547eDD5fa4BdAA638524C92921d` |
+| NonexclusiveRevocableConfirmationArbiter | `0xe483EDA58b5f9Eba06A1ad0151dA5e4a5fFC8300` |
+| NonexclusiveUnrevocableConfirmationArbiter | `0x01666d869918aDDDED1B30eF2d36f3C990F09BDE` |
+| RecipientArbiter | `0xF1C9E20078A13816ACdDF3153e2eAaDd93Fd6E57` |
+| AttesterArbiter | `0x6CC4068d471E96A1669097918e18017f5764f72a` |
+| SchemaArbiter | `0x913eAdD13dcCdeD9CD5518075083b6C7A9574A8c` |
+| UidArbiter | `0xae4fa2D5d7EDD6Aaf697dC0c98EDb921F0fEc058` |
+| RefUidArbiter | `0xE9ee2c57B18283b66d342D33d63C55f1427f9e9B` |
+| RevocableArbiter | `0xeda25079f76ef93c54cC042116Be8D88E49D3439` |
+| TimeAfterArbiter | `0x0ea9e144FfDc6456E5cE8d1f75c686112e8f29c5` |
+| TimeBeforeArbiter | `0x68A6e6022ab9984Ee1A9A6cee384FF2aE8be5264` |
+| TimeEqualArbiter | `0x208385Fb349c01af2CfA8C6b86F633F6642718e2` |
+| ExpirationTimeAfterArbiter | `0x309509db364526C7aE202eA9ED94a398a0819d38` |
+| ExpirationTimeBeforeArbiter | `0xFAf8a07709dB9f90d0A0415876CfE00D904cd40B` |
+| ExpirationTimeEqualArbiter | `0x7c782ac7741BB78DB7491Ee222af0a04f7f2bc0b` |

--- a/docs/skills/alkahest-developer/references/python-api.md
+++ b/docs/skills/alkahest-developer/references/python-api.md
@@ -1,0 +1,269 @@
+# Alkahest Python SDK API Reference
+
+The Python SDK is a PyO3 wrapper around the Rust SDK. It exposes the same functionality with Python-idiomatic naming and types.
+
+## Client Construction
+
+```python
+from alkahest_py import PyAlkahestClient
+
+# Full client with all extensions (Base Sepolia default)
+client = PyAlkahestClient("0xPRIVATE_KEY", "https://rpc-url")
+
+# With custom addresses
+from alkahest_py import (
+    DefaultExtensionConfig,
+    PyErc20Addresses, PyErc721Addresses, PyErc1155Addresses,
+    PyNativeTokenAddresses, PyTokenBundleAddresses, PyAttestationAddresses,
+    PyArbitersAddresses, PyStringObligationAddresses, PyCommitRevealObligationAddresses,
+)
+
+config = DefaultExtensionConfig(
+    erc20_addresses=PyErc20Addresses(eas="0x...", barter_utils="0x...", ...),
+    # ... other address configs
+)
+client = PyAlkahestClient("0xPRIVATE_KEY", "https://rpc-url", config)
+```
+
+## API Access Pattern
+
+The Python SDK uses nested property accessors:
+
+```python
+client.<extension>.<category>.<subcategory>.<method>()
+```
+
+All async methods use Python's `await` syntax.
+
+## Full API Tree
+
+```
+client
+├── list_extensions() -> List[str]
+├── has_extension(extension_type: str) -> bool
+├── extract_obligation_data(attestation) -> str
+├── get_escrow_attestation(fulfillment) -> PyOracleAttestation
+├── extract_demand_data(escrow_attestation) -> PyTrustedOracleArbiterDemandData
+├── get_escrow_and_demand(fulfillment) -> tuple
+├── wait_for_fulfillment(contract_address, buy_attestation, from_block?) -> EscowClaimedLog
+│
+├── erc20
+│   ├── util
+│   │   └── approve(token_address, amount, purpose)
+│   ├── escrow
+│   │   ├── non_tierable
+│   │   │   ├── create(token, amount, arbiter, demand, expiration) -> str (uid)
+│   │   │   ├── collect(escrow_uid, fulfillment_uid) -> str (tx_hash)
+│   │   │   └── get(uid) -> PyDecodedAttestation
+│   │   └── tierable
+│   ├── payment
+│   │   ├── pay(token, amount, payee, ...) -> str (uid)
+│   │   ├── approve_and_pay(token, amount, payee, ...) -> str (uid)
+│   │   └── get(uid) -> PyDecodedAttestation
+│   └── barter
+│       ├── buy_erc20_for_erc20(bid_token, bid_amount, ask_token, ask_amount, expiration)
+│       ├── buy_erc20_for_erc721(bid_token, bid_amount, ask_token, ask_id, expiration)
+│       └── ... (other cross-token combinations)
+│
+├── erc721                            # Same structure as erc20
+│   ├── util (.approve)
+│   ├── escrow.non_tierable / .tierable
+│   ├── payment
+│   └── barter
+│
+├── erc1155                           # Same structure
+│   ├── util (.approve_all)
+│   ├── escrow.non_tierable / .tierable
+│   ├── payment
+│   └── barter
+│
+├── native_token                      # No util
+│   ├── escrow.non_tierable / .tierable
+│   ├── payment
+│   └── barter
+│
+├── token_bundle
+│   ├── util (.approve)
+│   ├── escrow.non_tierable / .tierable
+│   ├── payment
+│   └── barter
+│
+├── attestation
+│   ├── escrow.v1.non_tierable / .tierable
+│   ├── escrow.v2.non_tierable / .tierable
+│   └── util
+│       ├── get_attestation(uid) -> PyAttestation
+│       ├── register_schema(schema, resolver, revocable) -> str
+│       └── attest(schema, data, ...) -> str (uid)
+│
+├── string_obligation
+│   ├── do_obligation(item, ref_uid?, schema?) -> str (uid)
+│   └── get_obligation(uid) -> PyDecodedAttestation[PyStringObligationData]
+│
+├── commit_reveal
+│   ├── do_obligation(payload, salt, schema, ref_uid?) -> str (uid)
+│   ├── commit(commitment) -> str (tx_hash)
+│   ├── compute_commitment(ref_uid, claimer, payload, salt, schema) -> str
+│   ├── reclaim_bond(obligation_uid) -> str (tx_hash)
+│   ├── slash_bond(commitment) -> str (tx_hash)
+│   ├── bond_amount() -> str (U256 as string)
+│   ├── commit_deadline() -> str
+│   ├── slashed_bond_recipient() -> str (address)
+│   ├── get_commitment(commitment) -> tuple(u64, u64, str)
+│   ├── is_commitment_claimed(commitment) -> bool
+│   └── get_obligation(uid) -> PyDecodedAttestation[PyCommitRevealObligationData]
+│
+└── arbiters
+    ├── trusted_oracle
+    │   ├── get_eas_address() -> str
+    │   ├── get_trusted_oracle_arbiter_address() -> str
+    │   ├── request_arbitration(obligation_uid, oracle, demand) -> str (tx_hash)
+    │   ├── extract_obligation_data(attestation) -> str
+    │   ├── extract_demand_data(escrow_attestation) -> PyTrustedOracleArbiterDemandData
+    │   ├── arbitrate(obligation, demand, decision) -> str (tx_hash)
+    │   └── wait_for_arbitration(obligation, demand?, oracle?, from_block?) -> PyArbitrationMadeLog
+    │
+    ├── logical
+    │   ├── all
+    │   │   ├── address() -> str
+    │   │   ├── encode(arbiters: list, demands: list) -> bytes
+    │   │   └── decode(demand_bytes) -> tuple(list, list)
+    │   └── any                        # Same API as all
+    │
+    ├── confirmation
+    │   ├── exclusive_revocable
+    │   │   ├── confirm(escrow, fulfillment)
+    │   │   ├── revoke(escrow, fulfillment)
+    │   │   └── is_confirmed(escrow, fulfillment) -> bool
+    │   ├── exclusive_unrevocable
+    │   ├── nonexclusive_revocable
+    │   └── nonexclusive_unrevocable
+    │   └── address(arbiter_type) -> str
+    │
+    ├── attestation_properties
+    │   ├── attester                   # .address(), .encode(attester), .decode(bytes)
+    │   ├── recipient
+    │   ├── schema
+    │   ├── uid
+    │   ├── ref_uid
+    │   ├── revocable
+    │   ├── time_after
+    │   ├── time_before
+    │   ├── time_equal
+    │   ├── expiration_time_after
+    │   ├── expiration_time_before
+    │   └── expiration_time_equal
+    │
+    ├── eas_address() -> str
+    ├── trivial_arbiter_address() -> str
+    ├── trusted_oracle_arbiter_address() -> str
+    ├── intrinsics_arbiter_address() -> str
+    ├── intrinsics_arbiter_2_address() -> str
+    ├── erc8004_arbiter_address() -> str
+    ├── any_arbiter_address() -> str
+    ├── all_arbiter_address() -> str
+    └── confirmation_arbiter_address(arbiter_type) -> str
+```
+
+## Key Type Differences from Rust/TypeScript
+
+| Concept | Python type | Notes |
+|---------|------------|-------|
+| Addresses | `str` | Hex with `0x` prefix |
+| U256 / big integers | `str` | Decimal string representation |
+| Bytes | `bytes` or `str` | Hex strings for hashes, raw bytes for payloads |
+| Transaction receipts | `str` | Returns tx hash as hex string |
+| Attestation UIDs | `str` | Returned directly from write methods |
+| Boolean | `bool` | Standard Python bool |
+
+## Data Type Classes
+
+### Obligation data (with static encode/decode)
+
+```python
+from alkahest_py import (
+    PyERC20EscrowObligationData,      # token, amount, arbiter, demand
+    PyERC20PaymentObligationData,     # token, amount, payee
+    PyERC721EscrowObligationData,     # token, token_id, arbiter, demand
+    PyERC721PaymentObligationData,    # token, token_id, payee
+    PyERC1155EscrowObligationData,    # token, token_id, amount, arbiter, demand
+    PyERC1155PaymentObligationData,   # token, token_id, amount, payee
+    PyStringObligationData,           # item
+    PyCommitRevealObligationData,     # payload, salt, schema
+)
+
+# Static encode/decode
+encoded = PyCommitRevealObligationData.encode(obligation_data)
+decoded = PyCommitRevealObligationData.decode(encoded_bytes)
+```
+
+### Arbiter demand data
+
+```python
+from alkahest_py import (
+    PyTrustedOracleArbiterDemandData,
+    IntrinsicsArbiter2DemandData,     # schema (with encode/decode)
+    ERC8004ArbiterDemandData,         # validation_registry, validator_address, min_response
+    AttesterArbiterDemandData,
+    RecipientArbiterDemandData,
+    # ... all property arbiter demand data types
+)
+```
+
+### Attestation types
+
+```python
+from alkahest_py import PyAttestation
+
+attestation.uid           # str
+attestation.schema        # str
+attestation.time          # int
+attestation.expiration_time  # int
+attestation.revocation_time  # int
+attestation.ref_uid       # str
+attestation.recipient     # str
+attestation.attester      # str
+attestation.revocable     # bool
+attestation.data          # str (hex)
+
+attestation.is_expired()  # bool
+attestation.is_revoked()  # bool
+attestation.is_valid()    # bool
+```
+
+### Event log types
+
+```python
+from alkahest_py import (
+    PyArbitrationMadeLog,        # decision_key, obligation, oracle, decision
+    PyConfirmationMadeLog,
+    PyConfirmationRequestedLog,
+    AttestedLog,                 # recipient, attester, uid, schema_uid
+    EscowClaimedLog,             # payment, fulfillment, fulfiller
+)
+```
+
+## Async Usage
+
+All write operations and most reads are async:
+
+```python
+import asyncio
+
+async def main():
+    client = PyAlkahestClient("0xKEY", "https://rpc")
+    uid = await client.string_obligation.do_obligation("hello", ref_uid=escrow_uid)
+    attestation = await client.string_obligation.get_obligation(uid)
+    print(attestation.data.item)
+
+asyncio.run(main())
+```
+
+## Test Utilities
+
+```python
+from alkahest_py import EnvTestManager, PyMockERC20, PyMockERC721, PyMockERC1155
+
+manager = EnvTestManager()
+# Properties: rpc_url, god, alice, bob, alice_private_key, bob_private_key, addresses
+```

--- a/docs/skills/alkahest-developer/references/rust-api.md
+++ b/docs/skills/alkahest-developer/references/rust-api.md
@@ -1,0 +1,243 @@
+# Alkahest Rust SDK API Reference
+
+## Client Construction
+
+```rust
+use alkahest_rs::AlkahestClient;
+
+// Full client with all extensions (Base Sepolia default)
+let client = AlkahestClient::with_base_extensions(
+    "0xPRIVATE_KEY",
+    "https://rpc-url",
+    None, // uses BASE_SEPOLIA_ADDRESSES
+).await?;
+
+// With specific chain addresses
+use alkahest_rs::{ETHEREUM_SEPOLIA_ADDRESSES, FILECOIN_CALIBRATION_ADDRESSES, ETHEREUM_ADDRESSES};
+let client = AlkahestClient::with_base_extensions(
+    "0xPRIVATE_KEY",
+    "https://rpc-url",
+    Some(ETHEREUM_SEPOLIA_ADDRESSES),
+).await?;
+
+// Bare client (no extensions)
+let bare = AlkahestClient::new("0xPRIVATE_KEY", "https://rpc-url").await?;
+
+// Add extensions individually
+let extended = bare.extend::<Erc20Module>(Some(erc20_config)).await?;
+let more = extended.extend_default::<ArbitersModule>().await?;
+```
+
+**Type alias:** `DefaultAlkahestClient = AlkahestClient<BaseExtensions>`
+
+## Extension Access
+
+```rust
+client.erc20()               // -> &Erc20Module
+client.erc721()              // -> &Erc721Module
+client.erc1155()             // -> &Erc1155Module
+client.native_token()        // -> &NativeTokenModule
+client.token_bundle()        // -> &TokenBundleModule
+client.attestation()         // -> &AttestationModule
+client.string_obligation()   // -> &StringObligationModule
+client.commit_reveal()       // -> &CommitRevealObligationModule
+client.arbiters()            // -> &ArbitersModule
+client.oracle()              // -> &OracleModule (alias for TrustedOracle)
+```
+
+Extension access uses trait bounds: e.g., `client.erc20()` requires `Extensions: HasErc20`.
+
+## Full API Tree
+
+```
+client
+├── get_attested_event(receipt) -> Log<Attested>
+├── wait_for_fulfillment(contract, buy_uid, from_block) -> Log<EscrowClaimed>
+├── extract_obligation_data::<T: SolType>(attestation) -> T
+├── extract_demand_data::<T: SolType>(attestation) -> T
+├── get_escrow_attestation(fulfillment) -> Attestation
+├── get_escrow_and_demand::<T: SolType>(fulfillment) -> (Attestation, T)
+│
+├── erc20()
+│   ├── approve(&token, purpose) -> Receipt
+│   ├── approve_if_less(&token, purpose) -> Option<Receipt>
+│   ├── escrow()
+│   │   ├── non_tierable()
+│   │   │   ├── make_statement(token, amount, arbiter, demand, expiration) -> Receipt
+│   │   │   ├── collect_payment(escrow_uid, fulfillment_uid) -> Receipt
+│   │   │   ├── get_statement(uid) -> DecodedAttestation<ObligationData>
+│   │   │   └── decode_statement(bytes) -> ObligationData
+│   │   └── tierable()              // (same API with tier support)
+│   ├── payment()
+│   │   ├── make_statement(token, amount, payee, expiration, ref_uid) -> Receipt
+│   │   ├── get_statement(uid) -> DecodedAttestation<ObligationData>
+│   │   └── decode_statement(bytes) -> ObligationData
+│   ├── barter()
+│   │   ├── buy_erc20_for_erc20(&bid, &ask, expiration) -> Receipt
+│   │   ├── buy_erc20_for_erc721(&bid, &ask, expiration) -> Receipt
+│   │   ├── buy_erc721_for_erc20(&bid, &ask, expiration) -> Receipt
+│   │   ├── buy_erc20_for_erc1155(&bid, &ask, expiration) -> Receipt
+│   │   ├── buy_erc20_for_native(&bid, native_amount, expiration) -> Receipt
+│   │   └── buy_native_for_erc20(native_amount, &ask, expiration) -> Receipt
+│   └── util()
+│       └── permit-related helpers
+│
+├── erc721()                         // Same structure as erc20
+│   ├── approve(&token, purpose)
+│   ├── escrow().non_tierable() / .tierable()
+│   ├── payment()
+│   └── barter()
+│
+├── erc1155()
+│   ├── approve_all(token_address, purpose)
+│   ├── escrow().non_tierable() / .tierable()
+│   ├── payment()
+│   └── barter()
+│
+├── native_token()                   // No approval needed
+│   ├── escrow().non_tierable() / .tierable()
+│   ├── payment()
+│   └── barter()
+│
+├── token_bundle()
+│   ├── approve(&bundle, purpose)
+│   ├── escrow().non_tierable() / .tierable()
+│   ├── payment()
+│   └── barter()
+│
+├── attestation()
+│   ├── escrow().v1() / .v2()
+│   └── util()
+│
+├── string_obligation()
+│   ├── do_obligation(item, schema, ref_uid) -> Receipt
+│   ├── do_obligation_json(data, schema, ref_uid) -> Receipt
+│   ├── get_obligation(uid) -> DecodedAttestation<ObligationData>
+│   ├── decode(bytes) -> ObligationData
+│   ├── decode_json::<T>(bytes) -> T
+│   └── encode(&data) -> Bytes
+│
+├── commit_reveal()
+│   ├── do_obligation(&data, ref_uid) -> Receipt
+│   ├── commit(commitment) -> Receipt          // sends bond as ETH
+│   ├── compute_commitment(ref_uid, claimer, &data) -> FixedBytes<32>
+│   ├── reveal(ref_uid, claimer, &data) -> Receipt
+│   ├── claim(ref_uid, claimer_data) -> Receipt
+│   ├── claim_and_revoke_as_attester(ref_uid) -> Receipt
+│   ├── reclaim_bond(obligation_uid) -> Receipt
+│   ├── slash_bond(commitment) -> Receipt
+│   ├── get_obligation(uid) -> DecodedAttestation<ObligationData>
+│   ├── decode(bytes) -> ObligationData
+│   └── encode(&data) -> Bytes
+│
+├── arbiters()
+│   ├── trusted_oracle()
+│   │   ├── arbitrate(obligation, demand, decision) -> Receipt
+│   │   └── request_arbitration(obligation, oracle, demand) -> Receipt
+│   ├── logical()
+│   │   ├── decode_all_demand(bytes) -> (Vec<Address>, Vec<Bytes>)
+│   │   └── decode_any_demand(bytes) -> (Vec<Address>, Vec<Bytes>)
+│   ├── attestation_properties()
+│   │   ├── decode_attester_demand(bytes) -> Address
+│   │   ├── decode_recipient_demand(bytes) -> Address
+│   │   ├── decode_schema_demand(bytes) -> FixedBytes<32>
+│   │   ├── decode_uid_demand(bytes) -> FixedBytes<32>
+│   │   ├── decode_ref_uid_demand(bytes) -> FixedBytes<32>
+│   │   ├── decode_revocable_demand(bytes) -> bool
+│   │   ├── decode_time_after_demand(bytes) -> u64
+│   │   ├── decode_time_before_demand(bytes) -> u64
+│   │   └── ... (all property arbiters)
+│   └── decode_arbiter_demand(arbiter_addr, &bytes) -> DecodedDemand
+│
+└── oracle()                         // Alias for trusted_oracle
+    ├── arbitrate(obligation, demand, decision) -> Receipt
+    └── request_arbitration(obligation, oracle, demand) -> Receipt
+```
+
+## Address Helpers
+
+```rust
+client.erc20_address(Erc20Contract::EscrowObligation)     // -> Address
+client.erc20_address(Erc20Contract::PaymentObligation)
+client.erc20_address(Erc20Contract::BarterUtils)
+client.erc721_address(Erc721Contract::EscrowObligation)
+// ... same pattern for all modules
+client.arbiters_address(ArbitersContract::TrustedOracleArbiter)
+client.arbiters_address(ArbitersContract::AllArbiter)
+client.commit_reveal_obligation_address(CommitRevealObligationContract::Obligation)
+```
+
+## Key Types
+
+```rust
+// Token data
+struct Erc20Data { address: Address, value: U256 }
+struct Erc721Data { address: Address, id: U256 }
+struct Erc1155Data { address: Address, id: U256, value: U256 }
+struct NativeTokenData { value: U256 }
+struct TokenBundleData { erc20s: Vec<Erc20Data>, erc721s: Vec<Erc721Data>, erc1155s: Vec<Erc1155Data>, native_amount: U256 }
+
+// Demand
+struct ArbiterData { arbiter: Address, demand: Bytes }
+
+// Decoded attestation
+struct DecodedAttestation<T> { attestation: IEAS::Attestation, data: T }
+
+// Approval
+enum ApprovalPurpose { Escrow, Payment, BarterUtils }
+```
+
+## Important Patterns
+
+### Single-return-value calls
+
+Alloy returns primitives directly for single-return contract calls:
+
+```rust
+// Returns U256, not a struct
+let balance: U256 = contract.balanceOf(addr).call().await?;
+
+// Returns bool directly
+let is_claimed: bool = contract.isCommitmentClaimed(commitment).call().await?;
+```
+
+Only multi-return functions return structs with named fields.
+
+### Getting attestation UID from receipt
+
+```rust
+let receipt = client.erc20().escrow().non_tierable().make_statement(...).await?;
+let attested_event = client.get_attested_event(receipt)?;
+let uid = attested_event.inner.uid;
+```
+
+### ABI encoding demands
+
+Use alloy's `SolValue` trait:
+
+```rust
+use alloy::sol_types::SolValue;
+
+// Encode TrustedOracle demand
+let demand = TrustedOracleArbiter::DemandData {
+    oracle: oracle_address,
+    data: Bytes::new(),
+}.abi_encode();
+
+// Encode AllArbiter demand
+let demand = AllArbiter::DemandData {
+    arbiters: vec![arbiter_a, arbiter_b],
+    demands: vec![demand_a.into(), demand_b.into()],
+}.abi_encode();
+```
+
+## Predefined Address Configs
+
+```rust
+use alkahest_rs::{
+    BASE_SEPOLIA_ADDRESSES,           // Default
+    ETHEREUM_SEPOLIA_ADDRESSES,
+    FILECOIN_CALIBRATION_ADDRESSES,
+    ETHEREUM_ADDRESSES,
+};
+```

--- a/docs/skills/alkahest-developer/references/typescript-api.md
+++ b/docs/skills/alkahest-developer/references/typescript-api.md
@@ -1,0 +1,247 @@
+# Alkahest TypeScript SDK API Reference
+
+## Client Construction
+
+```typescript
+import { makeClient, makeMinimalClient } from "@alkahest/ts-sdk";
+import { createWalletClient, http } from "viem";
+import { privateKeyToAccount } from "viem/accounts";
+import { baseSepolia } from "viem/chains";
+
+const walletClient = createWalletClient({
+  account: privateKeyToAccount("0xKEY"),
+  chain: baseSepolia,
+  transport: http("https://rpc"),
+});
+
+// Full client (all extensions pre-loaded)
+const client = makeClient(walletClient);
+// With custom addresses:
+const client = makeClient(walletClient, customAddresses);
+
+// Minimal client (extend yourself)
+const minimal = makeMinimalClient(walletClient);
+const extended = minimal.extend((base) => ({
+  myErc20: makeErc20Client(base.viemClient, pickErc20Addresses(base.contractAddresses)),
+}));
+```
+
+## Address Configuration
+
+```typescript
+import { contractAddresses, supportedChains } from "@alkahest/ts-sdk";
+
+// Chains: "Base Sepolia", "Sepolia", "Filecoin Calibration", "Ethereum"
+const addresses = contractAddresses["Base Sepolia"];
+```
+
+Auto-detected from viem client's chain. Override with second arg to `makeClient`.
+
+## Core Types
+
+```typescript
+type Erc20 = { address: `0x${string}`; value: bigint };
+type Erc721 = { address: `0x${string}`; id: bigint };
+type Erc1155 = { address: `0x${string}`; id: bigint; value: bigint };
+type TokenBundle = { erc20s: Erc20[]; erc721s: Erc721[]; erc1155s: Erc1155[] };
+type Demand = { arbiter: `0x${string}`; demand: `0x${string}` };
+type Attestation = {
+  uid: `0x${string}`; schema: `0x${string}`; time: bigint;
+  expirationTime: bigint; revocationTime: bigint; refUID: `0x${string}`;
+  recipient: `0x${string}`; attester: `0x${string}`; revocable: boolean;
+  data: `0x${string}`;
+};
+```
+
+## Full API Tree
+
+```
+client
+├── address                           // Connected wallet address
+├── contractAddresses                 // All deployed addresses for this chain
+├── viemClient                        // Underlying viem client
+│
+├── getAttestation(uid)               // Fetch EAS attestation
+├── getAttestedEventFromTxHash(hash)  // Extract Attested event from tx
+├── waitForFulfillment(contract, escrowUid, pollingInterval?)
+├── extractObligationData(abi, attestation)
+├── extractDemandData(abi, escrowAttestation)
+├── getEscrowAttestation(fulfillment)
+├── getEscrowAndDemand(demandAbi, fulfillment)
+├── decodeDemand({ arbiter, demand })
+│
+├── arbiters
+│   ├── general
+│   │   ├── intrinsics               // (no methods — use address only)
+│   │   ├── intrinsics2
+│   │   │   ├── encodeDemand({ schema })
+│   │   │   └── decodeDemand(bytes)   // => { schema }
+│   │   └── trustedOracle
+│   │       ├── encodeDemand({ oracle, data })
+│   │       ├── decodeDemand(bytes)   // => { oracle, data }
+│   │       ├── arbitrate(attestation, decision)
+│   │       └── arbitrateMany({ mode, pollingInterval, onAfterArbitrate, ... })
+│   │
+│   ├── logical
+│   │   ├── all
+│   │   │   ├── encodeDemand({ arbiters[], demands[] })
+│   │   │   ├── decodeDemand(bytes)
+│   │   │   └── decodeDemandRecursive(bytes, decoders)
+│   │   └── any                       // (same API as all)
+│   │
+│   ├── attestationProperties
+│   │   ├── attester     .encodeDemand({ attester }) / .decodeDemand(bytes)
+│   │   ├── recipient    .encodeDemand({ recipient }) / .decodeDemand(bytes)
+│   │   ├── schema       .encodeDemand({ schema }) / .decodeDemand(bytes)
+│   │   ├── uid          .encodeDemand({ uid }) / .decodeDemand(bytes)
+│   │   ├── refUid       .encodeDemand({ refUID }) / .decodeDemand(bytes)
+│   │   ├── revocable    .encodeDemand({ revocable }) / .decodeDemand(bytes)
+│   │   ├── timeAfter    .encodeDemand({ time }) / .decodeDemand(bytes)
+│   │   ├── timeBefore   .encodeDemand({ time }) / .decodeDemand(bytes)
+│   │   ├── timeEqual    .encodeDemand({ time }) / .decodeDemand(bytes)
+│   │   ├── expirationTimeAfter  .encodeDemand({ expirationTime }) / .decodeDemand(bytes)
+│   │   ├── expirationTimeBefore .encodeDemand({ expirationTime }) / .decodeDemand(bytes)
+│   │   └── expirationTimeEqual  .encodeDemand({ expirationTime }) / .decodeDemand(bytes)
+│   │
+│   └── confirmation
+│       ├── exclusiveRevocable
+│       │   ├── confirm(escrow, fulfillment)
+│       │   ├── revokeConfirmation(escrow, fulfillment)
+│       │   └── isConfirmed(escrow, fulfillment)
+│       ├── exclusiveUnrevocable      // confirm, isConfirmed (no revoke)
+│       ├── nonexclusiveRevocable     // confirm, revokeConfirmation, isConfirmed
+│       └── nonexclusiveUnrevocable   // confirm, isConfirmed
+│
+├── erc20
+│   ├── util
+│   │   ├── signPermit(props)
+│   │   ├── getPermitSignature(spender, token, deadline)
+│   │   └── getPermitDeadline()
+│   ├── escrow
+│   │   ├── nonTierable
+│   │   │   ├── address
+│   │   │   ├── getSchema()
+│   │   │   ├── encodeObligation(token: Erc20, demand: Demand)
+│   │   │   ├── encodeObligationRaw({ token, amount, arbiter, demand })
+│   │   │   ├── decodeObligation(bytes)    // => { token, amount, arbiter, demand }
+│   │   │   ├── getObligation(uid)
+│   │   │   ├── doObligation(encodedData, refUID?)
+│   │   │   ├── collectObligation(escrowUid, fulfillmentUid)
+│   │   │   └── arbitrate(escrowUid, fulfillmentUid, decision)
+│   │   └── tierable                       // (same API with tier support)
+│   ├── payment
+│   │   ├── address
+│   │   ├── getSchema()
+│   │   ├── encodeObligation(token: Erc20, payee)
+│   │   ├── encodeObligationRaw({ token, amount, payee })
+│   │   ├── decodeObligation(bytes)        // => { token, amount, payee }
+│   │   ├── getObligation(uid)
+│   │   └── doObligation(encodedData, refUID?)
+│   └── barter
+│       ├── address
+│       ├── buyErc20ForErc20(bid: Erc20, ask: Erc20, expiration)
+│       ├── buyErc20ForNative(bid: Erc20, ethAmount, expiration)
+│       ├── buyNativeForErc20(ethAmount, ask: Erc20, expiration)
+│       ├── buyErc20ForErc721(bid: Erc20, ask: Erc721, expiration)
+│       ├── buyErc721ForErc20(bid: Erc721, ask: Erc20, expiration)
+│       ├── buyErc20ForErc1155(bid: Erc20, ask: Erc1155, expiration)
+│       ├── buyErc1155ForErc20(bid: Erc1155, ask: Erc20, expiration)
+│       └── ... (more cross-token combinations)
+│
+├── erc721                                 // Same structure as erc20
+│   ├── util (.approve)
+│   ├── escrow.nonTierable / .tierable
+│   ├── payment
+│   └── barter
+│
+├── erc1155                                // Same structure
+│   ├── util (.approveAll)
+│   ├── escrow.nonTierable / .tierable
+│   ├── payment
+│   └── barter
+│
+├── nativeToken                            // No util (no approvals needed)
+│   ├── escrow.nonTierable / .tierable
+│   ├── payment
+│   └── barter
+│
+├── bundle
+│   ├── util (.approve)
+│   ├── escrow.nonTierable / .tierable
+│   ├── payment
+│   └── barter
+│
+├── attestation
+│   ├── util
+│   └── escrow.v1 / .v2
+│
+├── stringObligation
+│   ├── address
+│   ├── encode({ item, schema })
+│   ├── decode(bytes)                      // => { item, schema }
+│   ├── decodeJson(bytes)                  // => parsed JSON
+│   ├── decodeZod(bytes, zodSchema)
+│   ├── decodeArkType(bytes, arkTypeSchema)
+│   ├── doObligation(item, schema?, refUID?)
+│   ├── doObligationJson(item, schema?, refUID?)
+│   ├── getSchema()
+│   ├── getObligation(uid)
+│   └── getJsonObligation(uid)
+│
+└── commitReveal
+    ├── address
+    ├── encode({ payload, salt, schema })
+    ├── decode(bytes)                      // => { payload, salt, schema }
+    ├── doObligation(data, refUID?)
+    ├── commit(commitment)                 // sends bond as ETH
+    ├── computeCommitment(refUID, claimer, data)
+    ├── reclaimBond(obligationUid)
+    ├── slashBond(commitment)
+    ├── getBondAmount()
+    ├── getCommitDeadline()
+    ├── getSlashedBondRecipient()
+    ├── getCommitment(commitment)          // => { claimer, amount, claimed }
+    ├── isCommitmentClaimed(commitment)
+    ├── getSchema()
+    └── getObligation(uid)
+```
+
+## Static Encode/Decode Exports
+
+For use without a client instance:
+
+```typescript
+import {
+  encodeAttesterDemand, decodeAttesterDemand,
+  encodeRecipientDemand, decodeRecipientDemand,
+  encodeTrustedOracleDemand, decodeTrustedOracleDemand,
+  encodeIntrinsics2Demand, decodeIntrinsics2Demand,
+  // ... all attestation property arbiters
+} from "@alkahest/ts-sdk";
+```
+
+## Permit vs Approve
+
+ERC20 tokens supporting EIP-2612 can use gasless approvals:
+
+```typescript
+// Standard approve (separate transaction)
+await client.erc20.util.approve({ address: TOKEN, value: amount }, "escrow");
+
+// Permit (signature-based, no separate tx)
+const permit = await client.erc20.util.getPermitSignature(
+  spenderAddress, TOKEN, deadline,
+);
+// Pass permit to barter utils that accept it
+```
+
+Barter utils have `permitAnd*` variants that accept permit signatures.
+
+## Return Types
+
+Most write methods return `{ hash: `0x${string}`, attested?: { uid, schema, ... } }`.
+
+- `hash` — transaction hash
+- `attested` — present when the transaction creates an EAS attestation (escrows, payments, obligations)
+
+Read methods return typed data directly.

--- a/docs/skills/alkahest-user/SKILL.md
+++ b/docs/skills/alkahest-user/SKILL.md
@@ -1,0 +1,297 @@
+---
+name: alkahest-user
+description: Interact with Alkahest escrow contracts as a buyer, seller, or oracle using the TypeScript SDK
+---
+
+# Alkahest User Skill
+
+## What is Alkahest?
+
+Alkahest is an EAS-based (Ethereum Attestation Service) escrow protocol for trustless exchanges on EVM chains. It enables:
+
+- **Token escrow** with programmable release conditions (ERC20, ERC721, ERC1155, native tokens, bundles)
+- **Arbiter-based validation** — release conditions are defined by arbiter contracts that check fulfillment
+- **Composable demands** — combine multiple conditions with AND/OR logic
+- **Oracle arbitration** — off-chain validation with on-chain decision submission
+- **Commit-reveal** — frontrunning protection for self-contained fulfillment data
+
+Supported chains: Base Sepolia, Sepolia, Filecoin Calibration, Ethereum mainnet.
+
+## Roles
+
+| Role | Description |
+|------|-------------|
+| **Buyer** | Creates escrow with assets + demand (what they want in return) |
+| **Seller** | Fulfills the demand to collect escrowed assets |
+| **Oracle** | Validates fulfillment and submits on-chain decisions (for TrustedOracleArbiter) |
+
+## Setup
+
+```typescript
+import { createWalletClient, http } from "viem";
+import { privateKeyToAccount } from "viem/accounts";
+import { baseSepolia } from "viem/chains";
+import { makeClient } from "@alkahest/ts-sdk";
+
+const walletClient = createWalletClient({
+  account: privateKeyToAccount("0xYOUR_PRIVATE_KEY"),
+  chain: baseSepolia,
+  transport: http("https://your-rpc-url"),
+});
+
+const client = makeClient(walletClient);
+```
+
+The client auto-detects the chain and loads the correct contract addresses. To use custom addresses, pass them as the second argument to `makeClient`.
+
+## Buyer Workflow: Create Escrow
+
+### 1. Approve tokens (if ERC20/ERC721/ERC1155)
+
+```typescript
+await client.erc20.util.approve(
+  { address: TOKEN_ADDRESS, value: amount },
+  "escrow"
+);
+```
+
+### 2. Encode your demand
+
+The demand specifies what fulfillment you require. Choose an arbiter and encode its demand data:
+
+```typescript
+// Example: require fulfillment validated by a trusted oracle
+const demand = {
+  arbiter: client.contractAddresses.trustedOracleArbiter,
+  demand: client.arbiters.general.trustedOracle.encodeDemand({
+    oracle: ORACLE_ADDRESS,
+    data: "0x", // optional extra data for the oracle
+  }),
+};
+```
+
+### 3. Create the escrow
+
+```typescript
+const { hash, attested } = await client.erc20.escrow.nonTierable.doObligation(
+  client.erc20.escrow.nonTierable.encodeObligationRaw({
+    token: TOKEN_ADDRESS,
+    amount: parseEther("1.0"),
+    arbiter: demand.arbiter,
+    demand: demand.demand,
+  }),
+);
+const escrowUid = attested.uid;
+```
+
+### 4. Wait for fulfillment
+
+```typescript
+const result = await client.waitForFulfillment(
+  client.contractAddresses.erc20EscrowObligation,
+  escrowUid,
+);
+// result contains: { payment, fulfillment, fulfiller }
+```
+
+### 5. Reclaim expired escrow (if unfulfilled)
+
+```typescript
+// Only works after the escrow's expirationTime has passed
+// Not available via SDK helper — call the contract directly if needed
+```
+
+## Seller Workflow: Fulfill Escrow
+
+### Using StringObligation (off-chain validated work)
+
+```typescript
+// 1. Create fulfillment referencing the escrow
+const { hash, attested } = await client.stringObligation.doObligation(
+  "Here is my completed deliverable",
+  undefined, // schema (optional)
+  escrowUid,  // refUID — links to the escrow
+);
+
+// 2. If escrow uses TrustedOracleArbiter, request arbitration
+await client.arbiters.general.trustedOracle.arbitrate(
+  attested.uid, // the fulfillment UID
+  true,         // approval decision (as oracle)
+);
+```
+
+### Using direct payment (token-for-token barter)
+
+```typescript
+// Atomic swap: buy ERC20 for ERC20
+const { hash } = await client.erc20.barter.buyErc20ForErc20(
+  { address: BID_TOKEN, value: bidAmount },  // what you're offering
+  { address: ASK_TOKEN, value: askAmount },  // what you want
+  BigInt(Math.floor(Date.now() / 1000) + 3600), // expiration
+);
+```
+
+## Oracle Workflow: Arbitrate
+
+### Manual arbitration
+
+```typescript
+// Submit decision for a specific fulfillment
+await client.arbiters.general.trustedOracle.arbitrate(
+  fulfillmentAttestation, // the attestation to judge
+  true,                    // decision: true = approve, false = reject
+);
+```
+
+### Auto-arbitration (listen and decide)
+
+```typescript
+const { decisions, unwatch } = await client.arbiters.general.trustedOracle.arbitrateMany({
+  mode: "listen",           // "listen" for live, "past" for historical
+  pollingInterval: 5000,    // ms
+  onAfterArbitrate: (uid, decision) => {
+    console.log(`Arbitrated ${uid}: ${decision}`);
+  },
+});
+```
+
+## Commit-Reveal Workflow
+
+Use commit-reveal when fulfillment data is self-contained (e.g., a string answer) to prevent frontrunning.
+
+### Seller: Commit then reveal
+
+```typescript
+// 1. Compute commitment hash
+const commitment = await client.commitReveal.computeCommitment(
+  escrowUid,               // the escrow being fulfilled
+  sellerAddress,           // claimer address
+  { payload: "0x...", salt: "0x...", schema: "0x..." },
+);
+
+// 2. Commit with bond (sends ETH)
+const bondAmount = await client.commitReveal.getBondAmount();
+await client.commitReveal.commit(commitment);
+// Bond amount is sent as msg.value automatically
+
+// 3. Wait at least 1 block, then reveal
+const { attested } = await client.commitReveal.doObligation(
+  { payload: encodedPayload, salt: randomSalt, schema: schemaTag },
+  escrowUid,
+);
+
+// 4. Reclaim bond after successful reveal
+await client.commitReveal.reclaimBond(attested.uid);
+```
+
+### Composing commit-reveal with other demands
+
+Use `AllArbiter` to require both commit-reveal AND other conditions:
+
+```typescript
+const demand = client.arbiters.logical.all.encodeDemand({
+  arbiters: [
+    client.contractAddresses.commitRevealObligation, // built-in arbiter
+    client.contractAddresses.trustedOracleArbiter,
+  ],
+  demands: [
+    "0x", // commit-reveal has no demand data
+    client.arbiters.general.trustedOracle.encodeDemand({
+      oracle: ORACLE_ADDRESS,
+      data: "0x",
+    }),
+  ],
+});
+```
+
+## Composing Demands
+
+### AllArbiter (AND logic)
+
+All conditions must be satisfied:
+
+```typescript
+const demand = client.arbiters.logical.all.encodeDemand({
+  arbiters: [ARBITER_1, ARBITER_2],
+  demands: [DEMAND_1, DEMAND_2],
+});
+```
+
+### AnyArbiter (OR logic)
+
+At least one condition must be satisfied:
+
+```typescript
+const demand = client.arbiters.logical.any.encodeDemand({
+  arbiters: [ARBITER_1, ARBITER_2],
+  demands: [DEMAND_1, DEMAND_2],
+});
+```
+
+### Nesting
+
+Arbiters compose arbitrarily:
+
+```typescript
+// (conditionA AND conditionB) OR conditionC
+const innerDemand = client.arbiters.logical.all.encodeDemand({
+  arbiters: [ARBITER_A, ARBITER_B],
+  demands: [DEMAND_A, DEMAND_B],
+});
+const outerDemand = client.arbiters.logical.any.encodeDemand({
+  arbiters: [client.contractAddresses.allArbiter, ARBITER_C],
+  demands: [innerDemand, DEMAND_C],
+});
+```
+
+## Confirmation Arbiters
+
+For manual buyer-side approval of fulfillments:
+
+```typescript
+// Buyer confirms a fulfillment
+await client.arbiters.confirmation.exclusiveRevocable.confirm(escrowUid, fulfillmentUid);
+
+// Buyer revokes confirmation (if revocable)
+await client.arbiters.confirmation.exclusiveRevocable.revokeConfirmation(escrowUid, fulfillmentUid);
+
+// Check confirmation status
+const confirmed = await client.arbiters.confirmation.exclusiveRevocable.isConfirmed(escrowUid, fulfillmentUid);
+```
+
+Variants: `exclusiveRevocable`, `exclusiveUnrevocable`, `nonexclusiveRevocable`, `nonexclusiveUnrevocable`.
+
+## Decoding Attestations
+
+```typescript
+// Get an attestation by UID
+const attestation = await client.getAttestation(uid);
+
+// Decode obligation data from an escrow attestation
+const data = client.extractObligationData(erc20EscrowObligationAbi, attestation);
+
+// Decode demand from an escrow attestation
+const demandData = client.extractDemandData(trustedOracleArbiterDemandAbi, escrowAttestation);
+
+// Generic demand decoder (auto-detects arbiter type)
+const decoded = client.decodeDemand({ arbiter: arbiterAddress, demand: demandBytes });
+```
+
+## Escrow Types
+
+| Type | What's escrowed | Key fields |
+|------|----------------|------------|
+| ERC20 | Fungible tokens | `token`, `amount` |
+| ERC721 | NFTs | `token`, `id` |
+| ERC1155 | Semi-fungible tokens | `token`, `id`, `amount` |
+| Native Token | ETH/native currency | `amount` |
+| Token Bundle | Mix of all token types | `erc20s`, `erc721s`, `erc1155s` |
+| Attestation | EAS attestations | `attestation` (AttestationRequest) |
+
+All escrow types share the same workflow: approve -> encode obligation -> doObligation -> wait -> collect.
+
+## Additional Resources
+
+- Use the `alkahest-docs` MCP server for looking up contract details and addresses
+- See `references/contracts.md` for all contract addresses and obligation data schemas
+- See `references/arbiters.md` for all arbiter types and demand encoding patterns

--- a/docs/skills/alkahest-user/references/arbiters.md
+++ b/docs/skills/alkahest-user/references/arbiters.md
@@ -1,0 +1,279 @@
+# Alkahest Arbiter Reference
+
+Arbiters are contracts that validate whether a fulfillment satisfies an escrow's demand. Every arbiter implements:
+
+```solidity
+function checkObligation(
+    Attestation memory obligation,
+    bytes memory demand,
+    bytes32 fulfilling
+) external view returns (bool)
+```
+
+## General Arbiters
+
+### TrivialArbiter
+
+Always returns true. Use when no validation is needed (e.g., anyone can claim).
+
+**Demand data:** none (empty bytes `0x`)
+
+```typescript
+const demand = {
+  arbiter: client.contractAddresses.trivialArbiter,
+  demand: "0x",
+};
+```
+
+### IntrinsicsArbiter
+
+Validates attestation is not expired and not revoked.
+
+**Demand data:** none (empty bytes `0x`)
+
+```typescript
+const demand = {
+  arbiter: client.contractAddresses.intrinsicsArbiter,
+  demand: "0x",
+};
+```
+
+### IntrinsicsArbiter2
+
+Validates intrinsics (not expired, not revoked) AND that the fulfillment's schema matches.
+
+**Demand data:** `{ schema: bytes32 }`
+
+```typescript
+const demand = {
+  arbiter: client.contractAddresses.intrinsicsArbiter2,
+  demand: client.arbiters.general.intrinsics2.encodeDemand({
+    schema: "0x...", // required schema UID
+  }),
+};
+```
+
+### TrustedOracleArbiter
+
+Asynchronous arbitration — an oracle submits a decision on-chain.
+
+**Demand data:** `{ oracle: address, data: bytes }`
+
+```typescript
+// Encode demand
+const demand = {
+  arbiter: client.contractAddresses.trustedOracleArbiter,
+  demand: client.arbiters.general.trustedOracle.encodeDemand({
+    oracle: "0xOracleAddress",
+    data: "0x", // optional extra data for the oracle
+  }),
+};
+
+// Decode demand
+const decoded = client.arbiters.general.trustedOracle.decodeDemand(demandBytes);
+// => { oracle: "0x...", data: "0x..." }
+
+// Oracle submits decision
+await client.arbiters.general.trustedOracle.arbitrate(
+  fulfillmentAttestation, // attestation UID
+  true,                    // decision
+);
+
+// Auto-arbitrate (listen for requests)
+await client.arbiters.general.trustedOracle.arbitrateMany({
+  mode: "listen",
+  pollingInterval: 5000,
+  onAfterArbitrate: (uid, decision) => console.log(uid, decision),
+});
+```
+
+### ERC8004Arbiter
+
+Validates against an ERC-8004 ValidationRegistry.
+
+**Demand data:** `{ validationRegistry: address, validatorAddress: address, minResponse: uint8 }`
+
+## Attestation Property Arbiters
+
+These arbiters validate individual properties of EAS attestations.
+
+| Arbiter | Demand data | Validates |
+|---------|------------|-----------|
+| `AttesterArbiter` | `{ attester: address }` | `attestation.attester == attester` |
+| `RecipientArbiter` | `{ recipient: address }` | `attestation.recipient == recipient` |
+| `SchemaArbiter` | `{ schema: bytes32 }` | `attestation.schema == schema` |
+| `UidArbiter` | `{ uid: bytes32 }` | `attestation.uid == uid` |
+| `RefUidArbiter` | `{ refUID: bytes32 }` | `attestation.refUID == refUID` |
+| `RevocableArbiter` | `{ revocable: bool }` | `attestation.revocable == revocable` |
+| `TimeAfterArbiter` | `{ time: uint64 }` | `attestation.time >= time` |
+| `TimeBeforeArbiter` | `{ time: uint64 }` | `attestation.time <= time` (0 = no constraint) |
+| `TimeEqualArbiter` | `{ time: uint64 }` | `attestation.time == time` |
+| `ExpirationTimeAfterArbiter` | `{ expirationTime: uint64 }` | `attestation.expirationTime >= expirationTime` |
+| `ExpirationTimeBeforeArbiter` | `{ expirationTime: uint64 }` | `attestation.expirationTime <= expirationTime` |
+| `ExpirationTimeEqualArbiter` | `{ expirationTime: uint64 }` | `attestation.expirationTime == expirationTime` |
+
+### Encoding attestation property demands (TS SDK)
+
+Each property arbiter has an `encodeDemand`/`decodeDemand` pair under `client.arbiters.attestationProperties`:
+
+```typescript
+// Encode
+const demand = client.arbiters.attestationProperties.attester.encodeDemand({
+  attester: "0xRequiredAttester",
+});
+
+// Decode
+const decoded = client.arbiters.attestationProperties.attester.decodeDemand(demandBytes);
+// => { attester: "0x..." }
+
+// Available: attester, recipient, schema, uid, refUid, revocable,
+//            timeAfter, timeBefore, timeEqual,
+//            expirationTimeAfter, expirationTimeBefore, expirationTimeEqual
+```
+
+## Logical Arbiters
+
+### AllArbiter (AND)
+
+All sub-arbiters must return true.
+
+**Demand data:** `{ arbiters: address[], demands: bytes[] }`
+
+```typescript
+// Encode
+const demand = client.arbiters.logical.all.encodeDemand({
+  arbiters: [ARBITER_A, ARBITER_B],
+  demands: [DEMAND_A, DEMAND_B],
+});
+
+// Decode
+const decoded = client.arbiters.logical.all.decodeDemand(demandBytes);
+// => { arbiters: [...], demands: [...] }
+
+// Recursive decode (resolves nested arbiters)
+const tree = client.arbiters.logical.all.decodeDemandRecursive(demandBytes, {
+  [ARBITER_A]: (bytes) => ({ type: "attester", ...decodeAttesterDemand(bytes) }),
+  // ... decoders for each arbiter address
+});
+```
+
+### AnyArbiter (OR)
+
+At least one sub-arbiter must return true. Continues on errors (a reverting sub-arbiter counts as false).
+
+**Demand data:** `{ arbiters: address[], demands: bytes[] }` (same as AllArbiter)
+
+```typescript
+const demand = client.arbiters.logical.any.encodeDemand({
+  arbiters: [ARBITER_A, ARBITER_B],
+  demands: [DEMAND_A, DEMAND_B],
+});
+```
+
+### Nesting example
+
+```typescript
+// (attester is Alice AND time > deadline) OR (oracle approves)
+const innerDemand = client.arbiters.logical.all.encodeDemand({
+  arbiters: [
+    client.contractAddresses.attesterArbiter,
+    client.contractAddresses.timeAfterArbiter,
+  ],
+  demands: [
+    client.arbiters.attestationProperties.attester.encodeDemand({
+      attester: ALICE,
+    }),
+    client.arbiters.attestationProperties.timeAfter.encodeDemand({
+      time: BigInt(deadline),
+    }),
+  ],
+});
+
+const outerDemand = client.arbiters.logical.any.encodeDemand({
+  arbiters: [
+    client.contractAddresses.allArbiter,
+    client.contractAddresses.trustedOracleArbiter,
+  ],
+  demands: [
+    innerDemand,
+    client.arbiters.general.trustedOracle.encodeDemand({
+      oracle: ORACLE,
+      data: "0x",
+    }),
+  ],
+});
+```
+
+## Confirmation Arbiters
+
+Confirmation arbiters require the escrow creator (buyer) to manually confirm fulfillment.
+
+| Variant | Multiple fulfillments? | Can revoke? |
+|---------|----------------------|-------------|
+| `ExclusiveRevocable` | No (one only) | Yes |
+| `ExclusiveUnrevocable` | No (one only) | No |
+| `NonexclusiveRevocable` | Yes (many) | Yes |
+| `NonexclusiveUnrevocable` | Yes (many) | No |
+
+**Demand data:** none (confirmation state is stored in the arbiter contract)
+
+```typescript
+// Use as demand (no demand data needed)
+const demand = {
+  arbiter: client.contractAddresses.exclusiveRevocableConfirmationArbiter,
+  demand: "0x",
+};
+
+// Buyer confirms fulfillment
+await client.arbiters.confirmation.exclusiveRevocable.confirm(escrowUid, fulfillmentUid);
+
+// Buyer revokes (revocable variants only)
+await client.arbiters.confirmation.exclusiveRevocable.revokeConfirmation(escrowUid, fulfillmentUid);
+
+// Check status
+const isConfirmed = await client.arbiters.confirmation.exclusiveRevocable.isConfirmed(
+  escrowUid,
+  fulfillmentUid,
+);
+```
+
+## CommitRevealObligation as Arbiter
+
+`CommitRevealObligation` implements `IArbiter` — it verifies that the fulfiller committed to their data in an earlier block.
+
+**Demand data:** none (empty bytes `0x`)
+
+Use with `AllArbiter` to combine commit-reveal protection with other conditions:
+
+```typescript
+const demand = client.arbiters.logical.all.encodeDemand({
+  arbiters: [
+    client.contractAddresses.commitRevealObligation, // verifies commitment
+    client.contractAddresses.trustedOracleArbiter,    // verifies quality
+  ],
+  demands: [
+    "0x",
+    client.arbiters.general.trustedOracle.encodeDemand({
+      oracle: ORACLE,
+      data: "0x",
+    }),
+  ],
+});
+```
+
+## Payment Obligations as Arbiters
+
+`ERC20PaymentObligation`, `ERC721PaymentObligation`, etc. also implement `IArbiter`. They validate that the fulfillment attestation was created by the corresponding payment contract with matching token/amount/payee data.
+
+This is how barter (token-for-token) works: the escrow's arbiter is the payment obligation contract, and the demand encodes what payment is expected.
+
+```typescript
+// Escrow ERC20, demand ERC721 payment as fulfillment
+const demand = {
+  arbiter: client.contractAddresses.erc721PaymentObligation,
+  demand: client.erc721.payment.encodeObligation(
+    { address: NFT_ADDRESS, id: tokenId },
+    escrowCreator, // payee must be the escrow creator
+  ),
+};
+```

--- a/docs/skills/alkahest-user/references/contracts.md
+++ b/docs/skills/alkahest-user/references/contracts.md
@@ -1,0 +1,271 @@
+# Alkahest Contract Reference
+
+## Escrow Obligation Types
+
+Each escrow locks assets in a contract until an arbiter validates fulfillment.
+
+| Type | Contract | ObligationData fields |
+|------|----------|----------------------|
+| ERC20 | `ERC20EscrowObligation` | `token: address`, `amount: uint256`, `arbiter: address`, `demand: bytes` |
+| ERC721 | `ERC721EscrowObligation` | `token: address`, `tokenId: uint256`, `arbiter: address`, `demand: bytes` |
+| ERC1155 | `ERC1155EscrowObligation` | `token: address`, `tokenId: uint256`, `amount: uint256`, `arbiter: address`, `demand: bytes` |
+| Native Token | `NativeTokenEscrowObligation` | `amount: uint256`, `arbiter: address`, `demand: bytes` |
+| Token Bundle | `TokenBundleEscrowObligation` | `nativeAmount: uint256`, `erc20Tokens: address[]`, `erc20Amounts: uint256[]`, `erc721Tokens: address[]`, `erc721TokenIds: uint256[]`, `erc1155Tokens: address[]`, `erc1155TokenIds: uint256[]`, `erc1155Amounts: uint256[]`, `arbiter: address`, `demand: bytes` |
+| Attestation (v1) | `AttestationEscrowObligation` | `attestation: AttestationRequest`, `arbiter: address`, `demand: bytes` |
+| Attestation (v2) | `AttestationEscrowObligation2` | `attestation: AttestationRequest`, `arbiter: address`, `demand: bytes` |
+
+### Escrow lifecycle
+
+1. `doObligation(data, expirationTime)` — lock assets, create EAS attestation
+2. Fulfiller creates fulfillment attestation with `refUID` pointing to escrow
+3. `collectEscrow(escrowUid, fulfillmentUid)` — arbiter validates, releases assets
+4. `reclaimExpired(uid)` — reclaim assets after expiration (buyer only)
+
+## Payment Obligation Types
+
+Payments transfer assets immediately upon attestation creation (no escrow hold).
+
+| Type | Contract | ObligationData fields |
+|------|----------|----------------------|
+| ERC20 | `ERC20PaymentObligation` | `token: address`, `amount: uint256`, `payee: address` |
+| ERC721 | `ERC721PaymentObligation` | `token: address`, `tokenId: uint256`, `payee: address` |
+| ERC1155 | `ERC1155PaymentObligation` | `token: address`, `tokenId: uint256`, `amount: uint256`, `payee: address` |
+| Native Token | `NativeTokenPaymentObligation` | `amount: uint256`, `payee: address` |
+| Token Bundle | `TokenBundlePaymentObligation` | `nativeAmount: uint256`, `erc20Tokens: address[]`, `erc20Amounts: uint256[]`, `erc721Tokens: address[]`, `erc721TokenIds: uint256[]`, `erc1155Tokens: address[]`, `erc1155TokenIds: uint256[]`, `erc1155Amounts: uint256[]`, `payee: address` |
+
+## Fulfillment Obligation Types
+
+| Type | Contract | ObligationData fields |
+|------|----------|----------------------|
+| String | `StringObligation` | `item: string`, `schema: bytes32` |
+| Commit-Reveal | `CommitRevealObligation` | `payload: bytes`, `salt: bytes32`, `schema: bytes32` |
+
+### CommitRevealObligation details
+
+- `commit(commitment)` — submit hash commitment with ETH bond
+- `doObligation(data, refUID)` — reveal fulfillment data
+- `computeCommitment(refUID, claimer, data)` — compute expected commitment hash
+- `reclaimBond(obligationUid)` — reclaim bond after valid reveal
+- `slashBond(commitment)` — slash bond if reveal deadline passes
+- Commitment hash: `keccak256(abi.encode(refUID, claimer, keccak256(abi.encode(obligationData))))`
+- Built-in `IArbiter` implementation verifies commitment exists in an earlier block
+
+## Barter Utilities
+
+Barter utils combine escrow + payment into atomic single-transaction swaps.
+
+| Contract | Supported swaps |
+|----------|----------------|
+| `ERC20BarterUtils` | ERC20↔ERC20, ERC20↔ERC721, ERC20↔ERC1155, ERC20↔Bundle, ERC20↔ETH (with permit support) |
+| `NativeTokenBarterUtils` | ETH↔ERC20, ETH↔ERC721, ETH↔ERC1155, ETH↔Bundle, ETH↔ETH |
+| `TokenBundleBarterUtils` | Bundle↔Bundle (with multi-permit support) |
+
+## Contract Addresses
+
+### Base Sepolia
+
+| Contract | Address |
+|----------|---------|
+| EAS | `0x4200000000000000000000000000000000000021` |
+| EAS Schema Registry | `0x4200000000000000000000000000000000000020` |
+| **ERC20** | |
+| ERC20EscrowObligation | `0x1Fe964348Ec42D9Bb1A072503ce8b4744266FF43` |
+| ERC20PaymentObligation | `0x8d13d7542E64D9Da29AB66B6E9b4a6583C64b3F6` |
+| ERC20BarterUtils | `0x946Ef4E912897B4A24b9250513dfeE3fc4303Dde` |
+| **ERC721** | |
+| ERC721EscrowObligation | `0x7675a56b2880EF059cFC725E715E1139D689c07B` |
+| ERC721PaymentObligation | `0x9Daf829f183cA46ad2146F489E7d14335C9B59a9` |
+| ERC721BarterUtils | `0x707f280Fa738b4cc175A369d450f2f603094cbAf` |
+| **ERC1155** | |
+| ERC1155EscrowObligation | `0xB8A3107DA5428a34f818ea4229233fBAe59C16F2` |
+| ERC1155PaymentObligation | `0x6f71429bD940Bf3345780a8E5F5cf3BcdffE80C1` |
+| ERC1155BarterUtils | `0x4E4F0F883B1fEC20F219E0c8D2ec0061FE3c1328` |
+| **Native Token** | |
+| NativeTokenEscrowObligation | `0x8a1172D32B8cEf14094cF1E7d6F3d1A36D949FDe` |
+| NativeTokenPaymentObligation | `0xAB1E9714fbD4f9B5546e891B7Ba392b08c44c37A` |
+| NativeTokenBarterUtils | `0xaaB70Cfc37C5E73e185E2976609A82Ba22A4310d` |
+| **Token Bundle** | |
+| TokenBundleEscrowObligation | `0x38e8E5684aFB24A88cD9B276032bCBD19C4b9d6e` |
+| TokenBundlePaymentObligation | `0xFa5446475De31fa3c6457E2b62EA5a8F8172Cd29` |
+| TokenBundleBarterUtils | `0x47C033F49D5A1559AC48f27571204a29b8E728b8` |
+| **Attestation** | |
+| AttestationEscrowObligation | `0x9D133Cbd51270a2A410465F82dAFFD6c1C87322D` |
+| AttestationEscrowObligation2 | `0xa076e9ca47f192E6AfB67817608E382074CF0Dcf` |
+| AttestationBarterUtils | `0x84D390BCd90d5f65D14ff66f6860DCa45e776666` |
+| **Fulfillment** | |
+| StringObligation | `0x544873C22A3228798F91a71C4ef7a9bFe96E7CE0` |
+| CommitRevealObligation | `0x447b11ce03237f0C674eF7F16c913c3B2e8ef494` |
+| **Arbiters** | |
+| TrivialArbiter | `0x50EDa6c29C740bfbA6875422287025D985b96b7b` |
+| TrustedOracleArbiter | `0x3664b11BcCCeCA27C21BBAB43548961eD14d4D6D` |
+| AllArbiter | `0x0D95c1Cd62cd9C7cCCB237a3Ae08aA61Ed83381f` |
+| AnyArbiter | `0xaaC3465f340C7A2841A120F81Ce6744cda00d263` |
+| IntrinsicsArbiter | `0x24aAFec3f86CAd330600dD2397DEB8498D44bfd9` |
+| IntrinsicsArbiter2 | `0x51a28Ad45BE6eb6fd6D76af56a7D62ECd99547C7` |
+| ERC8004Arbiter | `0x67B23406dd9e9EA884B3d14746ef73106b1C35d6` |
+| ExclusiveRevocableConfirmationArbiter | `0xBA0e678f4F1a62f5d737F9289B7e1F2F8580DD8D` |
+| ExclusiveUnrevocableConfirmationArbiter | `0x141Bfd94A1C2B2728dF693657d1C7589b06A139E` |
+| NonexclusiveRevocableConfirmationArbiter | `0xB78A1870C5412EBa6042a5b1dE895E8f879AbeC6` |
+| NonexclusiveUnrevocableConfirmationArbiter | `0x74FaFAAEa1bA879E73Cd7e38ec6F3ff86554D4B7` |
+| RecipientArbiter | `0xE6CB55B60b6B47B45de05df75B48D656E4bD3730` |
+| AttesterArbiter | `0xB0d19784373EC5FDd2E44A2b594B10FE9bBecC94` |
+| SchemaArbiter | `0xc15Ef82Adf03820dA8a0705200602107a06652BE` |
+| UidArbiter | `0x0Be4E6D777D5C1AE3DDF338AF2398A279571511b` |
+| RefUidArbiter | `0xdEc95668f431639AAE975CfA9101Bb2A5b5803F6` |
+| RevocableArbiter | `0x550eF7e901F612914651f3c92c0798eBab037AF6` |
+| TimeAfterArbiter | `0xd88274b04194bebA06B32D3F67265e4b530F4C4d` |
+| TimeBeforeArbiter | `0xEC177a4FA6c42B1EA2bbEC70F3FFaE2aCD94e4aF` |
+| TimeEqualArbiter | `0x0E16A9f94aD457214d5e8AdD30c64D8c6FD4a416` |
+| ExpirationTimeAfterArbiter | `0x05Ae296859454612a9a346B2EeBE6915319993Ec` |
+| ExpirationTimeBeforeArbiter | `0x698008cC7F4714D331Aa27278BfE6B74FA925cF7` |
+| ExpirationTimeEqualArbiter | `0x4d05EA86C2C0af7CA94dc71Da45aba9368e664e4` |
+
+### Sepolia
+
+| Contract | Address |
+|----------|---------|
+| EAS | `0xC2679fBD37d54388Ce493F1DB75320D236e1815e` |
+| EAS Schema Registry | `0x0a7E2Ff54e76B8E6659aedc9103FB21c038050D0` |
+| ERC20EscrowObligation | `0xB2c808911E84E80156101983897Da7c80e13cB47` |
+| ERC20PaymentObligation | `0xb822aA07F55a8B75Ee133ede1f21C4E49DE7952f` |
+| ERC20BarterUtils | `0x5bf7c8b0d60d05af0a3De531EB876De271E80dbc` |
+| ERC721EscrowObligation | `0x2A7df117e45D93d34a7893CC3aE8B105Ae0B561C` |
+| ERC721PaymentObligation | `0x59A9c929778Ad2cC4D5DB6151bDEf0F9Fa7A068C` |
+| ERC721BarterUtils | `0xEB0C0c41F708B8b3556a6F44a1a015a6832C2d2C` |
+| ERC1155EscrowObligation | `0xf04d9CA943f57353A3A735494E503280C1cD5e77` |
+| ERC1155PaymentObligation | `0x52748DD0E39eD6eA9f626179b5eb512302adA7D9` |
+| ERC1155BarterUtils | `0x52De4B30721b3E3660A79da7491a9B2F8a9cB1D5` |
+| NativeTokenEscrowObligation | `0x9bA50DB048d1E5db034377abf97F92496D027C71` |
+| NativeTokenPaymentObligation | `0xf60db64506E366a0A6c1f4cF9D849Adc7bB886D6` |
+| NativeTokenBarterUtils | `0xA42032D8BFeE2302cC6F80ff51D283Ffc5a4081f` |
+| TokenBundleEscrowObligation | `0x677Aa9e1CD9D05f57FbCa2327155EA7479ec7Ac3` |
+| TokenBundlePaymentObligation | `0x36Fcf1Ddee838a94B1358285A11e8bbbb90eD9A1` |
+| TokenBundleBarterUtils | `0xA7EacA68Bffc9443eA08fd58633Eeed3f5EE8A92` |
+| AttestationEscrowObligation | `0x6eb7792D821f32914Be75901F1b4269B13Efad2e` |
+| AttestationEscrowObligation2 | `0x1A7c6F951e0a33F4910dbe56a200Eb413AEca17b` |
+| AttestationBarterUtils | `0x5E6602F080E9B37267aa52306c699ae54Cd71056` |
+| StringObligation | `0xC51C938f5497be8157DAf8CCc3Eb11Afb8b752C0` |
+| CommitRevealObligation | `0x9fD6D7A3B4e4b5dD75c50F5f16Deba46162127C3` |
+| TrivialArbiter | `0x594E79466b6ac01C6416C929e428264a4bdF0C92` |
+| TrustedOracleArbiter | `0x3B2a812E3eb3B729D40d866Da16c2BB2b6cDd2f2` |
+| AllArbiter | `0x847F69d27E4F1A8a115aCa3F4358B079706dc9CE` |
+| AnyArbiter | `0xe968dFA581B8aBb94eC5F24d0b56163DE69511fD` |
+| IntrinsicsArbiter | `0xaabdDAa76651d20922d1F561f924a40F6fE7710c` |
+| IntrinsicsArbiter2 | `0xF486f9a62eeb085e99828e1D706bBA5dfC1bD1fD` |
+| ERC8004Arbiter | `0x367fEd55E65bd0FCCF8F966A04989AB61E1b5A49` |
+| ExclusiveRevocableConfirmationArbiter | `0x941044D43F9d75dfA8Ad24880B9B9cAD6e116a66` |
+| ExclusiveUnrevocableConfirmationArbiter | `0x16aeE626D398B547eDD5fa4BdAA638524C92921d` |
+| NonexclusiveRevocableConfirmationArbiter | `0xe483EDA58b5f9Eba06A1ad0151dA5e4a5fFC8300` |
+| NonexclusiveUnrevocableConfirmationArbiter | `0x01666d869918aDDDED1B30eF2d36f3C990F09BDE` |
+| RecipientArbiter | `0xF1C9E20078A13816ACdDF3153e2eAaDd93Fd6E57` |
+| AttesterArbiter | `0x6CC4068d471E96A1669097918e18017f5764f72a` |
+| SchemaArbiter | `0x913eAdD13dcCdeD9CD5518075083b6C7A9574A8c` |
+| UidArbiter | `0xae4fa2D5d7EDD6Aaf697dC0c98EDb921F0fEc058` |
+| RefUidArbiter | `0xE9ee2c57B18283b66d342D33d63C55f1427f9e9B` |
+| RevocableArbiter | `0xeda25079f76ef93c54cC042116Be8D88E49D3439` |
+| TimeAfterArbiter | `0x0ea9e144FfDc6456E5cE8d1f75c686112e8f29c5` |
+| TimeBeforeArbiter | `0x68A6e6022ab9984Ee1A9A6cee384FF2aE8be5264` |
+| TimeEqualArbiter | `0x208385Fb349c01af2CfA8C6b86F633F6642718e2` |
+| ExpirationTimeAfterArbiter | `0x309509db364526C7aE202eA9ED94a398a0819d38` |
+| ExpirationTimeBeforeArbiter | `0xFAf8a07709dB9f90d0A0415876CfE00D904cd40B` |
+| ExpirationTimeEqualArbiter | `0x7c782ac7741BB78DB7491Ee222af0a04f7f2bc0b` |
+
+### Filecoin Calibration
+
+| Contract | Address |
+|----------|---------|
+| EAS | `0x3c79a0225380fB6F3CB990FfC4E3D5aF4546b524` |
+| EAS Schema Registry | `0x2BB94a4E6eC0D81dE7f81007b572Ac09A5BE37b4` |
+| ERC20EscrowObligation | `0x6bcec91a89a63d50368bce54cb9ed0399992c18b` |
+| ERC20PaymentObligation | `0x33f6f558c1fcac597f2b635bc50554055ff98165` |
+| ERC20BarterUtils | `0xb5800e34602154ce92c5eb0e7cb455306d7d590e` |
+| ERC721EscrowObligation | `0x99f5335b95e1c0be4c218a59aae26efc50d5673f` |
+| ERC721PaymentObligation | `0x5b6bff4dc108c58b97721330666f56c8028c097c` |
+| ERC721BarterUtils | `0x797a737defb8cae0a30324ecfa52eaab9c0a5fd6` |
+| ERC1155EscrowObligation | `0xf9dbc74553faecac775201113198085c4d572805` |
+| ERC1155PaymentObligation | `0x4cb076af47f0f3909ebafd88cbc0c4cc8dee17dd` |
+| ERC1155BarterUtils | `0x850d8df3ff0149bd5a9191a958b287b25564716b` |
+| NativeTokenEscrowObligation | `0x7490102a8b821c70679508426823f26c9bab4714` |
+| NativeTokenPaymentObligation | `0xd511278d5b9e5f8f9b99d01ea326b8232c133be5` |
+| NativeTokenBarterUtils | `0x3c07027874650794eae300c603f066af182ea86a` |
+| TokenBundleEscrowObligation | `0x902ac1997bd29a037263e0d80952c80d69d9afd4` |
+| TokenBundlePaymentObligation | `0xc1b02efec19a171ecbb7c8ad54b9617e80fdf40f` |
+| TokenBundleBarterUtils | `0xfca2c2df4023a0a418bf354b5bfff1ebfe0520a9` |
+| AttestationEscrowObligation | `0xd59c6c6cb025e76a0a1e706c62a9df38b04694e2` |
+| AttestationEscrowObligation2 | `0xa22b4d9fe7a746d44be1e724bb1a26593bca2c1b` |
+| AttestationBarterUtils | `0xcda1e1ea425e31a789feffc8e3d90f839ff49c9f` |
+| StringObligation | `0x66c3f78258823b9b899ab14b11e1dcf978c060d7` |
+| CommitRevealObligation | `0x32889Ee549d61Ed5D14f2D499fCc809a4feC0dD8` |
+| TrivialArbiter | `0xd56bd862e7bebd0bd7356603e9e52b32c241e2ae` |
+| TrustedOracleArbiter | `0x61dc9c2d757a1c9d0d38a281288d9ef918e77baa` |
+| AllArbiter | `0x49026902790a8ecb427f335ca0d097c7c5795d13` |
+| AnyArbiter | `0xb6890a8cb8cdefce11edc0314125b750f48bff1b` |
+| IntrinsicsArbiter | `0x81dc8f2c5677b02afcafef34fa7e75d55dfaef20` |
+| IntrinsicsArbiter2 | `0x7b20a4b25af2a2637c240622d6c3875dea609a64` |
+| ERC8004Arbiter | `0x3c1E21911C609714dBc0Ab90800c7aD8817B8e83` |
+| ExclusiveRevocableConfirmationArbiter | `0xa740634e718c8727853d1e69963303d5cb8ea44c` |
+| ExclusiveUnrevocableConfirmationArbiter | `0xb3d71c6f96cdd41e56dd9870b232225c379f2890` |
+| NonexclusiveRevocableConfirmationArbiter | `0x831b40ae79d391c7d56209802b9745fe0743dbf5` |
+| NonexclusiveUnrevocableConfirmationArbiter | `0xfeaa2fa295d1453ba382b7ee0e3f66c489a6d9bb` |
+| RecipientArbiter | `0xe0d55949e6e1590f26ef37a1d01df52fbb1b2fce` |
+| AttesterArbiter | `0xe571d48d05962c57c95e48b8a7375466d1d02487` |
+| SchemaArbiter | `0x9d5817ff5519f45bf8ed6c3ada638b874dbcb540` |
+| UidArbiter | `0xaa9aef96068f2be679ae8781a4fc33ff4798758f` |
+| RefUidArbiter | `0x546526311e6639399fdc583df84eee8b123d79d5` |
+| RevocableArbiter | `0xe8d45cf2471882730a7e0ac142966df07ae148d4` |
+| TimeAfterArbiter | `0x2725a6869b42edfd155889098408ccb3b1ed060e` |
+| TimeBeforeArbiter | `0x014aa3dc53004b50bc13aa1d85a83bcca5c0671a` |
+| TimeEqualArbiter | `0x1c21a8fb4f69adb0ccdd22d8c125f8689bf227af` |
+| ExpirationTimeAfterArbiter | `0xbd90af50fb667724338eb8da541f923f1822ac3c` |
+| ExpirationTimeBeforeArbiter | `0xbcce130337f2d8029982a14471d8686afcef20ff` |
+| ExpirationTimeEqualArbiter | `0x98d5bc7593143e55e9949da97603126cae0bfd7f` |
+
+### Ethereum Mainnet
+
+| Contract | Address |
+|----------|---------|
+| EAS | `0xA1207F3BBa224E2c9c3c6D5aF63D0eb1582Ce587` |
+| EAS Schema Registry | `0xA7b39296258348C78294F95B872b282326A97BDF` |
+| ERC20EscrowObligation | `0xB2c808911E84E80156101983897Da7c80e13cB47` |
+| ERC20PaymentObligation | `0xb822aA07F55a8B75Ee133ede1f21C4E49DE7952f` |
+| ERC20BarterUtils | `0x5bf7c8b0d60d05af0a3De531EB876De271E80dbc` |
+| ERC721EscrowObligation | `0x2A7df117e45D93d34a7893CC3aE8B105Ae0B561C` |
+| ERC721PaymentObligation | `0x59A9c929778Ad2cC4D5DB6151bDEf0F9Fa7A068C` |
+| ERC721BarterUtils | `0xEB0C0c41F708B8b3556a6F44a1a015a6832C2d2C` |
+| ERC1155EscrowObligation | `0xf04d9CA943f57353A3A735494E503280C1cD5e77` |
+| ERC1155PaymentObligation | `0x52748DD0E39eD6eA9f626179b5eb512302adA7D9` |
+| ERC1155BarterUtils | `0x52De4B30721b3E3660A79da7491a9B2F8a9cB1D5` |
+| NativeTokenEscrowObligation | `0x9bA50DB048d1E5db034377abf97F92496D027C71` |
+| NativeTokenPaymentObligation | `0xf60db64506E366a0A6c1f4cF9D849Adc7bB886D6` |
+| NativeTokenBarterUtils | `0xA42032D8BFeE2302cC6F80ff51D283Ffc5a4081f` |
+| TokenBundleEscrowObligation | `0x677Aa9e1CD9D05f57FbCa2327155EA7479ec7Ac3` |
+| TokenBundlePaymentObligation | `0x36Fcf1Ddee838a94B1358285A11e8bbbb90eD9A1` |
+| TokenBundleBarterUtils | `0xA7EacA68Bffc9443eA08fd58633Eeed3f5EE8A92` |
+| AttestationEscrowObligation | `0x6eb7792D821f32914Be75901F1b4269B13Efad2e` |
+| AttestationEscrowObligation2 | `0x1A7c6F951e0a33F4910dbe56a200Eb413AEca17b` |
+| AttestationBarterUtils | `0x5E6602F080E9B37267aa52306c699ae54Cd71056` |
+| StringObligation | `0xC51C938f5497be8157DAf8CCc3Eb11Afb8b752C0` |
+| CommitRevealObligation | `0x05d9Aa2A6AE38619b864Ff7f87A8f94301ecAB42` |
+| TrivialArbiter | `0x594E79466b6ac01C6416C929e428264a4bdF0C92` |
+| TrustedOracleArbiter | `0x3B2a812E3eb3B729D40d866Da16c2BB2b6cDd2f2` |
+| AllArbiter | `0x847F69d27E4F1A8a115aCa3F4358B079706dc9CE` |
+| AnyArbiter | `0xe968dFA581B8aBb94eC5F24d0b56163DE69511fD` |
+| IntrinsicsArbiter | `0xaabdDAa76651d20922d1F561f924a40F6fE7710c` |
+| IntrinsicsArbiter2 | `0xF486f9a62eeb085e99828e1D706bBA5dfC1bD1fD` |
+| ERC8004Arbiter | `0xBE7fE4d7CEb2140eeBdf01e12D198AEBAdC1F54D` |
+| ExclusiveRevocableConfirmationArbiter | `0x941044D43F9d75dfA8Ad24880B9B9cAD6e116a66` |
+| ExclusiveUnrevocableConfirmationArbiter | `0x16aeE626D398B547eDD5fa4BdAA638524C92921d` |
+| NonexclusiveRevocableConfirmationArbiter | `0xe483EDA58b5f9Eba06A1ad0151dA5e4a5fFC8300` |
+| NonexclusiveUnrevocableConfirmationArbiter | `0x01666d869918aDDDED1B30eF2d36f3C990F09BDE` |
+| RecipientArbiter | `0xF1C9E20078A13816ACdDF3153e2eAaDd93Fd6E57` |
+| AttesterArbiter | `0x6CC4068d471E96A1669097918e18017f5764f72a` |
+| SchemaArbiter | `0x913eAdD13dcCdeD9CD5518075083b6C7A9574A8c` |
+| UidArbiter | `0xae4fa2D5d7EDD6Aaf697dC0c98EDb921F0fEc058` |
+| RefUidArbiter | `0xE9ee2c57B18283b66d342D33d63C55f1427f9e9B` |
+| RevocableArbiter | `0xeda25079f76ef93c54cC042116Be8D88E49D3439` |
+| TimeAfterArbiter | `0x0ea9e144FfDc6456E5cE8d1f75c686112e8f29c5` |
+| TimeBeforeArbiter | `0x68A6e6022ab9984Ee1A9A6cee384FF2aE8be5264` |
+| TimeEqualArbiter | `0x208385Fb349c01af2CfA8C6b86F633F6642718e2` |
+| ExpirationTimeAfterArbiter | `0x309509db364526C7aE202eA9ED94a398a0819d38` |
+| ExpirationTimeBeforeArbiter | `0xFAf8a07709dB9f90d0A0415876CfE00D904cd40B` |
+| ExpirationTimeEqualArbiter | `0x7c782ac7741BB78DB7491Ee222af0a04f7f2bc0b` |


### PR DESCRIPTION
## Summary
- Adds two AgentSkills-format skills under `docs/skills/` for AI agents interacting with Alkahest
- **alkahest-user**: core workflows (buyer escrow, seller fulfillment, oracle arbitration, commit-reveal, demand composition) with TS SDK examples
- **alkahest-developer**: SDK API reference for TypeScript, Rust, and Python with setup, patterns, and full API trees

## Files
- `docs/skills/alkahest-user/SKILL.md` — user-facing skill (297 lines)
- `docs/skills/alkahest-user/references/contracts.md` — all contract addresses (4 chains) and data schemas
- `docs/skills/alkahest-user/references/arbiters.md` — all arbiter types and encoding patterns
- `docs/skills/alkahest-developer/SKILL.md` — developer-facing skill (336 lines)
- `docs/skills/alkahest-developer/references/typescript-api.md` — full TS SDK API tree
- `docs/skills/alkahest-developer/references/rust-api.md` — full Rust SDK API tree
- `docs/skills/alkahest-developer/references/python-api.md` — full Python SDK API tree
- `docs/skills/alkahest-developer/references/contracts.md` — contract reference (shared with user skill)

## Test plan
- [ ] Verify SKILL.md frontmatter: `name` matches directory name, `description` present
- [ ] Verify both SKILL.md files are under 500 lines
- [ ] Spot-check code examples against actual SDK APIs
- [ ] Verify contract addresses match `sdks/ts/src/config.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)