### PR TITLE
feat: CLI tool with global npm install support

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -1,0 +1,200 @@
+# Alkahest CLI
+
+Command-line interface for the Alkahest escrow protocol, wrapping the TypeScript SDK. Designed for LLM agents and shell scripting with JSON output by default.
+
+## Installation
+
+```bash
+npm install -g alkahest-cli
+```
+
+Or for local development:
+```bash
+cd cli && npm install && npm run build
+npm link
+```
+
+Run commands with:
+```bash
+alkahest [global-flags] <command> <subcommand> [options]
+```
+
+## Authentication
+
+Provide a wallet via one of (in priority order):
+
+| Method | Flag / Env Var |
+|--------|---------------|
+| Private key flag | `--private-key 0x...` |
+| Mnemonic flag | `--mnemonic "word1 word2 ..."` |
+| Ledger USB | `--ledger [--ledger-path <path>]` |
+| Private key env | `ALKAHEST_PRIVATE_KEY=0x...` |
+| Compat env | `PRIVATE_KEY=0x...` |
+| Mnemonic env | `ALKAHEST_MNEMONIC="word1 word2 ..."` |
+
+Ledger support requires optional packages: `npm install @ledgerhq/hw-transport-node-hid @ledgerhq/hw-app-eth`
+
+## Global Flags
+
+```
+--chain <name>            base-sepolia (default) | sepolia | filecoin-calibration | ethereum | anvil
+--private-key <key>       0x-prefixed private key
+--mnemonic <phrase>       BIP39 mnemonic
+--ledger                  Use Ledger hardware wallet
+--ledger-path <path>      Custom HD derivation path (default: m/44'/60'/0'/0/0)
+--rpc-url <url>           Custom RPC URL (overrides chain default)
+--addresses-file <path>   JSON file with custom contract addresses (for local/custom deployments)
+--human                   Human-readable output (default: JSON)
+```
+
+## Output Format
+
+JSON by default. All BigInts serialized as strings.
+
+```json
+{ "success": true, "data": { "hash": "0x...", "uid": "0x..." } }
+{ "success": false, "error": { "code": "ESCROW_CREATE_FAILED", "message": "..." } }
+```
+
+Use `--human` for labeled, indented output.
+
+## Commands
+
+### escrow
+
+| Subcommand | Description | Key Options |
+|------------|-------------|-------------|
+| `create` | Create an escrow | `--erc20\|--erc721\|--erc1155\|--native` `--token` `--amount` `--arbiter` `--demand` `--expiration` `[--approve\|--permit]` `[--token-id]` |
+| `collect` | Collect after fulfillment | `--erc20\|...` `--escrow-uid` `--fulfillment-uid` |
+| `reclaim` | Reclaim expired escrow | `--erc20\|...` `--uid` |
+| `get` | Get escrow details | `--erc20\|...` `--uid` |
+| `wait` | Wait for fulfillment | `--erc20\|...` `--uid` |
+
+### payment
+
+| Subcommand | Description | Key Options |
+|------------|-------------|-------------|
+| `pay` | Make a payment | `--erc20\|--native` `--token` `--amount` `--payee` `[--ref-uid]` `[--approve\|--permit]` |
+| `get` | Get payment details | `--erc20\|--native` `--uid` |
+
+### barter
+
+| Subcommand | Description | Key Options |
+|------------|-------------|-------------|
+| `create` | Create barter offer | `--bid-type` `--ask-type` `--bid-token` `--bid-amount` `--ask-token` `--ask-amount` `--expiration` `[--approve\|--permit]` |
+| `fulfill` | Fulfill barter offer | `--uid` `--bid-type` `--ask-type` `[--approve\|--permit]` |
+
+Supported pairs: erc20/erc20, erc20/erc721, erc20/erc1155.
+
+### string
+
+| Subcommand | Description | Key Options |
+|------------|-------------|-------------|
+| `create` | Create string attestation | `--item` `[--schema]` `[--ref-uid]` |
+| `get` | Get string obligation | `--uid` |
+
+### commit-reveal
+
+| Subcommand | Description | Key Options |
+|------------|-------------|-------------|
+| `commit` | Submit commitment hash | `--commitment` |
+| `reveal` | Reveal committed value | `--payload` `--salt` `--schema` `[--ref-uid]` |
+| `compute-commitment` | Compute commitment hash | `--ref-uid` `--claimer` `--payload` `--salt` `--schema` |
+| `reclaim-bond` | Reclaim bond after reveal | `--uid` |
+| `slash-bond` | Slash unrevealed bond | `--commitment` |
+| `info` | Show bond amount, deadline | (no options) |
+
+### arbiter
+
+| Subcommand | Description | Key Options |
+|------------|-------------|-------------|
+| `arbitrate` | Arbitrate (trusted oracle) | `--obligation` `--demand` `--decision` |
+| `confirm` | Confirm fulfillment | `--fulfillment` `--escrow` `--type` |
+| `revoke` | Revoke confirmation | `--fulfillment` `--escrow` `--type` |
+| `encode-demand` | Encode demand data | `--type` + type-specific flags |
+| `decode-demand` | Decode demand data | `--arbiter` `--demand` |
+
+Encode demand types: `trusted-oracle`, `intrinsics2`, `all`, `any`, `recipient`, `attester`, `schema`, `uid`, `ref-uid`, `revocable`, `time-after`, `time-before`, `time-equal`, `expiration-time-after`, `expiration-time-before`, `expiration-time-equal`.
+
+### attestation
+
+| Subcommand | Description | Key Options |
+|------------|-------------|-------------|
+| `get` | Get raw attestation | `--uid` |
+| `decode` | Decode attestation data | `--uid` `--type` |
+
+### deploy
+
+```bash
+alkahest --private-key 0x... deploy [scope] [--eas] [--eas-address] [--eas-sr-address]
+```
+
+Scopes: `all` (default), `arbiters`, `obligations`, `utils`. Outputs deployed addresses as JSON.
+
+### config
+
+| Subcommand | Description |
+|------------|-------------|
+| `show` | Show contract addresses for current chain |
+| `chains` | List supported chains |
+
+## Examples
+
+### Create and collect an ERC20 escrow
+
+```bash
+# 1. Encode demand (trusted oracle)
+DEMAND=$(alkahest arbiter encode-demand \
+  --type trusted-oracle --oracle 0xORACLE --data 0x)
+
+# 2. Create escrow with auto-approve
+alkahest --private-key 0xBUYER escrow create \
+  --erc20 --token 0xTOKEN --amount 1000000000000000000 \
+  --arbiter 0xTRUSTED_ORACLE_ARBITER --demand 0xENCODED_DEMAND \
+  --expiration 1735689600 --approve
+
+# 3. Seller fulfills with a string obligation
+alkahest --private-key 0xSELLER string create \
+  --item "deliverable" --ref-uid 0xESCROW_UID
+
+# 4. Oracle approves
+alkahest --private-key 0xORACLE arbiter arbitrate \
+  --obligation 0xFULFILLMENT_UID --demand 0xDEMAND --decision true
+
+# 5. Seller collects
+alkahest --private-key 0xSELLER escrow collect \
+  --erc20 --escrow-uid 0xESCROW_UID --fulfillment-uid 0xFULFILLMENT_UID
+```
+
+### ERC20 barter (token swap)
+
+```bash
+# Alice offers 100 TokenA for 200 TokenB
+alkahest --private-key 0xALICE barter create \
+  --bid-type erc20 --ask-type erc20 \
+  --bid-token 0xTOKEN_A --bid-amount 100000000000000000000 \
+  --ask-token 0xTOKEN_B --ask-amount 200000000000000000000 \
+  --expiration 1735689600 --approve
+
+# Bob fulfills (auto-reads ask from the escrow)
+alkahest --private-key 0xBOB barter fulfill \
+  --uid 0xBARTER_UID --bid-type erc20 --ask-type erc20 --approve
+```
+
+### Deploy to local anvil
+
+```bash
+# Start anvil
+anvil --port 8546 &
+
+# Deploy all contracts (including EAS)
+alkahest --chain anvil --rpc-url http://127.0.0.1:8546 \
+  --private-key 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80 \
+  deploy --eas | jq '.data' > addresses.json
+
+# Use deployed addresses for subsequent commands
+alkahest --chain anvil --rpc-url http://127.0.0.1:8546 \
+  --addresses-file addresses.json --private-key 0x... \
+  escrow create --native --token 0x0 --amount 1000000000000000000 \
+  --arbiter 0xTRIVIAL_ARBITER --demand 0x --expiration 9999999999
+```

