### PR TITLE
feat(sdks): Add deferred oracle decisions and Charlie as third test account

### DIFF
--- a/sdks/py/alkahest_py/conftest.py
+++ b/sdks/py/alkahest_py/conftest.py
@@ -55,3 +55,21 @@ def bob_client(env):
         rpc_url=env.rpc_url,
         address_config=env.addresses,
     )
+
+
+@pytest.fixture
+def charlie_client(env):
+    """
+    Create an AlkahestClient for Charlie using the user-facing constructor.
+
+    This ensures tests exercise the same initialization path that real users hit,
+    catching any bugs in the Python SDK client construction.
+
+    Returns:
+        AlkahestClient: A fully initialized client for Charlie's account.
+    """
+    return AlkahestClient(
+        private_key=env.charlie_private_key,
+        rpc_url=env.rpc_url,
+        address_config=env.addresses,
+    )

--- a/sdks/py/alkahest_py/oracle/test_arbitrate_direct.py
+++ b/sdks/py/alkahest_py/oracle/test_arbitrate_direct.py
@@ -13,7 +13,7 @@ from alkahest_py import (
 )
 
 @pytest.mark.asyncio
-async def test_arbitrate_direct(env, alice_client, bob_client):
+async def test_arbitrate_direct(env, alice_client, bob_client, charlie_client):
     """Test direct arbitration using oracle_client.arbitrate()"""
 
     # Setup escrow
@@ -27,7 +27,7 @@ async def test_arbitrate_direct(env, alice_client, bob_client):
     inner_demand_data = b""
 
     # Full encoded DemandData
