### PR TITLE
docs: fix tab labels and reorder CLI last

### DIFF
--- a/docs/Escrow Flow (pt 1 - Token Trading).md
+++ b/docs/Escrow Flow (pt 1 - Token Trading).md
@@ -596,14 +596,6 @@ for erc20_token in &bundle_data.erc20s {
 
 You can reclaim your escrow if nobody fulfills it before it expires.
 
-**CLI**
-
-```bash
-# Alice reclaims her expired escrow
-alkahest --private-key 0xALICE_KEY escrow reclaim \
-  --erc20 --uid 0xESCROW_UID
-```
-
 **Solidity**
 
 ```solidity
@@ -639,6 +631,14 @@ escrow_contract
     .await?;
 ```
 
+**CLI**
+
+```bash
+# Alice reclaims her expired escrow
+alkahest --private-key 0xALICE_KEY escrow reclaim \
+  --erc20 --uid 0xESCROW_UID
+```
+
 ## Utility contracts and SDK functions
 
 There are utility contracts that provide a convenient interface for doing token trades atomically, and SDKs in TypeScript, Rust, and Python that wrap these. The SDKs additionally have functions that generate ERC-20 permits to enable easy approval and escrow/payment in one transaction.
@@ -646,34 +646,6 @@ There are utility contracts that provide a convenient interface for doing token 
 The functions to escrow one type of token, demanding any other type (buyYforX), and to fulfill any type of escrow demanding that token type (payXforY), are available in \[TokenType]BarterUtils.sol, or the corresponding barter module of each SDK (e.g. `client.erc20.barter`, `client.tokenBundle.barter`...). Available token types are native tokens (ETH), ERC-20, ERC-721, ERC-1155, and bundles of all of these together.
 
 For ERC-20 tokens, `permit_and_*` functions combine approval and action in a single gasless step. For escrow and payment modules, `approve_and_create` and `approve_and_pay` functions combine approval and action in two transactions but a single SDK call.
-
-**CLI**
-
-The CLI wraps the barter utility contracts. Use `--permit` for gasless ERC-20 approval:
-
-```bash
-# Alice: Create barter (ERC20 for ERC20) with permit
-alkahest --private-key 0xALICE_KEY barter create \
-  --bid-type erc20 --ask-type erc20 \
-  --bid-token 0xUSDC --bid-amount 1000000000 \
-  --ask-token 0xEURC --ask-amount 900000000 \
-  --expiration 1735689600 \
-  --permit
-
-# Bob: Fulfill the barter
-alkahest --private-key 0xBOB_KEY barter fulfill \
-  --uid 0xBARTER_UID \
-  --bid-type erc20 --ask-type erc20 \
-  --permit
-
-# Or use escrow create with --approve for non-barter escrows
-alkahest --private-key 0xALICE_KEY escrow create \
-  --erc20 \
-  --token 0xUSDC --amount 1000000000 \
-  --arbiter 0xARBITER --demand 0xDEMAND \
-  --expiration 1735689600 \
-  --approve
-```
 
 **Solidity**
 
@@ -794,4 +766,32 @@ escrow = await alice_client.erc20.escrow.non_tierable.approve_and_create(
     {"arbiter": custom_arbiter, "demand": custom_demand},
     0
 )
+```
+
+**CLI**
+
+The CLI wraps the barter utility contracts. Use `--permit` for gasless ERC-20 approval:
+
+```bash
+# Alice: Create barter (ERC20 for ERC20) with permit
+alkahest --private-key 0xALICE_KEY barter create \
+  --bid-type erc20 --ask-type erc20 \
+  --bid-token 0xUSDC --bid-amount 1000000000 \
+  --ask-token 0xEURC --ask-amount 900000000 \
+  --expiration 1735689600 \
+  --permit
+
+# Bob: Fulfill the barter
+alkahest --private-key 0xBOB_KEY barter fulfill \
+  --uid 0xBARTER_UID \
+  --bid-type erc20 --ask-type erc20 \
+  --permit
+
+# Or use escrow create with --approve for non-barter escrows
+alkahest --private-key 0xALICE_KEY escrow create \
+  --erc20 \
+  --token 0xUSDC --amount 1000000000 \
+  --arbiter 0xARBITER --demand 0xDEMAND \
+  --expiration 1735689600 \
+  --approve
 ```

--- a/docs/Escrow Flow (pt 2 - Job Trading).md
+++ b/docs/Escrow Flow (pt 2 - Job Trading).md
@@ -15,28 +15,6 @@ Here's how Alice buys a compute job from Bob with her ERC-20 token, where the va
 
 You can use TrustedOracleArbiter when you want an off-chain judge to decide whether a deal has been validly fulfilled. The judge could be a real person or an automated program. In this example, we'll demand that Bob capitalize a string for us, and Charlie will verify off-chain whether Bob did so correctly. In practice, this might represent Bob doing a complex computation, and Charlie verifying if it meets Alice's criteria.
 
-**CLI**
-
-```bash
-# Step 1: Encode the TrustedOracleArbiter demand
-alkahest arbiter encode-demand \
-  --type trusted-oracle \
-  --oracle 0xCHARLIE_ADDRESS \
-  --data 0x   # extra data for the oracle (can embed the query)
-# Returns: { "success": true, "data": { "encoded": "0x..." } }
-
-# Step 2: Create the escrow with the encoded demand
-alkahest --private-key 0xALICE_KEY escrow create \
-  --erc20 \
-  --token 0xERC20_TOKEN \
-  --amount 100000000000000000000 \
-  --arbiter 0xTRUSTED_ORACLE_ARBITER \
-  --demand 0xENCODED_DEMAND \
-  --expiration 1735689600 \
-  --approve
-# Returns: { "success": true, "data": { "uid": "0xESCROW_UID", ... } }
-```
-
 **Solidity**
 
 ```solidity
@@ -157,27 +135,33 @@ escrow_receipt = await alice_client.erc20.escrow.non_tierable.approve_and_create
 escrow_uid = escrow_receipt["log"]["uid"]
 ```
 
+**CLI**
+
+```bash
+# Step 1: Encode the TrustedOracleArbiter demand
+alkahest arbiter encode-demand \
+  --type trusted-oracle \
+  --oracle 0xCHARLIE_ADDRESS \
+  --data 0x   # extra data for the oracle (can embed the query)
+# Returns: { "success": true, "data": { "encoded": "0x..." } }
+
+# Step 2: Create the escrow with the encoded demand
+alkahest --private-key 0xALICE_KEY escrow create \
+  --erc20 \
+  --token 0xERC20_TOKEN \
+  --amount 100000000000000000000 \
+  --arbiter 0xTRUSTED_ORACLE_ARBITER \
+  --demand 0xENCODED_DEMAND \
+  --expiration 1735689600 \
+  --approve
+# Returns: { "success": true, "data": { "uid": "0xESCROW_UID", ... } }
+```
+
 ## Fulfilling a job and requesting arbitration
 
 The `data` field of TrustedOracleArbiter doesn't enforce any kind of schema, so you have to come to an agreement with a buyer beforehand in order to understand and parse their query. StringObligation is a similarly flexible contract that you can use for fulfillments when the data won't be used directly by other on-chain contracts.
 
 Note that the fulfillment should contain a copy or reference to the demand it's intended to fulfill. This is needed to prevent a fulfillment that's valid for one query being used to claim another escrow demanding the same judge, but with a different query. Usually, this is done by setting the escrow attestation as the refUID of the fulfillment.
-
-**CLI**
-
-```bash
-# Bob: Submit the result as a string fulfillment referencing the escrow
-alkahest --private-key 0xBOB_KEY string create \
-  --item "HELLO WORLD" \
-  --ref-uid 0xESCROW_UID
-# Returns: { "success": true, "data": { "uid": "0xFULFILLMENT_UID", ... } }
-
-# Charlie (oracle): Arbitrate the fulfillment
-alkahest --private-key 0xCHARLIE_KEY arbiter arbitrate \
-  --obligation 0xFULFILLMENT_UID \
-  --demand 0xDEMAND_HEX \
-  --decision true
-```
 
 **Solidity**
 
@@ -233,6 +217,22 @@ fulfillment_uid = await bob_client.string_obligation.do_obligation(
     "HELLO WORLD",  # The computed result (capitalized)
     escrow_uid      # Reference to the escrow being fulfilled
 )
+```
+
+**CLI**
+
+```bash
+# Bob: Submit the result as a string fulfillment referencing the escrow
+alkahest --private-key 0xBOB_KEY string create \
+  --item "HELLO WORLD" \
+  --ref-uid 0xESCROW_UID
+# Returns: { "success": true, "data": { "uid": "0xFULFILLMENT_UID", ... } }
+
+# Charlie (oracle): Arbitrate the fulfillment
+alkahest --private-key 0xCHARLIE_KEY arbiter arbitrate \
+  --obligation 0xFULFILLMENT_UID \
+  --demand 0xDEMAND_HEX \
+  --decision true
 ```
 
 Charlie should listen for `ArbitrationRequested` events demanding him as the oracle. Then he can retrieve the attestation from EAS, decide if it's valid, and use the arbitrate function on TrustedOracleArbiter to submit his decision on-chain.
@@ -434,20 +434,6 @@ unwatch = await charlie_client.oracle.listen_and_arbitrate_for_escrow_no_spawn(
 
 Bob can listen for the `ArbitrationMade` event from TrustedOracleArbiter, then claim the escrow if the decision was positive, or retry if not.
 
-**CLI**
-
-```bash
-# Bob: Collect the escrow after successful arbitration
-alkahest --private-key 0xBOB_KEY escrow collect \
-  --erc20 \
-  --escrow-uid 0xESCROW_UID \
-  --fulfillment-uid 0xFULFILLMENT_UID
-
-# Or wait for fulfillment (blocks until someone fulfills and collects)
-alkahest --private-key 0xALICE_KEY escrow wait \
-  --erc20 --uid 0xESCROW_UID
-```
-
 **Solidity**
 
 ```solidity
@@ -554,15 +540,21 @@ async def check_arbitration():
 result = await check_arbitration()
 ```
 
-If no valid fulfillment is made, Alice can reclaim the escrow after it expires.
-
 **CLI**
 
 ```bash
-# Alice reclaims her expired escrow
-alkahest --private-key 0xALICE_KEY escrow reclaim \
+# Bob: Collect the escrow after successful arbitration
+alkahest --private-key 0xBOB_KEY escrow collect \
+  --erc20 \
+  --escrow-uid 0xESCROW_UID \
+  --fulfillment-uid 0xFULFILLMENT_UID
+
+# Or wait for fulfillment (blocks until someone fulfills and collects)
+alkahest --private-key 0xALICE_KEY escrow wait \
   --erc20 --uid 0xESCROW_UID
 ```
+
+If no valid fulfillment is made, Alice can reclaim the escrow after it expires.
 
 **Solidity**
 
@@ -595,6 +587,14 @@ alice_client
 ```python
 # Alice reclaims her expired escrow
 await alice_client.erc20.escrow.non_tierable.reclaim_expired(escrow_uid)
+```
+
+**CLI**
+
+```bash
+# Alice reclaims her expired escrow
+alkahest --private-key 0xALICE_KEY escrow reclaim \
+  --erc20 --uid 0xESCROW_UID
 ```
 
 ## SDK utilities

--- a/docs/Escrow Flow (pt 2b - Frontrunning Protection).md
+++ b/docs/Escrow Flow (pt 2b - Frontrunning Protection).md
@@ -26,34 +26,6 @@ Since CommitRevealObligation only enforces the commit-reveal protocol — it doe
 - A valid commit-reveal (prevents frontrunning)
 - Charlie's approval (validates the result)
 
-**CLI**
-
-```bash
-# Step 1: Encode oracle demand
-alkahest arbiter encode-demand \
-  --type trusted-oracle \
-  --oracle 0xCHARLIE --data 0x
-# → { "encoded": "0xORACLE_DEMAND" }
-
-# Step 2: Compose with AllArbiter (commit-reveal + oracle)
-# Get contract addresses first
-alkahest config show --chain base-sepolia
-# Use commitRevealObligation and trustedOracleArbiter addresses
-
-alkahest arbiter encode-demand --type all \
-  --demands '[{"arbiter":"0xCOMMIT_REVEAL_OBLIGATION","demand":"0x"},{"arbiter":"0xTRUSTED_ORACLE_ARBITER","demand":"0xORACLE_DEMAND"}]'
-# → { "encoded": "0xCOMPOSED_DEMAND" }
-
-# Step 3: Create escrow with the composed demand
-alkahest --private-key 0xALICE_KEY escrow create \
-  --erc20 \
-  --token 0xERC20_TOKEN --amount 100000000000000000000 \
-  --arbiter 0xALL_ARBITER \
-  --demand 0xCOMPOSED_DEMAND \
-  --expiration 1735689600 \
-  --approve
-```
-
 **Solidity**
 
 ```solidity
@@ -86,7 +58,7 @@ bytes32 escrowUid = erc20EscrowObligation.doObligation(
 );
 ```
 
-**Viem**
+**TypeScript**
 
 ```typescript
 import { encodeAbiParameters, parseAbiParameters } from "viem";
@@ -113,7 +85,7 @@ const { attested: escrow } = await aliceClient.erc20.escrow.nonTierable.permitAn
 );
 ```
 
-**Alloy**
+**Rust**
 
 ```rust
 use alloy::sol_types::SolValue;
@@ -184,28 +156,39 @@ escrow_receipt = await alice_client.erc20.escrow.non_tierable.permit_and_create(
 escrow_uid = escrow_receipt["log"]["uid"]
 ```
 
+**CLI**
+
+```bash
+# Step 1: Encode oracle demand
+alkahest arbiter encode-demand \
+  --type trusted-oracle \
+  --oracle 0xCHARLIE --data 0x
+# → { "encoded": "0xORACLE_DEMAND" }
+
+# Step 2: Compose with AllArbiter (commit-reveal + oracle)
+# Get contract addresses first
+alkahest config show --chain base-sepolia
+# Use commitRevealObligation and trustedOracleArbiter addresses
+
+alkahest arbiter encode-demand --type all \
+  --demands '[{"arbiter":"0xCOMMIT_REVEAL_OBLIGATION","demand":"0x"},{"arbiter":"0xTRUSTED_ORACLE_ARBITER","demand":"0xORACLE_DEMAND"}]'
+# → { "encoded": "0xCOMPOSED_DEMAND" }
+
+# Step 3: Create escrow with the composed demand
+alkahest --private-key 0xALICE_KEY escrow create \
+  --erc20 \
+  --token 0xERC20_TOKEN --amount 100000000000000000000 \
+  --arbiter 0xALL_ARBITER \
+  --demand 0xCOMPOSED_DEMAND \
+  --expiration 1735689600 \
+  --approve
+```
+
 ## Committing to a fulfillment
 
 Bob computes his result, then commits to it before revealing. The commitment binds the data to Bob's address and the specific escrow, so no one else can use it.
 
 The `payload` field holds the actual result data (here, the ABI-encoded string). The `salt` is a random value Bob generates to make the commitment unpredictable. The `schema` field is an arbitrary tag describing the payload format — it's not enforced on-chain but helps off-chain consumers decode the payload.
-
-**CLI**
-
-```bash
-# Compute the commitment hash
-alkahest --private-key 0xBOB_KEY commit-reveal compute-commitment \
-  --ref-uid 0xESCROW_UID \
-  --claimer 0xBOB_ADDRESS \
-  --payload 0xPAYLOAD_HEX \
-  --salt 0xRANDOM_SALT_HEX \
-  --schema 0x0000000000000000000000000000000000000000000000000000000000000000
-# → { "commitment": "0x..." }
-
-# Submit the commitment with bond
-alkahest --private-key 0xBOB_KEY commit-reveal commit \
-  --commitment 0xCOMMITMENT_HASH
-```
 
 **Solidity**
 
@@ -224,7 +207,7 @@ bytes32 commitment = commitRevealObligation.computeCommitment(escrowUid, bob, da
 commitRevealObligation.commit{value: commitRevealObligation.bondAmount()}(commitment);
 ```
 
-**Viem**
+**TypeScript**
 
 ```typescript
 import { keccak256, toHex } from "viem";
@@ -247,7 +230,7 @@ const commitment = await bobClient.commitReveal.computeCommitment(
 const { hash: commitTx } = await bobClient.commitReveal.commit(commitment);
 ```
 
-**Alloy**
+**Rust**
 
 ```rust
 use alloy::primitives::{Bytes, FixedBytes};
@@ -296,21 +279,26 @@ commitment = await bob_client.commit_reveal.compute_commitment(
 commit_tx = await bob_client.commit_reveal.commit(commitment)
 ```
 
-## Revealing the fulfillment
-
-After waiting at least one block, Bob reveals his data by calling `doObligation()`. This creates an EAS attestation containing the payload, salt, and schema tag. The escrow UID is set as the attestation's `refUID`, linking the fulfillment to the escrow.
-
 **CLI**
 
 ```bash
-# Reveal the fulfillment (must be in a later block than the commit)
-alkahest --private-key 0xBOB_KEY commit-reveal reveal \
+# Compute the commitment hash
+alkahest --private-key 0xBOB_KEY commit-reveal compute-commitment \
+  --ref-uid 0xESCROW_UID \
+  --claimer 0xBOB_ADDRESS \
   --payload 0xPAYLOAD_HEX \
   --salt 0xRANDOM_SALT_HEX \
-  --schema 0x0000000000000000000000000000000000000000000000000000000000000000 \
-  --ref-uid 0xESCROW_UID
-# → { "uid": "0xFULFILLMENT_UID", ... }
+  --schema 0x0000000000000000000000000000000000000000000000000000000000000000
+# → { "commitment": "0x..." }
+
+# Submit the commitment with bond
+alkahest --private-key 0xBOB_KEY commit-reveal commit \
+  --commitment 0xCOMMITMENT_HASH
 ```
+
+## Revealing the fulfillment
+
+After waiting at least one block, Bob reveals his data by calling `doObligation()`. This creates an EAS attestation containing the payload, salt, and schema tag. The escrow UID is set as the attestation's `refUID`, linking the fulfillment to the escrow.
 
 **Solidity**
 
@@ -319,7 +307,7 @@ alkahest --private-key 0xBOB_KEY commit-reveal reveal \
 bytes32 fulfillmentUid = commitRevealObligation.doObligation(data, escrowUid);
 ```
 
-**Viem**
+**TypeScript**
 
 ```typescript
 // Bob reveals his fulfillment (must be in a later block than the commit)
@@ -329,7 +317,7 @@ const { hash: revealTx, attested: fulfillment } = await bobClient.commitReveal.d
 );
 ```
 
-**Alloy**
+**Rust**
 
 ```rust
 // Bob reveals his fulfillment (must be in a later block than the commit)
@@ -352,25 +340,21 @@ fulfillment_uid = await bob_client.commit_reveal.do_obligation(
 )
 ```
 
-## Arbitration and claiming
-
-The arbitration and claiming process is the same as in [pt 2](Escrow%20Flow%20(pt%202%20-%20Job%20Trading).md), with one difference: the fulfillment attestation is from CommitRevealObligation rather than StringObligation, so Charlie needs to decode `ObligationData` to extract the payload.
-
 **CLI**
 
 ```bash
-# Charlie arbitrates the fulfillment (same as pt 2)
-alkahest --private-key 0xCHARLIE_KEY arbiter arbitrate \
-  --obligation 0xFULFILLMENT_UID \
-  --demand 0xORACLE_DEMAND \
-  --decision true
-
-# Bob collects the escrow
-alkahest --private-key 0xBOB_KEY escrow collect \
-  --erc20 \
-  --escrow-uid 0xESCROW_UID \
-  --fulfillment-uid 0xFULFILLMENT_UID
+# Reveal the fulfillment (must be in a later block than the commit)
+alkahest --private-key 0xBOB_KEY commit-reveal reveal \
+  --payload 0xPAYLOAD_HEX \
+  --salt 0xRANDOM_SALT_HEX \
+  --schema 0x0000000000000000000000000000000000000000000000000000000000000000 \
+  --ref-uid 0xESCROW_UID
+# → { "uid": "0xFULFILLMENT_UID", ... }
 ```
+
+## Arbitration and claiming
+
+The arbitration and claiming process is the same as in [pt 2](Escrow%20Flow%20(pt%202%20-%20Job%20Trading).md), with one difference: the fulfillment attestation is from CommitRevealObligation rather than StringObligation, so Charlie needs to decode `ObligationData` to extract the payload.
 
 **Solidity**
 
@@ -388,7 +372,7 @@ bool isValid = /* validate result against the query */;
 trustedOracleArbiter.arbitrate(fulfillmentUid, isValid);
 ```
 
-**Viem**
+**TypeScript**
 
 ```typescript
 // In Charlie's arbitration callback, decode the CommitRevealObligation data
@@ -429,7 +413,7 @@ const { unwatch } = await charlieClient.oracle.listenAndArbitrateForEscrow({
 });
 ```
 
-**Alloy**
+**Rust**
 
 ```rust
 use alloy::sol_types::SolValue;
@@ -467,6 +451,22 @@ is_valid = result == query[11:].upper() if query.startswith("capitalize ") else 
 await charlie_client.oracle.arbitrate(fulfillment_uid, is_valid)
 ```
 
+**CLI**
+
+```bash
+# Charlie arbitrates the fulfillment (same as pt 2)
+alkahest --private-key 0xCHARLIE_KEY arbiter arbitrate \
+  --obligation 0xFULFILLMENT_UID \
+  --demand 0xORACLE_DEMAND \
+  --decision true
+
+# Bob collects the escrow
+alkahest --private-key 0xBOB_KEY escrow collect \
+  --erc20 \
+  --escrow-uid 0xESCROW_UID \
+  --fulfillment-uid 0xFULFILLMENT_UID
+```
+
 Once Charlie approves, Bob claims the escrow exactly as in pt 2:
 
 **Solidity**
@@ -475,13 +475,13 @@ Once Charlie approves, Bob claims the escrow exactly as in pt 2:
 erc20EscrowObligation.collectEscrow(escrowUid, fulfillmentUid);
 ```
 
-**Viem**
+**TypeScript**
 
 ```typescript
 await bobClient.erc20.escrow.nonTierable.collect(escrow.uid, fulfillment.uid);
 ```
 
-**Alloy**
+**Rust**
 
 ```rust
 bob_client
@@ -502,26 +502,19 @@ await bob_client.erc20.escrow.non_tierable.collect(escrow_uid, fulfillment_uid)
 
 After a successful reveal (and escrow collection), Bob can reclaim his bond. The bond is returned to the address that committed (Bob).
 
-**CLI**
-
-```bash
-alkahest --private-key 0xBOB_KEY commit-reveal reclaim-bond \
-  --uid 0xFULFILLMENT_UID
-```
-
 **Solidity**
 
 ```solidity
 commitRevealObligation.reclaimBond(fulfillmentUid);
 ```
 
-**Viem**
+**TypeScript**
 
 ```typescript
 const { hash: reclaimTx } = await bobClient.commitReveal.reclaimBond(fulfillment.uid);
 ```
 
-**Alloy**
+**Rust**
 
 ```rust
 let reclaim_receipt = bob_client
@@ -536,17 +529,16 @@ let reclaim_receipt = bob_client
 reclaim_tx = await bob_client.commit_reveal.reclaim_bond(fulfillment_uid)
 ```
 
-## Bond slashing
-
-If a commitment goes unrevealed past the deadline, anyone can slash the bond. This disincentivizes spam commits that clutter the commitment space. The slashed bond is sent to a preconfigured recipient (or burned if set to `address(0)`).
-
 **CLI**
 
 ```bash
-# Slash an unrevealed commitment's bond (anyone can call after deadline)
-alkahest --private-key 0xANY_KEY commit-reveal slash-bond \
-  --commitment 0xCOMMITMENT_HASH
+alkahest --private-key 0xBOB_KEY commit-reveal reclaim-bond \
+  --uid 0xFULFILLMENT_UID
 ```
+
+## Bond slashing
+
+If a commitment goes unrevealed past the deadline, anyone can slash the bond. This disincentivizes spam commits that clutter the commitment space. The slashed bond is sent to a preconfigured recipient (or burned if set to `address(0)`).
 
 **Solidity**
 
@@ -555,7 +547,7 @@ alkahest --private-key 0xANY_KEY commit-reveal slash-bond \
 commitRevealObligation.slashBond(commitment);
 ```
 
-**Viem**
+**TypeScript**
 
 ```typescript
 // Check the deadline first
@@ -566,7 +558,7 @@ const [commitBlock, commitTimestamp, committer] = await bobClient.commitReveal.g
 const { hash: slashTx } = await anyClient.commitReveal.slashBond(commitment);
 ```
 
-**Alloy**
+**Rust**
 
 ```rust
 // Check the deadline first
@@ -594,6 +586,14 @@ deadline = await client.commit_reveal.commit_deadline()
 slash_tx = await client.commit_reveal.slash_bond(commitment)
 ```
 
+**CLI**
+
+```bash
+# Slash an unrevealed commitment's bond (anyone can call after deadline)
+alkahest --private-key 0xANY_KEY commit-reveal slash-bond \
+  --commitment 0xCOMMITMENT_HASH
+```
+
 ## Configuration
 
 CommitRevealObligation has three owner-configurable parameters:
@@ -604,14 +604,7 @@ CommitRevealObligation has three owner-configurable parameters:
 
 You can query these via the CLI or SDK:
 
-**CLI**
-
-```bash
-alkahest --private-key 0xKEY commit-reveal info
-# → { "bondAmount": "...", "commitDeadline": "...", "slashedBondRecipient": "0x..." }
-```
-
-**Viem**
+**TypeScript**
 
 ```typescript
 const bondAmount = await client.commitReveal.getBondAmount();
@@ -619,7 +612,7 @@ const deadline = await client.commitReveal.getCommitDeadline();
 const recipient = await client.commitReveal.getSlashedBondRecipient();
 ```
 
-**Alloy**
+**Rust**
 
 ```rust
 let bond_amount = client.commit_reveal().bond_amount().await?;
@@ -633,4 +626,11 @@ let recipient = client.commit_reveal().slashed_bond_recipient().await?;
 bond_amount = await client.commit_reveal.bond_amount()
 deadline = await client.commit_reveal.commit_deadline()
 recipient = await client.commit_reveal.slashed_bond_recipient()
+```
+
+**CLI**
+
+```bash
+alkahest --private-key 0xKEY commit-reveal info
+# → { "bondAmount": "...", "commitDeadline": "...", "slashedBondRecipient": "0x..." }
 ```

--- a/docs/Escrow Flow (pt 3 - Composing Demands).md
+++ b/docs/Escrow Flow (pt 3 - Composing Demands).md
@@ -10,34 +10,6 @@ The logical arbiter contracts AnyArbiter and AllArbiter can be used to compose d
 
 You can use AllArbiter to demand multiple conditions at the same time. For example, that your task is completed by a particular individual before a deadline, and validated by a third party.
 
-**CLI**
-
-```bash
-# Encode individual demands
-alkahest arbiter encode-demand --type recipient \
-  --recipient 0xBOB
-# → { "encoded": "0xRECIPIENT_DEMAND" }
-
-alkahest arbiter encode-demand --type trusted-oracle \
-  --oracle 0xCHARLIE --data 0x
-# → { "encoded": "0xORACLE_DEMAND" }
-
-# Compose with AllArbiter - both conditions must be met
-# Use addresses from: alkahest config show --chain base-sepolia
-alkahest arbiter encode-demand --type all \
-  --demands '[{"arbiter":"0xRECIPIENT_ARBITER","demand":"0xRECIPIENT_DEMAND"},{"arbiter":"0xTRUSTED_ORACLE_ARBITER","demand":"0xORACLE_DEMAND"}]'
-# → { "encoded": "0xCOMPOSED_DEMAND" }
-
-# Create escrow with the composed demand
-alkahest --private-key 0xALICE_KEY escrow create \
-  --erc20 \
-  --token 0xERC20_TOKEN --amount 100000000000000000000 \
-  --arbiter 0xALL_ARBITER \
-  --demand 0xCOMPOSED_DEMAND \
-  --expiration 1735689600 \
-  --approve
-```
-
 **Solidity**
 
 ```solidity
@@ -76,7 +48,7 @@ bytes32 escrowUid = erc20EscrowObligation.doObligation(
 );
 ```
 
-**Viem**
+**TypeScript**
 
 ```typescript
 // Example: Require job completed by specific recipient AND validated by oracle
@@ -106,7 +78,7 @@ const { attested: escrow } = await aliceClient.erc20.escrow.nonTierable.permitAn
 );
 ```
 
-**Alloy**
+**Rust**
 
 ```rust
 use alloy::sol_types::SolValue;
@@ -176,38 +148,35 @@ escrow_receipt = await alice_client.erc20.escrow.non_tierable.permit_and_create(
 )
 ```
 
-You can use AnyArbiter when multiple alternative conditions can be considered valid. For example, if you accept a decision from any of a list of trusted third party oracles, or if there are different proof mechanisms that equally ensure the validity of a result.
-
 **CLI**
 
 ```bash
-# Encode individual oracle demands
+# Encode individual demands
+alkahest arbiter encode-demand --type recipient \
+  --recipient 0xBOB
+# → { "encoded": "0xRECIPIENT_DEMAND" }
+
 alkahest arbiter encode-demand --type trusted-oracle \
   --oracle 0xCHARLIE --data 0x
-# → { "encoded": "0xORACLE1_DEMAND" }
+# → { "encoded": "0xORACLE_DEMAND" }
 
-alkahest arbiter encode-demand --type trusted-oracle \
-  --oracle 0xDAVE --data 0x
-# → { "encoded": "0xORACLE2_DEMAND" }
-
-alkahest arbiter encode-demand --type trusted-oracle \
-  --oracle 0xEVE --data 0x
-# → { "encoded": "0xORACLE3_DEMAND" }
-
-# Compose with AnyArbiter - any one oracle can validate
-alkahest arbiter encode-demand --type any \
-  --demands '[{"arbiter":"0xTRUSTED_ORACLE_ARBITER","demand":"0xORACLE1_DEMAND"},{"arbiter":"0xTRUSTED_ORACLE_ARBITER","demand":"0xORACLE2_DEMAND"},{"arbiter":"0xTRUSTED_ORACLE_ARBITER","demand":"0xORACLE3_DEMAND"}]'
+# Compose with AllArbiter - both conditions must be met
+# Use addresses from: alkahest config show --chain base-sepolia
+alkahest arbiter encode-demand --type all \
+  --demands '[{"arbiter":"0xRECIPIENT_ARBITER","demand":"0xRECIPIENT_DEMAND"},{"arbiter":"0xTRUSTED_ORACLE_ARBITER","demand":"0xORACLE_DEMAND"}]'
 # → { "encoded": "0xCOMPOSED_DEMAND" }
 
-# Create escrow with flexible oracle validation
+# Create escrow with the composed demand
 alkahest --private-key 0xALICE_KEY escrow create \
   --erc20 \
-  --token 0xERC20_TOKEN --amount 50000000000000000000 \
-  --arbiter 0xANY_ARBITER \
+  --token 0xERC20_TOKEN --amount 100000000000000000000 \
+  --arbiter 0xALL_ARBITER \
   --demand 0xCOMPOSED_DEMAND \
   --expiration 1735689600 \
   --approve
 ```
+
+You can use AnyArbiter when multiple alternative conditions can be considered valid. For example, if you accept a decision from any of a list of trusted third party oracles, or if there are different proof mechanisms that equally ensure the validity of a result.
 
 **Solidity**
 
@@ -258,7 +227,7 @@ bytes32 escrowUid = erc20EscrowObligation.doObligation(
 );
 ```
 
-**Viem**
+**TypeScript**
 
 ```typescript
 // Example: Accept validation from ANY of multiple trusted oracles
@@ -297,7 +266,7 @@ const { attested: escrow } = await aliceClient.erc20.escrow.nonTierable.approveA
 );
 ```
 
-**Alloy**
+**Rust**
 
 ```rust
 // Example: Accept validation from ANY of multiple trusted oracles
@@ -372,43 +341,38 @@ escrow_receipt = await alice_client.erc20.escrow.non_tierable.approve_and_create
 )
 ```
 
-Logical arbiters can be stacked. For example, you could demand that a job is completed before a deadline by a particular party, and validated by any of a list of trusted oracles.
-
 **CLI**
 
 ```bash
-# Encode individual demands
-alkahest arbiter encode-demand --type time-before --time 1735693200
-# → { "encoded": "0xDEADLINE_DEMAND" }
-
-alkahest arbiter encode-demand --type recipient --recipient 0xBOB
-# → { "encoded": "0xRECIPIENT_DEMAND" }
-
-alkahest arbiter encode-demand --type trusted-oracle --oracle 0xCHARLIE --data 0x
+# Encode individual oracle demands
+alkahest arbiter encode-demand --type trusted-oracle \
+  --oracle 0xCHARLIE --data 0x
 # → { "encoded": "0xORACLE1_DEMAND" }
 
-alkahest arbiter encode-demand --type trusted-oracle --oracle 0xDAVE --data 0x
+alkahest arbiter encode-demand --type trusted-oracle \
+  --oracle 0xDAVE --data 0x
 # → { "encoded": "0xORACLE2_DEMAND" }
 
-# Create the OR condition for oracles
+alkahest arbiter encode-demand --type trusted-oracle \
+  --oracle 0xEVE --data 0x
+# → { "encoded": "0xORACLE3_DEMAND" }
+
+# Compose with AnyArbiter - any one oracle can validate
 alkahest arbiter encode-demand --type any \
-  --demands '[{"arbiter":"0xTRUSTED_ORACLE_ARBITER","demand":"0xORACLE1_DEMAND"},{"arbiter":"0xTRUSTED_ORACLE_ARBITER","demand":"0xORACLE2_DEMAND"}]'
-# → { "encoded": "0xORACLE_OR_DEMAND" }
+  --demands '[{"arbiter":"0xTRUSTED_ORACLE_ARBITER","demand":"0xORACLE1_DEMAND"},{"arbiter":"0xTRUSTED_ORACLE_ARBITER","demand":"0xORACLE2_DEMAND"},{"arbiter":"0xTRUSTED_ORACLE_ARBITER","demand":"0xORACLE3_DEMAND"}]'
+# → { "encoded": "0xCOMPOSED_DEMAND" }
 
-# Combine all conditions with AllArbiter: deadline AND recipient AND (oracle1 OR oracle2)
-alkahest arbiter encode-demand --type all \
-  --demands '[{"arbiter":"0xTIME_BEFORE_ARBITER","demand":"0xDEADLINE_DEMAND"},{"arbiter":"0xRECIPIENT_ARBITER","demand":"0xRECIPIENT_DEMAND"},{"arbiter":"0xANY_ARBITER","demand":"0xORACLE_OR_DEMAND"}]'
-# → { "encoded": "0xFINAL_DEMAND" }
-
-# Create the escrow with nested logical arbiters
+# Create escrow with flexible oracle validation
 alkahest --private-key 0xALICE_KEY escrow create \
   --erc20 \
-  --token 0xERC20_TOKEN --amount 200000000000000000000 \
-  --arbiter 0xALL_ARBITER \
-  --demand 0xFINAL_DEMAND \
-  --expiration 1735700400 \
+  --token 0xERC20_TOKEN --amount 50000000000000000000 \
+  --arbiter 0xANY_ARBITER \
+  --demand 0xCOMPOSED_DEMAND \
+  --expiration 1735689600 \
   --approve
 ```
+
+Logical arbiters can be stacked. For example, you could demand that a job is completed before a deadline by a particular party, and validated by any of a list of trusted oracles.
 
 **Solidity**
 
@@ -476,7 +440,7 @@ bytes32 escrowUid = erc20EscrowObligation.doObligation(
 );
 ```
 
-**Viem**
+**TypeScript**
 
 ```typescript
 // Example: Complex composition - deadline AND recipient AND (oracle1 OR oracle2)
@@ -524,7 +488,7 @@ const { attested: escrow } = await aliceClient.erc20.escrow.nonTierable.approveA
 );
 ```
 
-**Alloy**
+**Rust**
 
 ```rust
 // Example: Complex composition - deadline AND recipient AND (oracle1 OR oracle2)
@@ -622,19 +586,45 @@ escrow_receipt = await alice_client.erc20.escrow.non_tierable.approve_and_create
 )
 ```
 
-## Parsing composed demands
-
-The CLI and SDKs provide built-in support for recursively parsing composed demands. The parsers automatically detect the arbiter type and decode each sub-demand appropriately.
-
 **CLI**
 
 ```bash
-# Decode a composed demand given the arbiter address and encoded demand hex
-alkahest arbiter decode-demand \
+# Encode individual demands
+alkahest arbiter encode-demand --type time-before --time 1735693200
+# → { "encoded": "0xDEADLINE_DEMAND" }
+
+alkahest arbiter encode-demand --type recipient --recipient 0xBOB
+# → { "encoded": "0xRECIPIENT_DEMAND" }
+
+alkahest arbiter encode-demand --type trusted-oracle --oracle 0xCHARLIE --data 0x
+# → { "encoded": "0xORACLE1_DEMAND" }
+
+alkahest arbiter encode-demand --type trusted-oracle --oracle 0xDAVE --data 0x
+# → { "encoded": "0xORACLE2_DEMAND" }
+
+# Create the OR condition for oracles
+alkahest arbiter encode-demand --type any \
+  --demands '[{"arbiter":"0xTRUSTED_ORACLE_ARBITER","demand":"0xORACLE1_DEMAND"},{"arbiter":"0xTRUSTED_ORACLE_ARBITER","demand":"0xORACLE2_DEMAND"}]'
+# → { "encoded": "0xORACLE_OR_DEMAND" }
+
+# Combine all conditions with AllArbiter: deadline AND recipient AND (oracle1 OR oracle2)
+alkahest arbiter encode-demand --type all \
+  --demands '[{"arbiter":"0xTIME_BEFORE_ARBITER","demand":"0xDEADLINE_DEMAND"},{"arbiter":"0xRECIPIENT_ARBITER","demand":"0xRECIPIENT_DEMAND"},{"arbiter":"0xANY_ARBITER","demand":"0xORACLE_OR_DEMAND"}]'
+# → { "encoded": "0xFINAL_DEMAND" }
+
+# Create the escrow with nested logical arbiters
+alkahest --private-key 0xALICE_KEY escrow create \
+  --erc20 \
+  --token 0xERC20_TOKEN --amount 200000000000000000000 \
   --arbiter 0xALL_ARBITER \
-  --demand 0xCOMPOSED_DEMAND_HEX
-# → Recursively decoded demand structure as JSON
+  --demand 0xFINAL_DEMAND \
+  --expiration 1735700400 \
+  --approve
 ```
+
+## Parsing composed demands
+
+The CLI and SDKs provide built-in support for recursively parsing composed demands. The parsers automatically detect the arbiter type and decode each sub-demand appropriately.
 
 **Solidity**
 
@@ -667,7 +657,7 @@ require(arbiters[0] == address(timeBeforeArbiter), "First arbiter must be TimeBe
 require(arbiters[1] == address(recipientArbiter), "Second arbiter must be RecipientArbiter");
 ```
 
-**Viem**
+**TypeScript**
 
 ```typescript
 import { decodeDemandWithAddresses } from "alkahest-ts/utils/demandParsing";
@@ -700,7 +690,7 @@ if (decoded.isUnknown) {
 }
 ```
 
-**Alloy**
+**Rust**
 
 ```rust
 use alkahest_rs::contracts::arbiters::logical::AllArbiter as AllArbiterContract;
@@ -773,6 +763,16 @@ for demand in decoded.demands:
 # For AnyArbiter, use the any decoder
 decoded_any = alice_client.arbiters.logical.any.decode(any_arbiter_demand)
 print(f"AnyArbiter sub-demands: {len(decoded_any.demands)}")
+```
+
+**CLI**
+
+```bash
+# Decode a composed demand given the arbiter address and encoded demand hex
+alkahest arbiter decode-demand \
+  --arbiter 0xALL_ARBITER \
+  --demand 0xCOMPOSED_DEMAND_HEX
+# → Recursively decoded demand structure as JSON
 ```
 
 For custom arbiters not included in the SDK's built-in decoders, you can extend the decoder registry (TypeScript) or manually decode the raw bytes using ABI decoding.


### PR DESCRIPTION
## Summary
- Rename **Viem** → **TypeScript** and **Alloy** → **Rust** labels in Composing Demands and Frontrunning Protection docs where sections use SDK client methods rather than raw library calls
- Reorder all code example groups so CLI is listed last (Solidity first as the most illustrative default)

🤖 Generated with [Claude Code](https://claude.com/claude-code)