--- a/cli/package.json
+++ b/cli/package.json
@@ -5,9 +5,13 @@
   "bin": {
     "alkahest": "./dist/index.js"
   },
+  "files": [
+    "dist"
+  ],
   "scripts": {
-    "build": "tsup src/index.ts --format esm --dts --clean",
-    "dev": "bun run src/index.ts"
+    "build": "tsup",
+    "dev": "bun run src/index.ts",
+    "prepublishOnly": "npm run build"
   },
   "dependencies": {
     "commander": "^13.1.0",

--- a/cli/package.json
+++ b/cli/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "type": "module",
   "bin": {
-    "alkahest": "./dist/index.js"
+    "alkahest": "dist/index.js"
   },
   "files": [
     "dist"

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -1,4 +1,3 @@
-#!/usr/bin/env node
 import { Command } from "commander";
 import { makeEscrowCommand } from "./commands/escrow.ts";
 import { makePaymentCommand } from "./commands/payment.ts";

--- a/cli/tsup.config.ts
+++ b/cli/tsup.config.ts
@@ -1,0 +1,25 @@
+import { defineConfig } from "tsup";
+import { writeFileSync, readFileSync } from "fs";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm"],
+  target: "node20",
+  platform: "node",
+  clean: true,
+  dts: false,
+  bundle: true,
+  splitting: false,
+  treeshake: true,
+  external: ["viem", "commander", "@viem/anvil"],
+  banner: {
+    js: "#!/usr/bin/env node",
+  },
+  onSuccess: async () => {
+    // Strip unused side-effect import of test-only dependency
+    const file = "dist/index.js";
+    let code = readFileSync(file, "utf-8");
+    code = code.replace(/^import\s+['"]@viem\/anvil['"];?\s*$/m, "");
+    writeFileSync(file, code);
+  },
+});

--- a/docs/Escrow Flow (pt 1 - Token Trading).md
+++ b/docs/Escrow Flow (pt 1 - Token Trading).md
@@ -231,7 +231,7 @@ The CLI's `barter create` command wraps the barter utility contracts to combine 
 ```bash
 # Alice: Create ERC20 escrow demanding an ERC721 token
 # First, get the ERC721PaymentObligation address for the demand arbiter
-bun run cli/src/index.ts config show --chain base-sepolia
+alkahest config show --chain base-sepolia
 # Use the erc721PaymentObligation address as --arbiter
 
 # The demand is the ABI-encoded ERC721PaymentObligation.ObligationData
@@ -239,7 +239,7 @@ bun run cli/src/index.ts config show --chain base-sepolia
 # You can construct this manually or use the SDK for encoding
 
 # Create the escrow
-bun run cli/src/index.ts --private-key 0xALICE_KEY escrow create \
+alkahest --private-key 0xALICE_KEY escrow create \
   --erc20 \
   --token 0xERC20_TOKEN \
   --amount 1000000000000000000000 \
@@ -253,14 +253,14 @@ Or use barter utilities for atomic swaps (recommended for simple token-for-token
 
 ```bash
 # Alice: Offer ERC20 for ERC20 (most common case)
-bun run cli/src/index.ts --private-key 0xALICE_KEY barter create \
+alkahest --private-key 0xALICE_KEY barter create \
   --bid-type erc20 --ask-type erc20 \
   --bid-token 0xUSDC --bid-amount 1000000000 \
   --ask-token 0xEURC --ask-amount 900000000 \
   --expiration 1735689600
 
 # Alice: Offer ERC20 for ERC721
-bun run cli/src/index.ts --private-key 0xALICE_KEY barter create \
+alkahest --private-key 0xALICE_KEY barter create \
   --bid-type erc20 --ask-type erc721 \
   --bid-token 0xUSDC --bid-amount 1000000000 \
   --ask-token 0xNFT --ask-amount 0 --ask-token-id 42 \
@@ -478,12 +478,12 @@ escrow_contract
 
 ```bash
 # Bob: Fulfill a barter escrow (counterparty pays)
-bun run cli/src/index.ts --private-key 0xBOB_KEY barter fulfill \
+alkahest --private-key 0xBOB_KEY barter fulfill \
   --uid 0xESCROW_UID \
   --bid-type erc20 --ask-type erc20
 
 # Or for manual escrow collection (after separately creating a payment):
-bun run cli/src/index.ts --private-key 0xBOB_KEY escrow collect \
+alkahest --private-key 0xBOB_KEY escrow collect \
   --erc20 \
   --escrow-uid 0xESCROW_UID \
   --fulfillment-uid 0xPAYMENT_UID
@@ -600,7 +600,7 @@ You can reclaim your escrow if nobody fulfills it before it expires.
 
 ```bash
 # Alice reclaims her expired escrow
-bun run cli/src/index.ts --private-key 0xALICE_KEY escrow reclaim \
+alkahest --private-key 0xALICE_KEY escrow reclaim \
   --erc20 --uid 0xESCROW_UID
 ```
 
@@ -653,7 +653,7 @@ The CLI wraps the barter utility contracts. Use `--permit` for gasless ERC-20 ap
 
 ```bash
 # Alice: Create barter (ERC20 for ERC20) with permit
-bun run cli/src/index.ts --private-key 0xALICE_KEY barter create \
+alkahest --private-key 0xALICE_KEY barter create \
   --bid-type erc20 --ask-type erc20 \
   --bid-token 0xUSDC --bid-amount 1000000000 \
   --ask-token 0xEURC --ask-amount 900000000 \
@@ -661,13 +661,13 @@ bun run cli/src/index.ts --private-key 0xALICE_KEY barter create \
   --permit
 
 # Bob: Fulfill the barter
-bun run cli/src/index.ts --private-key 0xBOB_KEY barter fulfill \
+alkahest --private-key 0xBOB_KEY barter fulfill \
   --uid 0xBARTER_UID \
   --bid-type erc20 --ask-type erc20 \
   --permit
 
 # Or use escrow create with --approve for non-barter escrows
-bun run cli/src/index.ts --private-key 0xALICE_KEY escrow create \
+alkahest --private-key 0xALICE_KEY escrow create \
   --erc20 \
   --token 0xUSDC --amount 1000000000 \
   --arbiter 0xARBITER --demand 0xDEMAND \

--- a/docs/Escrow Flow (pt 2 - Job Trading).md
+++ b/docs/Escrow Flow (pt 2 - Job Trading).md
@@ -19,14 +19,14 @@ You can use TrustedOracleArbiter when you want an off-chain judge to decide whet
 
 ```bash
 # Step 1: Encode the TrustedOracleArbiter demand
-bun run cli/src/index.ts arbiter encode-demand \
+alkahest arbiter encode-demand \
   --type trusted-oracle \
   --oracle 0xCHARLIE_ADDRESS \
   --data 0x   # extra data for the oracle (can embed the query)
 # Returns: { "success": true, "data": { "encoded": "0x..." } }
 
 # Step 2: Create the escrow with the encoded demand
-bun run cli/src/index.ts --private-key 0xALICE_KEY escrow create \
+alkahest --private-key 0xALICE_KEY escrow create \
   --erc20 \
   --token 0xERC20_TOKEN \
   --amount 100000000000000000000 \
@@ -167,13 +167,13 @@ Note that the fulfillment should contain a copy or reference to the demand it's 
 
 ```bash
 # Bob: Submit the result as a string fulfillment referencing the escrow
-bun run cli/src/index.ts --private-key 0xBOB_KEY string create \
+alkahest --private-key 0xBOB_KEY string create \
   --item "HELLO WORLD" \
   --ref-uid 0xESCROW_UID
 # Returns: { "success": true, "data": { "uid": "0xFULFILLMENT_UID", ... } }
 
 # Charlie (oracle): Arbitrate the fulfillment
-bun run cli/src/index.ts --private-key 0xCHARLIE_KEY arbiter arbitrate \
+alkahest --private-key 0xCHARLIE_KEY arbiter arbitrate \
   --obligation 0xFULFILLMENT_UID \
   --demand 0xDEMAND_HEX \
   --decision true
@@ -438,13 +438,13 @@ Bob can listen for the `ArbitrationMade` event from TrustedOracleArbiter, then c
 
 ```bash
 # Bob: Collect the escrow after successful arbitration
-bun run cli/src/index.ts --private-key 0xBOB_KEY escrow collect \
+alkahest --private-key 0xBOB_KEY escrow collect \
   --erc20 \
   --escrow-uid 0xESCROW_UID \
   --fulfillment-uid 0xFULFILLMENT_UID
 
 # Or wait for fulfillment (blocks until someone fulfills and collects)
-bun run cli/src/index.ts --private-key 0xALICE_KEY escrow wait \
+alkahest --private-key 0xALICE_KEY escrow wait \
   --erc20 --uid 0xESCROW_UID
 ```
 
@@ -560,7 +560,7 @@ If no valid fulfillment is made, Alice can reclaim the escrow after it expires.
 
 ```bash
 # Alice reclaims her expired escrow
-bun run cli/src/index.ts --private-key 0xALICE_KEY escrow reclaim \
+alkahest --private-key 0xALICE_KEY escrow reclaim \
   --erc20 --uid 0xESCROW_UID
 ```
 

--- a/docs/Escrow Flow (pt 2b - Frontrunning Protection).md
+++ b/docs/Escrow Flow (pt 2b - Frontrunning Protection).md
@@ -30,22 +30,22 @@ Since CommitRevealObligation only enforces the commit-reveal protocol — it doe
 
 ```bash
 # Step 1: Encode oracle demand
-bun run cli/src/index.ts arbiter encode-demand \
+alkahest arbiter encode-demand \
   --type trusted-oracle \
   --oracle 0xCHARLIE --data 0x
 # → { "encoded": "0xORACLE_DEMAND" }
 
 # Step 2: Compose with AllArbiter (commit-reveal + oracle)
 # Get contract addresses first
-bun run cli/src/index.ts config show --chain base-sepolia
+alkahest config show --chain base-sepolia
 # Use commitRevealObligation and trustedOracleArbiter addresses
 
-bun run cli/src/index.ts arbiter encode-demand --type all \
+alkahest arbiter encode-demand --type all \
   --demands '[{"arbiter":"0xCOMMIT_REVEAL_OBLIGATION","demand":"0x"},{"arbiter":"0xTRUSTED_ORACLE_ARBITER","demand":"0xORACLE_DEMAND"}]'
 # → { "encoded": "0xCOMPOSED_DEMAND" }
 
 # Step 3: Create escrow with the composed demand
-bun run cli/src/index.ts --private-key 0xALICE_KEY escrow create \
+alkahest --private-key 0xALICE_KEY escrow create \
   --erc20 \
   --token 0xERC20_TOKEN --amount 100000000000000000000 \
   --arbiter 0xALL_ARBITER \
@@ -194,7 +194,7 @@ The `payload` field holds the actual result data (here, the ABI-encoded string).
 
 ```bash
 # Compute the commitment hash
-bun run cli/src/index.ts --private-key 0xBOB_KEY commit-reveal compute-commitment \
+alkahest --private-key 0xBOB_KEY commit-reveal compute-commitment \
   --ref-uid 0xESCROW_UID \
   --claimer 0xBOB_ADDRESS \
   --payload 0xPAYLOAD_HEX \
@@ -203,7 +203,7 @@ bun run cli/src/index.ts --private-key 0xBOB_KEY commit-reveal compute-commitmen
 # → { "commitment": "0x..." }
 
 # Submit the commitment with bond
-bun run cli/src/index.ts --private-key 0xBOB_KEY commit-reveal commit \
+alkahest --private-key 0xBOB_KEY commit-reveal commit \
   --commitment 0xCOMMITMENT_HASH
 ```
 
@@ -304,7 +304,7 @@ After waiting at least one block, Bob reveals his data by calling `doObligation(
 
 ```bash
 # Reveal the fulfillment (must be in a later block than the commit)
-bun run cli/src/index.ts --private-key 0xBOB_KEY commit-reveal reveal \
+alkahest --private-key 0xBOB_KEY commit-reveal reveal \
   --payload 0xPAYLOAD_HEX \
   --salt 0xRANDOM_SALT_HEX \
   --schema 0x0000000000000000000000000000000000000000000000000000000000000000 \
@@ -360,13 +360,13 @@ The arbitration and claiming process is the same as in [pt 2](Escrow%20Flow%20(p
 
 ```bash
 # Charlie arbitrates the fulfillment (same as pt 2)
-bun run cli/src/index.ts --private-key 0xCHARLIE_KEY arbiter arbitrate \
+alkahest --private-key 0xCHARLIE_KEY arbiter arbitrate \
   --obligation 0xFULFILLMENT_UID \
   --demand 0xORACLE_DEMAND \
   --decision true
 
 # Bob collects the escrow
-bun run cli/src/index.ts --private-key 0xBOB_KEY escrow collect \
+alkahest --private-key 0xBOB_KEY escrow collect \
   --erc20 \
   --escrow-uid 0xESCROW_UID \
   --fulfillment-uid 0xFULFILLMENT_UID
@@ -505,7 +505,7 @@ After a successful reveal (and escrow collection), Bob can reclaim his bond. The
 **CLI**
 
 ```bash
-bun run cli/src/index.ts --private-key 0xBOB_KEY commit-reveal reclaim-bond \
+alkahest --private-key 0xBOB_KEY commit-reveal reclaim-bond \
   --uid 0xFULFILLMENT_UID
 ```
 
@@ -544,7 +544,7 @@ If a commitment goes unrevealed past the deadline, anyone can slash the bond. Th
 
 ```bash
 # Slash an unrevealed commitment's bond (anyone can call after deadline)
-bun run cli/src/index.ts --private-key 0xANY_KEY commit-reveal slash-bond \
+alkahest --private-key 0xANY_KEY commit-reveal slash-bond \
   --commitment 0xCOMMITMENT_HASH
 ```
 
@@ -607,7 +607,7 @@ You can query these via the CLI or SDK:
 **CLI**
 
 ```bash
-bun run cli/src/index.ts --private-key 0xKEY commit-reveal info
+alkahest --private-key 0xKEY commit-reveal info
 # → { "bondAmount": "...", "commitDeadline": "...", "slashedBondRecipient": "0x..." }
 ```
 

--- a/docs/Escrow Flow (pt 3 - Composing Demands).md
+++ b/docs/Escrow Flow (pt 3 - Composing Demands).md
@@ -14,22 +14,22 @@ You can use AllArbiter to demand multiple conditions at the same time. For examp
 
 ```bash
 # Encode individual demands
-bun run cli/src/index.ts arbiter encode-demand --type recipient \
+alkahest arbiter encode-demand --type recipient \
   --recipient 0xBOB
 # → { "encoded": "0xRECIPIENT_DEMAND" }
 
-bun run cli/src/index.ts arbiter encode-demand --type trusted-oracle \
+alkahest arbiter encode-demand --type trusted-oracle \
   --oracle 0xCHARLIE --data 0x
 # → { "encoded": "0xORACLE_DEMAND" }
 
 # Compose with AllArbiter - both conditions must be met
-# Use addresses from: bun run cli/src/index.ts config show --chain base-sepolia
-bun run cli/src/index.ts arbiter encode-demand --type all \
+# Use addresses from: alkahest config show --chain base-sepolia
+alkahest arbiter encode-demand --type all \
   --demands '[{"arbiter":"0xRECIPIENT_ARBITER","demand":"0xRECIPIENT_DEMAND"},{"arbiter":"0xTRUSTED_ORACLE_ARBITER","demand":"0xORACLE_DEMAND"}]'
 # → { "encoded": "0xCOMPOSED_DEMAND" }
 
 # Create escrow with the composed demand
-bun run cli/src/index.ts --private-key 0xALICE_KEY escrow create \
+alkahest --private-key 0xALICE_KEY escrow create \
   --erc20 \
   --token 0xERC20_TOKEN --amount 100000000000000000000 \
   --arbiter 0xALL_ARBITER \
@@ -182,25 +182,25 @@ You can use AnyArbiter when multiple alternative conditions can be considered va
 
 ```bash
 # Encode individual oracle demands
-bun run cli/src/index.ts arbiter encode-demand --type trusted-oracle \
+alkahest arbiter encode-demand --type trusted-oracle \
   --oracle 0xCHARLIE --data 0x
 # → { "encoded": "0xORACLE1_DEMAND" }
 
-bun run cli/src/index.ts arbiter encode-demand --type trusted-oracle \
+alkahest arbiter encode-demand --type trusted-oracle \
   --oracle 0xDAVE --data 0x
 # → { "encoded": "0xORACLE2_DEMAND" }
 
-bun run cli/src/index.ts arbiter encode-demand --type trusted-oracle \
+alkahest arbiter encode-demand --type trusted-oracle \
   --oracle 0xEVE --data 0x
 # → { "encoded": "0xORACLE3_DEMAND" }
 
 # Compose with AnyArbiter - any one oracle can validate
-bun run cli/src/index.ts arbiter encode-demand --type any \
+alkahest arbiter encode-demand --type any \
   --demands '[{"arbiter":"0xTRUSTED_ORACLE_ARBITER","demand":"0xORACLE1_DEMAND"},{"arbiter":"0xTRUSTED_ORACLE_ARBITER","demand":"0xORACLE2_DEMAND"},{"arbiter":"0xTRUSTED_ORACLE_ARBITER","demand":"0xORACLE3_DEMAND"}]'
 # → { "encoded": "0xCOMPOSED_DEMAND" }
 
 # Create escrow with flexible oracle validation
-bun run cli/src/index.ts --private-key 0xALICE_KEY escrow create \
+alkahest --private-key 0xALICE_KEY escrow create \
   --erc20 \
   --token 0xERC20_TOKEN --amount 50000000000000000000 \
   --arbiter 0xANY_ARBITER \
@@ -378,30 +378,30 @@ Logical arbiters can be stacked. For example, you could demand that a job is com
 
 ```bash
 # Encode individual demands
-bun run cli/src/index.ts arbiter encode-demand --type time-before --time 1735693200
+alkahest arbiter encode-demand --type time-before --time 1735693200
 # → { "encoded": "0xDEADLINE_DEMAND" }
 
-bun run cli/src/index.ts arbiter encode-demand --type recipient --recipient 0xBOB
+alkahest arbiter encode-demand --type recipient --recipient 0xBOB
 # → { "encoded": "0xRECIPIENT_DEMAND" }
 
-bun run cli/src/index.ts arbiter encode-demand --type trusted-oracle --oracle 0xCHARLIE --data 0x
+alkahest arbiter encode-demand --type trusted-oracle --oracle 0xCHARLIE --data 0x
 # → { "encoded": "0xORACLE1_DEMAND" }
 
-bun run cli/src/index.ts arbiter encode-demand --type trusted-oracle --oracle 0xDAVE --data 0x
+alkahest arbiter encode-demand --type trusted-oracle --oracle 0xDAVE --data 0x
 # → { "encoded": "0xORACLE2_DEMAND" }
 
 # Create the OR condition for oracles
-bun run cli/src/index.ts arbiter encode-demand --type any \
+alkahest arbiter encode-demand --type any \
   --demands '[{"arbiter":"0xTRUSTED_ORACLE_ARBITER","demand":"0xORACLE1_DEMAND"},{"arbiter":"0xTRUSTED_ORACLE_ARBITER","demand":"0xORACLE2_DEMAND"}]'
 # → { "encoded": "0xORACLE_OR_DEMAND" }
 
 # Combine all conditions with AllArbiter: deadline AND recipient AND (oracle1 OR oracle2)
-bun run cli/src/index.ts arbiter encode-demand --type all \
+alkahest arbiter encode-demand --type all \
   --demands '[{"arbiter":"0xTIME_BEFORE_ARBITER","demand":"0xDEADLINE_DEMAND"},{"arbiter":"0xRECIPIENT_ARBITER","demand":"0xRECIPIENT_DEMAND"},{"arbiter":"0xANY_ARBITER","demand":"0xORACLE_OR_DEMAND"}]'
 # → { "encoded": "0xFINAL_DEMAND" }
 
 # Create the escrow with nested logical arbiters
-bun run cli/src/index.ts --private-key 0xALICE_KEY escrow create \
+alkahest --private-key 0xALICE_KEY escrow create \
   --erc20 \
   --token 0xERC20_TOKEN --amount 200000000000000000000 \
   --arbiter 0xALL_ARBITER \
@@ -630,7 +630,7 @@ The CLI and SDKs provide built-in support for recursively parsing composed deman
 
 ```bash
 # Decode a composed demand given the arbiter address and encoded demand hex
-bun run cli/src/index.ts arbiter decode-demand \
+alkahest arbiter decode-demand \
   --arbiter 0xALL_ARBITER \
   --demand 0xCOMPOSED_DEMAND_HEX
 # → Recursively decoded demand structure as JSON

--- a/docs/skills/alkahest-user/SKILL.md
+++ b/docs/skills/alkahest-user/SKILL.md
@@ -27,10 +27,10 @@ Supported chains: Base Sepolia, Sepolia, Filecoin Calibration, Ethereum mainnet.
 
 ## CLI Setup
 
-The CLI is at `cli/` in the repo root. Run commands with:
+Install globally via `npm install -g alkahest-cli`, then run commands with:
 
 ```bash
-bun run cli/src/index.ts [global-flags] <command> <subcommand> [options]
+alkahest [global-flags] <command> <subcommand> [options]
 ```
 
 ### Authentication
@@ -73,7 +73,7 @@ First, encode the demand data that specifies your release condition:
 
 ```bash
 # Trusted oracle demand — oracle must approve fulfillment
-bun run cli/src/index.ts arbiter encode-demand \
+alkahest arbiter encode-demand \
   --type trusted-oracle \
   --oracle 0xORACLE_ADDRESS \
   --data 0x
@@ -86,7 +86,7 @@ Use the `--arbiter` address and the encoded `--demand` hex from step 1:
 
 ```bash
 # ERC20 escrow with auto-approve
-bun run cli/src/index.ts --private-key 0xKEY escrow create \
+alkahest --private-key 0xKEY escrow create \
   --erc20 \
   --token 0xTOKEN_ADDRESS \
   --amount 1000000000000000000 \
@@ -96,7 +96,7 @@ bun run cli/src/index.ts --private-key 0xKEY escrow create \
   --approve
 
 # ERC721 escrow
-bun run cli/src/index.ts --private-key 0xKEY escrow create \
+alkahest --private-key 0xKEY escrow create \
   --erc721 \
   --token 0xNFT_ADDRESS \
   --token-id 42 \
@@ -107,7 +107,7 @@ bun run cli/src/index.ts --private-key 0xKEY escrow create \
   --approve
 
 # Native token (ETH) escrow — no approve needed
-bun run cli/src/index.ts --private-key 0xKEY escrow create \
+alkahest --private-key 0xKEY escrow create \
   --native \
   --token 0x0000000000000000000000000000000000000000 \
   --amount 500000000000000000 \
@@ -121,7 +121,7 @@ Returns `{ "success": true, "data": { "hash": "0x...", "uid": "0x...", ... } }`.
 ### 3. Wait for fulfillment
 
 ```bash
-bun run cli/src/index.ts --private-key 0xKEY escrow wait \
+alkahest --private-key 0xKEY escrow wait \
   --erc20 --uid 0xESCROW_UID
 # Blocks until fulfilled. Returns: { payment, fulfillment, fulfiller }
 ```
@@ -129,14 +129,14 @@ bun run cli/src/index.ts --private-key 0xKEY escrow wait \
 ### 4. Reclaim expired escrow (if unfulfilled)
 
 ```bash
-bun run cli/src/index.ts --private-key 0xKEY escrow reclaim \
+alkahest --private-key 0xKEY escrow reclaim \
   --erc20 --uid 0xESCROW_UID
 ```
 
 ### 5. Get escrow details
 
 ```bash
-bun run cli/src/index.ts --private-key 0xKEY escrow get \
+alkahest --private-key 0xKEY escrow get \
   --erc20 --uid 0xESCROW_UID
 ```
 
@@ -146,19 +146,19 @@ bun run cli/src/index.ts --private-key 0xKEY escrow get \
 
 ```bash
 # 1. Create fulfillment referencing the escrow
-bun run cli/src/index.ts --private-key 0xKEY string create \
+alkahest --private-key 0xKEY string create \
   --item "Here is my completed deliverable" \
   --ref-uid 0xESCROW_UID
 # Returns: { uid: "0xFULFILLMENT_UID", ... }
 
 # 2. If escrow uses TrustedOracleArbiter, oracle arbitrates
-bun run cli/src/index.ts --private-key 0xORACLE_KEY arbiter arbitrate \
+alkahest --private-key 0xORACLE_KEY arbiter arbitrate \
   --obligation 0xFULFILLMENT_UID \
   --demand 0xDEMAND_HEX \
   --decision true
 
 # 3. Collect the escrow
-bun run cli/src/index.ts --private-key 0xSELLER_KEY escrow collect \
+alkahest --private-key 0xSELLER_KEY escrow collect \
   --erc20 \
   --escrow-uid 0xESCROW_UID \
   --fulfillment-uid 0xFULFILLMENT_UID
@@ -168,14 +168,14 @@ bun run cli/src/index.ts --private-key 0xSELLER_KEY escrow collect \
 
 ```bash
 # Create a barter offer: bid ERC20 for ERC20
-bun run cli/src/index.ts --private-key 0xKEY barter create \
+alkahest --private-key 0xKEY barter create \
   --bid-type erc20 --ask-type erc20 \
   --bid-token 0xBID_TOKEN --bid-amount 1000000000000000000 \
   --ask-token 0xASK_TOKEN --ask-amount 2000000000000000000 \
   --expiration 1735689600
 
 # Counterparty fulfills the barter
-bun run cli/src/index.ts --private-key 0xCOUNTERPARTY_KEY barter fulfill \
+alkahest --private-key 0xCOUNTERPARTY_KEY barter fulfill \
   --uid 0xBARTER_UID \
   --bid-type erc20 --ask-type erc20
 ```
@@ -186,13 +186,13 @@ Supported barter pairs: `erc20/erc20`, `erc20/erc721`, `erc20/erc1155`. Use `--p
 
 ```bash
 # Approve a fulfillment
-bun run cli/src/index.ts --private-key 0xORACLE_KEY arbiter arbitrate \
+alkahest --private-key 0xORACLE_KEY arbiter arbitrate \
   --obligation 0xFULFILLMENT_UID \
   --demand 0xDEMAND_HEX \
   --decision true
 
 # Reject a fulfillment
-bun run cli/src/index.ts --private-key 0xORACLE_KEY arbiter arbitrate \
+alkahest --private-key 0xORACLE_KEY arbiter arbitrate \
   --obligation 0xFULFILLMENT_UID \
   --demand 0xDEMAND_HEX \
   --decision false
@@ -206,7 +206,7 @@ Use commit-reveal when fulfillment data is self-contained (e.g., a string answer
 
 ```bash
 # 1. Compute commitment hash
-bun run cli/src/index.ts --private-key 0xKEY commit-reveal compute-commitment \
+alkahest --private-key 0xKEY commit-reveal compute-commitment \
   --ref-uid 0xESCROW_UID \
   --claimer 0xSELLER_ADDRESS \
   --payload 0xPAYLOAD_HEX \
@@ -215,11 +215,11 @@ bun run cli/src/index.ts --private-key 0xKEY commit-reveal compute-commitment \
 # Returns: { commitment: "0x..." }
 
 # 2. Commit (sends bond as ETH)
-bun run cli/src/index.ts --private-key 0xKEY commit-reveal commit \
+alkahest --private-key 0xKEY commit-reveal commit \
   --commitment 0xCOMMITMENT_HASH
 
 # 3. Wait at least 1 block, then reveal
-bun run cli/src/index.ts --private-key 0xKEY commit-reveal reveal \
+alkahest --private-key 0xKEY commit-reveal reveal \
   --payload 0xPAYLOAD_HEX \
   --salt 0xSALT_HEX \
   --schema 0xSCHEMA_UID \
@@ -227,14 +227,14 @@ bun run cli/src/index.ts --private-key 0xKEY commit-reveal reveal \
 # Returns: { uid: "0xOBLIGATION_UID", ... }
 
 # 4. Reclaim bond after successful reveal
-bun run cli/src/index.ts --private-key 0xKEY commit-reveal reclaim-bond \
+alkahest --private-key 0xKEY commit-reveal reclaim-bond \
   --uid 0xOBLIGATION_UID
 
 # Check bond amount and deadline
-bun run cli/src/index.ts --private-key 0xKEY commit-reveal info
+alkahest --private-key 0xKEY commit-reveal info
 
 # Slash an unrevealed commitment's bond
-bun run cli/src/index.ts --private-key 0xKEY commit-reveal slash-bond \
+alkahest --private-key 0xKEY commit-reveal slash-bond \
   --commitment 0xCOMMITMENT_HASH
 ```
 
@@ -244,24 +244,24 @@ The `arbiter encode-demand` command encodes demand data for any arbiter type:
 
 ```bash
 # Trusted oracle
-bun run cli/src/index.ts arbiter encode-demand --type trusted-oracle \
+alkahest arbiter encode-demand --type trusted-oracle \
   --oracle 0xORACLE --data 0x
 
 # IntrinsicsArbiter2 (schema check)
-bun run cli/src/index.ts arbiter encode-demand --type intrinsics2 \
+alkahest arbiter encode-demand --type intrinsics2 \
   --schema 0xSCHEMA_UID
 
 # Attestation property arbiters
-bun run cli/src/index.ts arbiter encode-demand --type recipient --recipient 0xADDRESS
-bun run cli/src/index.ts arbiter encode-demand --type attester --attester 0xADDRESS
-bun run cli/src/index.ts arbiter encode-demand --type schema --schema 0xSCHEMA_UID
-bun run cli/src/index.ts arbiter encode-demand --type time-after --time 1735689600
+alkahest arbiter encode-demand --type recipient --recipient 0xADDRESS
+alkahest arbiter encode-demand --type attester --attester 0xADDRESS
+alkahest arbiter encode-demand --type schema --schema 0xSCHEMA_UID
+alkahest arbiter encode-demand --type time-after --time 1735689600
 
 # Logical composition (AllArbiter / AnyArbiter)
-bun run cli/src/index.ts arbiter encode-demand --type all \
+alkahest arbiter encode-demand --type all \
   --demands '[{"arbiter":"0xARB1","demand":"0xDEM1"},{"arbiter":"0xARB2","demand":"0xDEM2"}]'
 
-bun run cli/src/index.ts arbiter encode-demand --type any \
+alkahest arbiter encode-demand --type any \
   --demands '[{"arbiter":"0xARB1","demand":"0xDEM1"},{"arbiter":"0xARB2","demand":"0xDEM2"}]'
 ```
 
@@ -270,7 +270,7 @@ Available `--type` values: `trusted-oracle`, `intrinsics2`, `all`, `any`, `recip
 ### Decoding demands
 
 ```bash
-bun run cli/src/index.ts arbiter decode-demand \
+alkahest arbiter decode-demand \
   --arbiter 0xARBITER_ADDRESS \
   --demand 0xENCODED_HEX
 ```
@@ -281,13 +281,13 @@ For manual buyer-side approval of fulfillments:
 
 ```bash
 # Confirm a fulfillment
-bun run cli/src/index.ts --private-key 0xBUYER_KEY arbiter confirm \
+alkahest --private-key 0xBUYER_KEY arbiter confirm \
   --fulfillment 0xFULFILLMENT_UID \
   --escrow 0xESCROW_UID \
   --type exclusive-revocable
 
 # Revoke confirmation (revocable variants only)
-bun run cli/src/index.ts --private-key 0xBUYER_KEY arbiter revoke \
+alkahest --private-key 0xBUYER_KEY arbiter revoke \
   --fulfillment 0xFULFILLMENT_UID \
   --escrow 0xESCROW_UID \
   --type exclusive-revocable
@@ -299,31 +299,31 @@ Types: `exclusive-revocable`, `exclusive-unrevocable`, `nonexclusive-revocable`,
 
 ```bash
 # ERC20 payment with auto-approve
-bun run cli/src/index.ts --private-key 0xKEY payment pay \
+alkahest --private-key 0xKEY payment pay \
   --erc20 \
   --token 0xTOKEN --amount 1000000000000000000 \
   --payee 0xRECIPIENT \
   --approve
 
 # Native token payment
-bun run cli/src/index.ts --private-key 0xKEY payment pay \
+alkahest --private-key 0xKEY payment pay \
   --native \
   --token 0x0000000000000000000000000000000000000000 \
   --amount 500000000000000000 \
   --payee 0xRECIPIENT
 
 # Get payment details
-bun run cli/src/index.ts --private-key 0xKEY payment get --erc20 --uid 0xUID
+alkahest --private-key 0xKEY payment get --erc20 --uid 0xUID
 ```
 
 ## Attestations
 
 ```bash
 # Get raw attestation by UID
-bun run cli/src/index.ts --private-key 0xKEY attestation get --uid 0xUID
+alkahest --private-key 0xKEY attestation get --uid 0xUID
 
 # Decode attestation data by type
-bun run cli/src/index.ts --private-key 0xKEY attestation decode \
+alkahest --private-key 0xKEY attestation decode \
   --uid 0xUID --type erc20-escrow
 ```
 
@@ -333,10 +333,10 @@ Decode types: `erc20-escrow`, `erc20-payment`, `erc721-escrow`, `erc721-payment`
 
 ```bash
 # Show contract addresses for a chain
-bun run cli/src/index.ts config show --chain base-sepolia
+alkahest config show --chain base-sepolia
 
 # List supported chains
-bun run cli/src/index.ts config chains
+alkahest config chains
 ```
 
 ## Escrow Types


### PR DESCRIPTION
## Summary
- Add CLI wrapping the TypeScript SDK for LLM agent use and shell scripting (JSON output by default)
- Package CLI for `npm install -g alkahest-cli` with standalone Node.js execution (`alkahest` command)
- Add tsup bundler config with tree-shaking, shebang injection, and test-dep stubbing
- Update all docs and tutorials to use `alkahest` command instead of `bun run cli/src/index.ts`

## Test plan
- [x] `npm run build` produces single bundled `dist/index.js` with shebang
- [x] `node dist/index.js --help` works without errors
- [x] `./dist/index.js --version` works as direct executable
- [ ] `npm install -g` and run `alkahest --help` on a clean machine
- [ ] Verify all CLI subcommands work against Base Sepolia

🤖 Generated with [Claude Code](https://claude.com/claude-code)