-    demand_data = TrustedOracleArbiterDemandData(env.bob, inner_demand_data)
+    demand_data = TrustedOracleArbiterDemandData(env.charlie, inner_demand_data)
     demand_bytes = demand_data.encode_self()
 
     arbiter = {
@@ -45,11 +45,11 @@ async def test_arbitrate_direct(env, alice_client, bob_client):
     string_client = bob_client.string_obligation
     fulfillment_uid = await string_client.do_obligation("good", escrow_uid)
 
-    # Request arbitration
-    oracle_client = bob_client.oracle
-    await oracle_client.request_arbitration(fulfillment_uid, env.bob, inner_demand_data)
+    # Bob (fulfiller) requests Charlie (oracle) to arbitrate
+    await bob_client.oracle.request_arbitration(fulfillment_uid, env.charlie, inner_demand_data)
 
-    # Direct arbitration call
+    # Charlie (oracle) arbitrates directly
+    oracle_client = charlie_client.oracle
     tx_hash = await oracle_client.arbitrate(fulfillment_uid, inner_demand_data, True)
     assert tx_hash is not None, "Arbitration should return a transaction hash"
     assert tx_hash.startswith("0x"), f"Transaction hash should start with 0x, got {tx_hash}"
@@ -57,7 +57,7 @@ async def test_arbitrate_direct(env, alice_client, bob_client):
     print(f"Direct arbitration succeeded with tx: {tx_hash}")
 
 @pytest.mark.asyncio
-async def test_wait_for_arbitration(env, alice_client, bob_client):
+async def test_wait_for_arbitration(env, alice_client, bob_client, charlie_client):
     """Test waiting for arbitration event using oracle_client.wait_for_arbitration()"""
 
     # Setup escrow
@@ -68,7 +68,7 @@ async def test_wait_for_arbitration(env, alice_client, bob_client):
     trusted_oracle_arbiter = env.addresses.arbiters_addresses.trusted_oracle_arbiter
 
     inner_demand_data = b""
-    demand_data = TrustedOracleArbiterDemandData(env.bob, inner_demand_data)
+    demand_data = TrustedOracleArbiterDemandData(env.charlie, inner_demand_data)
     demand_bytes = demand_data.encode_self()
 
     arbiter = {
@@ -86,27 +86,29 @@ async def test_wait_for_arbitration(env, alice_client, bob_client):
     string_client = bob_client.string_obligation
     fulfillment_uid = await string_client.do_obligation("good", escrow_uid)
 
-    # Request and perform arbitration
-    oracle_client = bob_client.oracle
-    await oracle_client.request_arbitration(fulfillment_uid, env.bob, inner_demand_data)
+    # Bob (fulfiller) requests Charlie (oracle) to arbitrate
+    await bob_client.oracle.request_arbitration(fulfillment_uid, env.charlie, inner_demand_data)
+
+    # Charlie (oracle) arbitrates
+    oracle_client = charlie_client.oracle
     await oracle_client.arbitrate(fulfillment_uid, inner_demand_data, True)
 
     # Wait for arbitration event (should find it immediately since it's already done)
     event = await oracle_client.wait_for_arbitration(
         fulfillment_uid,
         inner_demand_data,
-        env.bob,
+        env.charlie,
         0  # from_block
     )
 
     assert event is not None, "Should find arbitration event"
     assert event.decision == True, f"Expected decision=True, got {event.decision}"
-    assert event.oracle.lower() == env.bob.lower(), "Oracle address should match"
+    assert event.oracle.lower() == env.charlie.lower(), "Oracle address should match"
 
     print(f"Found arbitration event: decision={event.decision}")
 
 @pytest.mark.asyncio
-async def test_get_escrow_attestation(env, alice_client, bob_client):
+async def test_get_escrow_attestation(env, alice_client, bob_client, charlie_client):
     """Test getting escrow attestation from a fulfillment attestation"""
 
     # Setup escrow
@@ -117,7 +119,7 @@ async def test_get_escrow_attestation(env, alice_client, bob_client):
     trusted_oracle_arbiter = env.addresses.arbiters_addresses.trusted_oracle_arbiter
 
     inner_demand_data = b""
-    demand_data = TrustedOracleArbiterDemandData(env.bob, inner_demand_data)
+    demand_data = TrustedOracleArbiterDemandData(env.charlie, inner_demand_data)
     demand_bytes = demand_data.encode_self()
 
     arbiter = {
@@ -135,9 +137,10 @@ async def test_get_escrow_attestation(env, alice_client, bob_client):
     string_client = bob_client.string_obligation
     fulfillment_uid = await string_client.do_obligation("test_data", escrow_uid)
 
-    # Request arbitration
-    oracle_client = bob_client.oracle
-    await oracle_client.request_arbitration(fulfillment_uid, env.bob, inner_demand_data)
+    # Bob (fulfiller) requests Charlie (oracle) to arbitrate
+    await bob_client.oracle.request_arbitration(fulfillment_uid, env.charlie, inner_demand_data)
+
+    oracle_client = charlie_client.oracle
 
     # Get a fulfillment attestation (we need to construct one with the ref_uid)
     from alkahest_py import OracleAttestation
@@ -163,7 +166,7 @@ async def test_get_escrow_attestation(env, alice_client, bob_client):
     print(f"Got escrow attestation: {escrow_attestation.uid}")
 
 @pytest.mark.asyncio
-async def test_get_escrow_and_demand(env, alice_client, bob_client):
+async def test_get_escrow_and_demand(env, alice_client, bob_client, charlie_client):
     """Test getting escrow attestation and demand data in one call"""
 
     # Setup escrow
@@ -174,7 +177,7 @@ async def test_get_escrow_and_demand(env, alice_client, bob_client):
     trusted_oracle_arbiter = env.addresses.arbiters_addresses.trusted_oracle_arbiter
 
     inner_demand_data = b"test_demand"
-    demand_data = TrustedOracleArbiterDemandData(env.bob, inner_demand_data)
+    demand_data = TrustedOracleArbiterDemandData(env.charlie, inner_demand_data)
     demand_bytes = demand_data.encode_self()
 
     arbiter = {
@@ -208,13 +211,13 @@ async def test_get_escrow_and_demand(env, alice_client, bob_client):
     )
 
     # Get escrow and demand in one call
-    oracle_client = bob_client.oracle
+    oracle_client = charlie_client.oracle
     escrow_attestation, extracted_demand = await oracle_client.get_escrow_and_demand(fulfillment_attestation)
 
     assert escrow_attestation is not None, "Should get escrow attestation"
     assert escrow_attestation.uid == escrow_uid, f"Escrow UID should match"
     assert extracted_demand is not None, "Should get demand data"
-    assert extracted_demand.oracle.lower() == env.bob.lower(), f"Oracle should match: {extracted_demand.oracle} vs {env.bob}"
+    assert extracted_demand.oracle.lower() == env.charlie.lower(), f"Oracle should match: {extracted_demand.oracle} vs {env.charlie}"
     assert bytes(extracted_demand.data) == inner_demand_data, f"Demand data should match: {bytes(extracted_demand.data)} vs {inner_demand_data}"
 
     print(f"Got escrow and demand: oracle={extracted_demand.oracle}, data={bytes(extracted_demand.data)}")

--- a/sdks/py/alkahest_py/oracle/test_arbitrate_past.py
+++ b/sdks/py/alkahest_py/oracle/test_arbitrate_past.py
@@ -14,9 +14,8 @@ from alkahest_py import (
 )
 
 @pytest.mark.asyncio
-async def test_arbitrate_past_sync(env, alice_client, bob_client):
+async def test_arbitrate_past_sync(env, alice_client, bob_client, charlie_client):
     """Test trivial arbitrate_many: escrow -> fulfillment -> arbitration -> collection"""
-    # Setup test environment
 
     # Setup escrow with proper oracle demand data
     mock_erc20 = MockERC20(env.mock_addresses.erc20_a, env.god_wallet_provider)
@@ -29,7 +28,7 @@ async def test_arbitrate_past_sync(env, alice_client, bob_client):
     inner_demand_data = b""  # Empty bytes for this simple test
 
     # The full encoded DemandData - this is what gets stored in the escrow
-    demand_data = TrustedOracleArbiterDemandData(env.bob, inner_demand_data)
+    demand_data = TrustedOracleArbiterDemandData(env.charlie, inner_demand_data)
     demand_bytes = demand_data.encode_self()
 
     arbiter = {
@@ -47,19 +46,18 @@ async def test_arbitrate_past_sync(env, alice_client, bob_client):
     string_client = bob_client.string_obligation
     fulfillment_uid = await string_client.do_obligation("good", escrow_uid)
 
-    # Request arbitration with inner demand data (not the full encoded DemandData)
-    # because TrustedOracleArbiter.checkObligation() uses only demand_.data for the decisionKey
-    oracle_client = bob_client.oracle
-    await oracle_client.request_arbitration(fulfillment_uid, env.bob, inner_demand_data)
+    # Bob (fulfiller) requests Charlie (oracle) to arbitrate
+    await bob_client.oracle.request_arbitration(fulfillment_uid, env.charlie, inner_demand_data)
 
     # Decision function that approves "good" obligations
     def decision_function(attestation, demand):
         """Decision function receives attestation and demand as separate arguments"""
-        obligation_str = bob_client.extract_obligation_data(attestation)
+        obligation_str = charlie_client.extract_obligation_data(attestation)
         print(f"Decision function called with obligation: {obligation_str}, demand: {len(demand)} bytes")
         return obligation_str == "good"
 
-    # Call arbitrate_many with simplified API
+    # Charlie (oracle) arbitrates
+    oracle_client = charlie_client.oracle
     decisions = await oracle_client.arbitrate_many(decision_function, None, ArbitrationMode.Past)
 
     # Verify arbitration found decisions
@@ -76,9 +74,8 @@ async def test_arbitrate_past_sync(env, alice_client, bob_client):
     print(f"Arbitrate decision passed. Tx: {collection_receipt}")
 
 @pytest.mark.asyncio
-async def test_conditional_arbitrate_past(env, alice_client, bob_client):
+async def test_conditional_arbitrate_past(env, alice_client, bob_client, charlie_client):
     """Test conditional arbitrate_many: approve only 'good' obligations"""
-    # Setup test environment
 
     # Setup escrow
     mock_erc20 = MockERC20(env.mock_addresses.erc20_a, env.god_wallet_provider)
@@ -91,7 +88,7 @@ async def test_conditional_arbitrate_past(env, alice_client, bob_client):
     inner_demand_data = b""  # Empty bytes for this simple test
 
     # The full encoded DemandData - this is what gets stored in the escrow
-    demand_data = TrustedOracleArbiterDemandData(env.bob, inner_demand_data)
+    demand_data = TrustedOracleArbiterDemandData(env.charlie, inner_demand_data)
     demand_bytes = demand_data.encode_self()
 
     arbiter = {
@@ -110,18 +107,17 @@ async def test_conditional_arbitrate_past(env, alice_client, bob_client):
     good_fulfillment = await string_client.do_obligation("good", escrow_uid)
     bad_fulfillment = await string_client.do_obligation("bad", escrow_uid)
 
-    # Request arbitration for both with inner demand data (not the full encoded DemandData)
-    # because TrustedOracleArbiter.checkObligation() uses only demand_.data for the decisionKey
-    oracle_client = bob_client.oracle
-    await oracle_client.request_arbitration(good_fulfillment, env.bob, inner_demand_data)
-    await oracle_client.request_arbitration(bad_fulfillment, env.bob, inner_demand_data)
+    # Bob (fulfiller) requests Charlie (oracle) to arbitrate both
+    await bob_client.oracle.request_arbitration(good_fulfillment, env.charlie, inner_demand_data)
+    await bob_client.oracle.request_arbitration(bad_fulfillment, env.charlie, inner_demand_data)
 
     # Decision function that approves only "good" obligations
     def decision_function(attestation, demand):
-        obligation_str = bob_client.extract_obligation_data(attestation)
+        obligation_str = charlie_client.extract_obligation_data(attestation)
         return obligation_str == "good"
 
-    # Arbitrate both
+    # Charlie (oracle) arbitrates both
+    oracle_client = charlie_client.oracle
     decisions = await oracle_client.arbitrate_many(decision_function, None, ArbitrationMode.Past)
 
     # Verify we got 2 decisions, only 1 approved
@@ -132,9 +128,8 @@ async def test_conditional_arbitrate_past(env, alice_client, bob_client):
     print(f"Conditional arbitration passed: {len(approved)}/2 approved")
 
 @pytest.mark.asyncio
-async def test_skip_arbitrated(env, alice_client, bob_client):
+async def test_skip_arbitrated(env, alice_client, bob_client, charlie_client):
     """Test PastUnarbitrated mode prevents re-arbitrating"""
-    # Setup test environment
 
     # Setup escrow
     mock_erc20 = MockERC20(env.mock_addresses.erc20_a, env.god_wallet_provider)
@@ -147,7 +142,7 @@ async def test_skip_arbitrated(env, alice_client, bob_client):
     inner_demand_data = b""  # Empty bytes for this simple test
 
     # The full encoded DemandData - this is what gets stored in the escrow
-    demand_data = TrustedOracleArbiterDemandData(env.bob, inner_demand_data)
+    demand_data = TrustedOracleArbiterDemandData(env.charlie, inner_demand_data)
     demand_bytes = demand_data.encode_self()
 
     arbiter = {
@@ -165,17 +160,16 @@ async def test_skip_arbitrated(env, alice_client, bob_client):
     string_client = bob_client.string_obligation
     fulfillment_uid = await string_client.do_obligation("good", escrow_uid)
 
-    # Request arbitration with inner demand data (not the full encoded DemandData)
-    # because TrustedOracleArbiter.checkObligation() uses only demand_.data for the decisionKey
-    oracle_client = bob_client.oracle
-    await oracle_client.request_arbitration(fulfillment_uid, env.bob, inner_demand_data)
+    # Bob (fulfiller) requests Charlie (oracle) to arbitrate
+    await bob_client.oracle.request_arbitration(fulfillment_uid, env.charlie, inner_demand_data)
 
     # Decision function
     def decision_function(attestation, demand):
-        obligation_str = bob_client.extract_obligation_data(attestation)
+        obligation_str = charlie_client.extract_obligation_data(attestation)
         return obligation_str == "good"
 
-    # First arbitration
+    # Charlie (oracle) arbitrates
+    oracle_client = charlie_client.oracle
     decisions = await oracle_client.arbitrate_many(decision_function, None, ArbitrationMode.Past)
     assert len(decisions) == 1, "First arbitration should find 1 decision"
 

--- a/sdks/py/alkahest_py/oracle/test_capitalization.py
+++ b/sdks/py/alkahest_py/oracle/test_capitalization.py
@@ -26,7 +26,7 @@ class ShellOracleDemand:
     test_cases: List[ShellTestCase]
 
 @pytest.mark.asyncio
-async def test_synchronous_offchain_oracle_capitalization_flow(env, alice_client, bob_client):
+async def test_synchronous_offchain_oracle_capitalization_flow(env, alice_client, bob_client, charlie_client):
     """
     Test a synchronous offchain oracle that verifies shell commands
     Alice escrows ERC20 collateral guarded by Charlie's oracle.
@@ -35,9 +35,8 @@ async def test_synchronous_offchain_oracle_capitalization_flow(env, alice_client
     Bob collects the escrowed payment upon successful arbitration.
     """
 
-    # Bob acts as the oracle for this test
-    oracle_address = env.bob
-    oracle_client = bob_client
+    oracle_address = env.charlie
+    oracle_client = charlie_client
 
     # Step 1: Alice escrows ERC20 collateral guarded by Charlie's oracle suite
     mock_erc20 = MockERC20(env.mock_addresses.erc20_a, env.god_wallet_provider)

--- a/sdks/py/alkahest_py/oracle/test_identity.py
+++ b/sdks/py/alkahest_py/oracle/test_identity.py
@@ -98,16 +98,16 @@ async def create_identity_payload(account: Account, nonce: int, data: str = "pro
     })
 
 @pytest.mark.asyncio
-async def test_contextless_offchain_identity_oracle_flow(env, bob_client):
+async def test_contextless_offchain_identity_oracle_flow(env, bob_client, charlie_client):
     """
     Test a contextless identity verification oracle
     Uses signature verification and nonce tracking without requiring escrow.
+    Bob submits identity proofs. Charlie (the oracle) verifies them.
     Tests both successful verification and replay attack prevention.
     """
 
-    # Simplification: Bob acts as the oracle
-    oracle_address = env.bob
-    oracle_client = bob_client
+    oracle_address = env.charlie
+    oracle_client = charlie_client
 
     # Clear and setup identity registry
     identity_registry.clear()

--- a/sdks/py/alkahest_py/oracle/test_listen_and_arbitrate_new_fulfillments_no_spawn.py
+++ b/sdks/py/alkahest_py/oracle/test_listen_and_arbitrate_new_fulfillments_no_spawn.py
@@ -13,7 +13,7 @@ from alkahest_py import (
 )
 
 @pytest.mark.asyncio
-async def test_arbitrate_many_future(env, alice_client, bob_client):
+async def test_arbitrate_many_future(env, alice_client, bob_client, charlie_client):
     """Test arbitrate_many with Future mode: only processes new fulfillments"""
     # Setup test environment
 
@@ -24,7 +24,7 @@ async def test_arbitrate_many_future(env, alice_client, bob_client):
     price = {"address": env.mock_addresses.erc20_a, "value": 100}
     trusted_oracle_arbiter = env.addresses.arbiters_addresses.trusted_oracle_arbiter
 
-    demand_data = TrustedOracleArbiterDemandData(env.bob, [])
+    demand_data = TrustedOracleArbiterDemandData(env.charlie, [])
     demand_bytes = demand_data.encode_self()
 
     arbiter = {
@@ -40,7 +40,7 @@ async def test_arbitrate_many_future(env, alice_client, bob_client):
 
     # Decision function
     def decision_function(attestation, demand):
-        obligation_str = bob_client.extract_obligation_data(attestation)
+        obligation_str = charlie_client.extract_obligation_data(attestation)
         print(f"Arbitrating obligation: {obligation_str}")
         return obligation_str == "good"
 
@@ -52,7 +52,7 @@ async def test_arbitrate_many_future(env, alice_client, bob_client):
 
     # Start listening with Future mode (should not process past arbitrations)
     # Note: This test is timing-dependent and may be flaky
-    oracle_client = bob_client.oracle
+    oracle_client = charlie_client.oracle
 
     # With Future mode and short timeout, should process 0 past decisions
     decisions = await oracle_client.arbitrate_many(

--- a/sdks/py/alkahest_py/oracle/test_listen_and_arbitrate_no_spawn.py
+++ b/sdks/py/alkahest_py/oracle/test_listen_and_arbitrate_no_spawn.py
@@ -13,9 +13,8 @@ from alkahest_py import (
 )
 
 @pytest.mark.asyncio
-async def test_arbitrate_many_all(env, alice_client, bob_client):
+async def test_arbitrate_many_all(env, alice_client, bob_client, charlie_client):
     """Test arbitrate_many with All mode: processes past arbitrations and waits for new ones"""
-    # Setup test environment
 
     # Setup escrow
     mock_erc20 = MockERC20(env.mock_addresses.erc20_a, env.god_wallet_provider)
@@ -28,7 +27,7 @@ async def test_arbitrate_many_all(env, alice_client, bob_client):
     inner_demand_data = b""  # Empty bytes for this simple test
 
     # The full encoded DemandData - this is what gets stored in the escrow
-    demand_data = TrustedOracleArbiterDemandData(env.bob, inner_demand_data)
+    demand_data = TrustedOracleArbiterDemandData(env.charlie, inner_demand_data)
     demand_bytes = demand_data.encode_self()
 
     arbiter = {
@@ -48,12 +47,14 @@ async def test_arbitrate_many_all(env, alice_client, bob_client):
 
     # Request arbitration with inner demand data (not the full encoded DemandData)
     # because TrustedOracleArbiter.checkObligation() uses only demand_.data for the decisionKey
-    oracle_client = bob_client.oracle
-    await oracle_client.request_arbitration(fulfillment_uid, env.bob, inner_demand_data)
+    # Bob (fulfiller) requests Charlie (oracle) to arbitrate
+    await bob_client.oracle.request_arbitration(fulfillment_uid, env.charlie, inner_demand_data)
+
+    oracle_client = charlie_client.oracle
 
     # Decision function
     def decision_function(attestation, demand):
-        obligation_str = bob_client.extract_obligation_data(attestation)
+        obligation_str = charlie_client.extract_obligation_data(attestation)
         print(f"Arbitrating obligation: {obligation_str}")
         return obligation_str == "good"
 

--- a/sdks/py/alkahest_py/oracle/test_uptime.py
+++ b/sdks/py/alkahest_py/oracle/test_uptime.py
@@ -1,16 +1,23 @@
 """
-Test asynchronous offchain oracle uptime monitoring flow (simplified)
+Test asynchronous offchain oracle uptime monitoring flow
+
+Uses the full async worker pattern: the listener callback defers decisions
+by returning None, and a background worker processes jobs and manually
+submits arbitration decisions on-chain.
 """
 import pytest
+import asyncio
 import json
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional, Tuple
 from alkahest_py import (
     EnvTestManager,
     MockERC20,
     TrustedOracleArbiterDemandData,
     ArbitrationMode,
 )
+
 
 @dataclass
 class UptimeDemand:
@@ -20,13 +27,81 @@ class UptimeDemand:
     end: int
     check_interval_secs: int
 
+
+@dataclass
+class PingEvent:
+    delay_secs: float
+    success: bool
+
+
+@dataclass
+class UptimeJob:
+    min_uptime: float
+    schedule: List[PingEvent]
+    demand: bytes
+
+
+@dataclass
+class SchedulerContext:
+    job_db: Dict[str, UptimeJob] = field(default_factory=dict)
+    url_index: Dict[str, str] = field(default_factory=dict)
+    notify: Optional[asyncio.Event] = field(default_factory=asyncio.Event)
+
+
+async def run_worker(ctx: SchedulerContext, oracle_client) -> None:
+    """Background worker that processes scheduled uptime jobs and submits decisions."""
+    while True:
+        # Get next job from queue
+        uid = None
+        job = None
+        for k, v in list(ctx.job_db.items()):
+            uid = k
+            job = v
+            del ctx.job_db[k]
+            break
+
+        if uid is not None and job is not None:
+            # Execute the monitoring schedule
+            successes = 0
+            total_checks = max(len(job.schedule), 1)
+
+            for ping in job.schedule:
+                await asyncio.sleep(ping.delay_secs)
+                # In production: actually ping the service
+                if ping.success:
+                    successes += 1
+
+            # Calculate result and make decision
+            uptime = successes / total_checks
+            decision = uptime >= job.min_uptime
+
+            # Submit decision on-chain manually
+            # This is the key difference from sync oracles: we call arbitrate()
+            # directly instead of returning True/False from the callback
+            await oracle_client.oracle.arbitrate(uid, list(job.demand), decision)
+        else:
+            # Wait for new work or timeout
+            ctx.notify.clear()
+            try:
+                await asyncio.wait_for(ctx.notify.wait(), timeout=2.0)
+            except asyncio.TimeoutError:
+                if not ctx.job_db:
+                    break  # No work and no notifications - exit
+
+
 @pytest.mark.asyncio
 async def test_asynchronous_offchain_oracle_uptime_flow(env, alice_client, bob_client):
     """
-    Test an asynchronous offchain oracle that monitors service uptime
+    Test an asynchronous offchain oracle that monitors service uptime.
+
+    Uses the full async worker pattern matching the TypeScript and Rust SDKs:
+    1. Listener receives arbitration requests and defers decisions (returns None)
+    2. Jobs are queued for background processing
+    3. Worker processes jobs over time and submits decisions manually
+
     Alice escrows payment for uptime monitoring service.
     Bob claims to provide the service at a URL.
-    Charlie monitors the service asynchronously and arbitrates.
+    The oracle (Bob, simplified) monitors the service asynchronously and arbitrates.
     Bob collects payment if uptime meets the threshold.
     """
 
@@ -44,25 +119,23 @@ async def test_asynchronous_offchain_oracle_uptime_flow(env, alice_client, bob_c
         min_uptime=0.75,
         start=now,
         end=now + 10,
-        check_interval_secs=2
+        check_interval_secs=2,
     )
 
-    # The inner data field (JSON payload) - this is what gets passed to arbitrate()
     inner_demand_data = json.dumps({
         "service_url": demand_payload.service_url,
         "min_uptime": demand_payload.min_uptime,
         "start": demand_payload.start,
         "end": demand_payload.end,
-        "check_interval_secs": demand_payload.check_interval_secs
-    }).encode('utf-8')
+        "check_interval_secs": demand_payload.check_interval_secs,
+    }).encode("utf-8")
 
-    # The full encoded DemandData - this is what gets stored in the escrow
     demand_data = TrustedOracleArbiterDemandData(oracle_address, inner_demand_data)
     demand_bytes = demand_data.encode_self()
 
     arbiter = {
         "arbiter": env.addresses.arbiters_addresses.trusted_oracle_arbiter,
-        "demand": demand_bytes
+        "demand": demand_bytes,
     }
 
     price = {"address": env.mock_addresses.erc20_a, "value": 100}
@@ -71,64 +144,105 @@ async def test_asynchronous_offchain_oracle_uptime_flow(env, alice_client, bob_c
     escrow_receipt = await alice_client.erc20.escrow.non_tierable.permit_and_create(
         price, arbiter, expiration
     )
-    escrow_uid = escrow_receipt['log']['uid']
+    escrow_uid = escrow_receipt["log"]["uid"]
 
     # Step 2: Bob submits the service URL as fulfillment
     service_url = demand_payload.service_url
     fulfillment_uid = await bob_client.string_obligation.do_obligation(
-        service_url,
-        escrow_uid
+        service_url, escrow_uid
     )
 
-    # Step 3: Request arbitration with inner demand data (not the full encoded DemandData)
-    # because TrustedOracleArbiter.checkObligation() uses only demand_.data for the decisionKey
-    await bob_client.oracle.request_arbitration(fulfillment_uid, oracle_address, inner_demand_data)
+    # Step 3: Request arbitration
+    await bob_client.oracle.request_arbitration(
+        fulfillment_uid, oracle_address, inner_demand_data
+    )
 
-    # Step 4: Oracle arbitrates using simulated uptime monitoring
-    async def decision_function(attestation, demand):
-        """Simulate uptime monitoring and decide if service meets SLA"""
+    # Step 4: Set up scheduler context (shared state between listener and worker)
+    ctx = SchedulerContext()
+    ctx.url_index[service_url] = fulfillment_uid
+
+    # Step 5: Start background worker
+    worker_task = asyncio.create_task(run_worker(ctx, oracle_client))
+
+    # Step 6: Define scheduling callback that defers decisions
+    async def schedule_decision(attestation, demand):
+        """
+        Schedule uptime monitoring but DON'T make a decision yet.
+        Returns None to defer the decision to the background worker.
+        """
         try:
             # Extract service URL from fulfillment
             statement = oracle_client.oracle.extract_obligation_data(attestation)
 
-            # Parse demand directly from callback argument (no need to fetch from escrow!)
-            demand_json = json.loads(bytes(demand).decode('utf-8'))
+            # Look up the fulfillment UID from our URL index
+            uid = ctx.url_index.get(statement)
+            if uid is None or uid in ctx.job_db:
+                return None
+
+            # Parse demand from callback argument
+            demand_json = json.loads(bytes(demand).decode("utf-8"))
 
             # Verify URL matches
-            if statement != demand_json['service_url']:
-                return False
+            if statement != demand_json["service_url"]:
+                return None
 
-            # Simulate uptime checks using demand
-            total_span = max(demand_json['end'] - demand_json['start'], 1)
-            interval = max(demand_json['check_interval_secs'], 1)
+            # Create monitoring schedule
+            total_span = max(demand_json["end"] - demand_json["start"], 1)
+            interval = max(demand_json["check_interval_secs"], 1)
             checks = max(total_span // interval, 1)
 
-            # Simulate checks: fail one check (index 1)
-            successes = checks - 1  # One failure
-            uptime = successes / checks
+            schedule = []
+            for i in range(checks):
+                schedule.append(PingEvent(
+                    delay_secs=0.1 + i * 0.025,
+                    # Simulate: one check fails (index 1)
+                    success=(i != 1),
+                ))
 
-            # Decide based on minimum uptime requirement
-            return uptime >= demand_json['min_uptime']
+            # Store job for background worker
+            ctx.job_db[uid] = UptimeJob(
+                min_uptime=demand_json["min_uptime"],
+                schedule=schedule,
+                demand=bytes(demand),
+            )
+            ctx.notify.set()  # Wake up worker
+
+            # Return None to defer decision to the worker
+            return None
 
         except Exception:
-            return False
+            return None
 
     def callback(decision):
         pass
 
-    # Arbitrate with AllUnarbitrated mode
+    # Step 7: Run listener (processes existing arbitration requests)
     decisions = await oracle_client.oracle.arbitrate_many(
-        decision_function,
+        schedule_decision,
         callback,
         ArbitrationMode.AllUnarbitrated,
-        timeout_seconds=2.0
+        timeout_seconds=2.0,
     )
 
-    # Verify decision
-    assert len(decisions) >= 1, "Expected at least 1 decision"
-    assert decisions[0].decision == True, "Expected uptime check to pass"
+    # The listener should NOT have produced any decisions (all deferred)
+    assert len(decisions) == 0, (
+        f"Expected 0 decisions from listener (all deferred), got {len(decisions)}"
+    )
 
-    # Step 5: Bob collects the escrowed payment
+    # Step 8: Wait for the worker to finish processing
+    await asyncio.wait_for(worker_task, timeout=10.0)
+
+    # Step 9: Verify the arbitration was submitted by the worker
+    # Wait for the arbitration event on-chain
+    arbitration = await oracle_client.oracle.wait_for_arbitration(
+        fulfillment_uid,
+        list(inner_demand_data),
+        oracle_address,
+        None,  # from_block
+    )
+    assert arbitration.decision is True, "Expected uptime check to pass"
+
+    # Step 10: Bob collects the escrowed payment
     await bob_client.erc20.escrow.non_tierable.collect(escrow_uid, fulfillment_uid)
 
     print("Asynchronous offchain oracle uptime test passed")

--- a/sdks/py/alkahest_py/oracle/test_uptime.py
+++ b/sdks/py/alkahest_py/oracle/test_uptime.py
@@ -90,7 +90,7 @@ async def run_worker(ctx: SchedulerContext, oracle_client) -> None:
 
 
 @pytest.mark.asyncio
-async def test_asynchronous_offchain_oracle_uptime_flow(env, alice_client, bob_client):
+async def test_asynchronous_offchain_oracle_uptime_flow(env, alice_client, bob_client, charlie_client):
     """
     Test an asynchronous offchain oracle that monitors service uptime.
 
@@ -101,13 +101,12 @@ async def test_asynchronous_offchain_oracle_uptime_flow(env, alice_client, bob_c
 
     Alice escrows payment for uptime monitoring service.
     Bob claims to provide the service at a URL.
-    The oracle (Bob, simplified) monitors the service asynchronously and arbitrates.
+    Charlie (the oracle) monitors the service asynchronously and arbitrates.
     Bob collects payment if uptime meets the threshold.
     """
 
-    # Simplification: Bob acts as the oracle
-    oracle_address = env.bob
-    oracle_client = bob_client
+    oracle_address = env.charlie
+    oracle_client = charlie_client
 
     # Step 1: Alice escrows ERC20 with uptime demand
     mock_erc20 = MockERC20(env.mock_addresses.erc20_a, env.god_wallet_provider)

--- a/sdks/py/src/clients/arbiters/trusted_oracle.rs
+++ b/sdks/py/src/clients/arbiters/trusted_oracle.rs
@@ -330,6 +330,10 @@ impl OracleClient {
                     let py_attestation = PyOracleAttestation::from(&awd.attestation);
                     let py_demand: Vec<u8> = awd.demand.to_vec();
                     let result = decision_func.call1(py, (py_attestation, py_demand)).ok()?;
+                    // If Python returned None, defer the decision (return Rust None)
+                    if result.is_none(py) {
+                        return None;
+                    }
                     result
                         .extract::<bool>(py)
                         .or_else(|_| result.is_truthy(py))
@@ -438,8 +442,11 @@ impl OracleClient {
                         Err(_) => return None,
                     };
 
-                    // Extract boolean
+                    // Extract boolean, treating Python None as Rust None (defer)
                     Python::with_gil(|py| {
+                        if result.is_none(py) {
+                            return None;
+                        }
                         result.extract::<bool>(py)
                             .or_else(|_| result.is_truthy(py))
                             .ok()

--- a/sdks/py/src/utils.rs
+++ b/sdks/py/src/utils.rs
@@ -97,9 +97,13 @@ pub struct EnvTestManager {
     #[pyo3(get)]
     pub bob: String,
     #[pyo3(get)]
+    pub charlie: String,
+    #[pyo3(get)]
     pub alice_private_key: String,
     #[pyo3(get)]
     pub bob_private_key: String,
+    #[pyo3(get)]
+    pub charlie_private_key: String,
     #[pyo3(get)]
     pub addresses: PyDefaultExtensionConfig,
     #[pyo3(get)]
@@ -120,6 +124,7 @@ impl EnvTestManager {
         // Extract private keys as hex strings (with 0x prefix)
         let alice_private_key = format!("0x{}", hex::encode(ctx.alice.to_bytes()));
         let bob_private_key = format!("0x{}", hex::encode(ctx.bob.to_bytes()));
+        let charlie_private_key = format!("0x{}", hex::encode(ctx.charlie.to_bytes()));
 
         Ok(Self {
             runtime: rt,
@@ -127,8 +132,10 @@ impl EnvTestManager {
             god: ctx.god.address().to_string(),
             alice: ctx.alice.address().to_string(),
             bob: ctx.bob.address().to_string(),
+            charlie: ctx.charlie.address().to_string(),
             alice_private_key,
             bob_private_key,
+            charlie_private_key,
             addresses: PyDefaultExtensionConfig::from(&ctx.addresses),
             mock_addresses: PyMockAddresses::from(&ctx.mock_addresses),
             god_wallet_provider: PyWalletProvider {

--- a/sdks/rs/src/utils.rs
+++ b/sdks/rs/src/utils.rs
@@ -264,6 +264,7 @@ pub async fn setup_test_environment() -> eyre::Result<TestContext> {
 
     let alice: PrivateKeySigner = anvil.keys()[1].clone().into();
     let bob: PrivateKeySigner = anvil.keys()[2].clone().into();
+    let charlie: PrivateKeySigner = anvil.keys()[3].clone().into();
 
     let addresses = DefaultExtensionConfig {
         arbiters_addresses: ArbitersAddresses {
@@ -360,15 +361,23 @@ pub async fn setup_test_environment() -> eyre::Result<TestContext> {
         Some(addresses.clone()),
     )
     .await?;
+    let charlie_client = AlkahestClient::with_base_extensions(
+        charlie.clone(),
+        anvil.ws_endpoint_url(),
+        Some(addresses.clone()),
+    )
+    .await?;
 
     Ok(TestContext {
         anvil,
         alice,
         bob,
+        charlie,
         god,
         god_provider: god_provider_,
         alice_client,
         bob_client,
+        charlie_client,
         addresses,
         mock_addresses: MockAddresses {
             erc20_a: mock_erc20_a.address().clone(),
@@ -385,10 +394,12 @@ pub struct TestContext {
     pub anvil: AnvilInstance,
     pub alice: PrivateKeySigner,
     pub bob: PrivateKeySigner,
+    pub charlie: PrivateKeySigner,
     pub god: PrivateKeySigner,
     pub god_provider: WalletProvider,
     pub alice_client: AlkahestClient<crate::extensions::BaseExtensions>,
     pub bob_client: AlkahestClient<crate::extensions::BaseExtensions>,
+    pub charlie_client: AlkahestClient<crate::extensions::BaseExtensions>,
     pub addresses: DefaultExtensionConfig,
     pub mock_addresses: MockAddresses,
 }

--- a/sdks/rs/tests/offchain_oracle_capitalization.rs
+++ b/sdks/rs/tests/offchain_oracle_capitalization.rs
@@ -3,7 +3,7 @@ use std::{
 };
 
 use alkahest_rs::{
-    AlkahestClient, DefaultAlkahestClient,
+    DefaultAlkahestClient,
     clients::oracle::ArbitrationMode,
     contracts::{self, obligations::StringObligation},
     extensions::{HasErc20, HasOracle, HasStringObligation},
@@ -11,7 +11,7 @@ use alkahest_rs::{
     types::{ArbiterData, Erc20Data},
     utils::{TestContext, setup_test_environment},
 };
-use alloy::{primitives::Bytes, signers::local::PrivateKeySigner};
+use alloy::primitives::Bytes;
 use eyre::{Result, WrapErr, eyre};
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
@@ -28,14 +28,7 @@ struct ShellOracleDemand {
 
 async fn run_synchronous_oracle_capitalization_example(test: &TestContext) -> eyre::Result<()> {
     // Charlie is the off-chain oracle Alice requests in her escrow demand.
-    let charlie_signer: PrivateKeySigner = test.anvil.keys()[3].clone().into();
-    let charlie_client = AlkahestClient::with_base_extensions(
-        charlie_signer.clone(),
-        test.anvil.ws_endpoint_url(),
-        Some(test.addresses.clone()),
-    )
-    .await
-    .wrap_err("failed to construct Charlie's client")?;
+    let charlie_client = &test.charlie_client;
     let charlie_oracle = charlie_client.oracle().clone();
     println!("step1: charlie oracle client set up");
     // Step 1. Alice escrows ERC20 collateral guarded by Charlie's oracle suite.

--- a/sdks/rs/tests/offchain_oracle_identity.rs
+++ b/sdks/rs/tests/offchain_oracle_identity.rs
@@ -3,7 +3,7 @@ use std::{
 };
 
 use alkahest_rs::{
-    AlkahestClient, DefaultAlkahestClient,
+    DefaultAlkahestClient,
     clients::oracle::ArbitrationMode,
     contracts::obligations::StringObligation,
     extensions::{HasArbiters, HasOracle, HasStringObligation},
@@ -84,14 +84,7 @@ fn verify_identity(
 }
 
 async fn run_contextless_identity_example(test: &TestContext) -> eyre::Result<()> {
-    let charlie_signer: PrivateKeySigner = test.anvil.keys()[3].clone().into();
-    let charlie_client = AlkahestClient::with_base_extensions(
-        charlie_signer.clone(),
-        test.anvil.ws_endpoint_url(),
-        Some(test.addresses.clone()),
-    )
-    .await
-    .wrap_err("failed to build Charlie client")?;
+    let charlie_client = &test.charlie_client;
 
     let charlie_oracle = charlie_client.oracle().clone();
     let charlie_arbiters = charlie_client.arbiters().clone();

--- a/sdks/rs/tests/offchain_oracle_uptime.rs
+++ b/sdks/rs/tests/offchain_oracle_uptime.rs
@@ -8,7 +8,7 @@ use std::{
 };
 
 use alkahest_rs::{
-    AlkahestClient, DefaultAlkahestClient,
+    DefaultAlkahestClient,
     clients::oracle::ArbitrationMode,
     contracts::{self, obligations::StringObligation},
     extensions::{HasArbiters, HasErc20, HasOracle, HasStringObligation},
@@ -16,10 +16,7 @@ use alkahest_rs::{
     types::{ArbiterData, Erc20Data},
     utils::{TestContext, setup_test_environment},
 };
-use alloy::{
-    primitives::{Bytes, FixedBytes},
-    signers::local::PrivateKeySigner,
-};
+use alloy::primitives::{Bytes, FixedBytes};
 use eyre::{Result, WrapErr, eyre};
 use serde::{Deserialize, Serialize};
 use tokio::sync::{Mutex, Notify};
@@ -178,14 +175,7 @@ async fn setup_escrow_with_uptime_demand(
 }
 
 async fn run_async_uptime_oracle_example(test: &TestContext) -> eyre::Result<()> {
-    let charlie_signer: PrivateKeySigner = test.anvil.keys()[3].clone().into();
-    let charlie_client = AlkahestClient::with_base_extensions(
-        charlie_signer.clone(),
-        test.anvil.ws_endpoint_url(),
-        Some(test.addresses.clone()),
-    )
-    .await
-    .wrap_err("failed to construct Charlie's client")?;
+    let charlie_client = &test.charlie_client;
 
     let charlie_oracle = charlie_client.oracle().clone();
     let charlie_arbiters = charlie_client.arbiters().clone();


### PR DESCRIPTION
## Description

Adds support for deferred decisions in the Python SDK's `arbitrate_many`, enabling the async worker pattern. Also adds Charlie as a third test account to the Rust and Python SDK test environments (TypeScript already had it), and updates all oracle tests across all three SDKs to use the proper 3-party pattern: Alice (escrow creator), Bob (fulfiller), Charlie (oracle/arbiter).

## Changes

### Python SDK: Deferred oracle decisions
- Fix `arbitrate_many` to treat Python `None` returns as Rust `None` (defer) instead of `False` (reject), enabling the async worker pattern where a listener defers decisions to a background worker
- Rewrite `test_uptime.py` to use the full async worker pattern matching the TypeScript and Rust SDK tests: listener callback returns `None` to defer, background worker processes jobs and manually calls `oracle.arbitrate()`

### Test environment: Add Charlie as third account
- **Rust SDK**: Add `charlie`/`charlie_client` to `TestContext` and `setup_test_environment()`
- **Python SDK**: Add `charlie`/`charlie_private_key` to `EnvTestManager`, add `charlie_client` pytest fixture

### Test cleanup: Use 3-party pattern consistently
- **Rust tests**: Replace manual Charlie construction in 3 oracle test files with `test.charlie_client`
- **Python tests**: Replace Bob-as-oracle with Charlie across all 7 oracle test files, ensuring `request_arbitration` is called by Bob (fulfiller) and arbitration by Charlie (oracle)