### PR TITLE
py-sdk: expose chain configs via DefaultExtensionConfig.for_chain

### DIFF
--- a/sdks/py/Cargo.toml
+++ b/sdks/py/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alkahest-py"
-version = "0.2.1"
+version = "0.3.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/sdks/py/alkahest_py/__init__.py
+++ b/sdks/py/alkahest_py/__init__.py
@@ -53,6 +53,7 @@ from .alkahest_py import (
     PyStringObligationAddresses as StringObligationAddresses,
     PyCommitRevealObligationAddresses as CommitRevealObligationAddresses,
     PyArbitersAddresses as ArbitersAddresses,
+    PyDefaultExtensionConfig as DefaultExtensionConfig,
     # IEAS Types
     PyAttestation as Attestation,
     PyAttestationRequest as AttestationRequest,
@@ -116,6 +117,7 @@ __all__ = [
     "StringObligationAddresses",
     "CommitRevealObligationAddresses",
     "ArbitersAddresses",
+    "DefaultExtensionConfig",
     # IEAS Types
     "Attestation",
     "AttestationRequest",

--- a/sdks/py/pyproject.toml
+++ b/sdks/py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "alkahest-py"
-version = "0.2.1"
+version = "0.3.0"
 requires-python = ">=3.8"
 classifiers = [
     "Programming Language :: Rust",

--- a/sdks/py/src/lib.rs
+++ b/sdks/py/src/lib.rs
@@ -535,6 +535,7 @@ fn alkahest_py(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<CommitRevealObligationClient>()?;
     m.add_class::<PyCommitRevealObligationData>()?;
     m.add_class::<PyErc20Data>()?;
+    m.add_class::<crate::types::PyDefaultExtensionConfig>()?;
 
     // Arbiters Client and related types
     m.add_class::<ArbitersClient>()?;

--- a/sdks/py/src/types.rs
+++ b/sdks/py/src/types.rs
@@ -322,6 +322,7 @@ impl TryFrom<Erc20Data> for alkahest_rs::types::Erc20Data {
 }
 
 use pyo3::prelude::*;
+use pyo3::types::PyType;
 
 #[pyclass]
 #[derive(Clone)]
@@ -565,6 +566,65 @@ impl From<&alkahest_rs::DefaultExtensionConfig> for PyDefaultExtensionConfig {
             string_obligation_addresses: Some(PyStringObligationAddresses::from(&data.string_obligation_addresses)),
             commit_reveal_obligation_addresses: Some(PyCommitRevealObligationAddresses::from(&data.commit_reveal_obligation_addresses)),
         }
+    }
+}
+
+#[pymethods]
+impl PyDefaultExtensionConfig {
+    /// Return the address config for one of the SDK's known chains.
+    ///
+    /// Mirrors the TS SDK's chain-name-keyed lookup. Accepted names:
+    ///   "base_sepolia"        — default; matches the Rust `Default` impl
+    ///   "ethereum_sepolia"
+    ///   "ethereum_mainnet"
+    ///   "filecoin_calibration"
+    ///   "genlayer_bradbury"
+    ///
+    /// For local anvil or any chain not in this list, construct a
+    /// `DefaultExtensionConfig` manually from the address sub-types.
+    #[classmethod]
+    fn for_chain(_cls: &Bound<'_, PyType>, name: &str) -> PyResult<Self> {
+        let normalized = name.trim().to_ascii_lowercase();
+        let cfg: &alkahest_rs::DefaultExtensionConfig = match normalized.as_str() {
+            "base_sepolia" => &alkahest_rs::addresses::BASE_SEPOLIA_ADDRESSES,
+            "ethereum_sepolia" => &alkahest_rs::addresses::ETHEREUM_SEPOLIA_ADDRESSES,
+            "ethereum_mainnet" | "ethereum" | "mainnet" => &alkahest_rs::addresses::ETHEREUM_ADDRESSES,
+            "filecoin_calibration" => &alkahest_rs::addresses::FILECOIN_CALIBRATION_ADDRESSES,
+            "genlayer_bradbury" => &alkahest_rs::addresses::GENLAYER_BRADBURY_ADDRESSES,
+            other => {
+                return Err(PyValueError::new_err(format!(
+                    "Unknown chain '{}'. Supported: {:?}",
+                    other,
+                    Self::supported_chains_inner(),
+                )));
+            }
+        };
+        Ok(Self::from(cfg))
+    }
+
+    /// Return the list of chain names accepted by `for_chain`.
+    #[classmethod]
+    fn supported_chains(_cls: &Bound<'_, PyType>) -> Vec<String> {
+        Self::supported_chains_inner()
+    }
+
+    /// Return the SDK default config (Base Sepolia). Equivalent to passing
+    /// `None` as `address_config` to `AlkahestClient`, but explicit.
+    #[classmethod]
+    fn default_config(_cls: &Bound<'_, PyType>) -> Self {
+        Self::from(&alkahest_rs::addresses::BASE_SEPOLIA_ADDRESSES)
+    }
+}
+
+impl PyDefaultExtensionConfig {
+    fn supported_chains_inner() -> Vec<String> {
+        vec![
+            "base_sepolia".to_string(),
+            "ethereum_sepolia".to_string(),
+            "ethereum_mainnet".to_string(),
+            "filecoin_calibration".to_string(),
+            "genlayer_bradbury".to_string(),
+        ]
     }
 }
 


### PR DESCRIPTION
## Summary

The Rust SDK already declares `BASE_SEPOLIA_ADDRESSES`, `ETHEREUM_SEPOLIA_ADDRESSES`, `ETHEREUM_ADDRESSES`, `FILECOIN_CALIBRATION_ADDRESSES`, and `GENLAYER_BRADBURY_ADDRESSES` as public constants in `sdks/rs/src/addresses.rs`, and the TS SDK's `makeClient` looks them up by chain name via the viem client's `chain.name`. The Python bindings, by contrast, exposed only the address sub-types and the duck-typed `DefaultExtensionConfig` FromPyObject — so a Python user could only pass `None` (= base_sepolia default) to `AlkahestClient` or hand-build a config from scratch. There was no way to reach `ethereum_sepolia` / `ethereum` / `filecoin_calibration` / `genlayer_bradbury` without copy-pasting the Rust constants.

This PR registers `PyDefaultExtensionConfig` as a Python class and adds three classmethods that bring Python parity with the TS chain-name shortcut:

```python
from alkahest_py import AlkahestClient, DefaultExtensionConfig

DefaultExtensionConfig.supported_chains()
# -> ['base_sepolia', 'ethereum_sepolia', 'ethereum_mainnet',
#     'filecoin_calibration', 'genlayer_bradbury']

cfg = DefaultExtensionConfig.for_chain("ethereum_sepolia")
client = AlkahestClient(priv_key, rpc_url, cfg)

DefaultExtensionConfig.default_config()  # explicit base_sepolia, == None
```

Accepted names match the Rust constant names; `ethereum_mainnet` also accepts `"ethereum"` and `"mainnet"` aliases (matching how the constant is declared as `ETHEREUM_ADDRESSES`).

The returned object is the existing `PyDefaultExtensionConfig` pyclass — its address sub-fields have `#[pyo3(get)]` accessors, so it's directly compatible with the `AlkahestClient(..., address_config)` constructor's existing FromPyObject duck-typing.

Net diff: +63 lines in `sdks/py/`, no behavior change for existing callers.

## Why

In our (`simple-market-service`) repo we currently maintain a hand-copied `ETHEREUM_SEPOLIA_ADDRESSES` / `ETHEREUM_ADDRESSES` block in `service/src/service/clients/alkahest.py` because the Python SDK had no way to surface those values. With this change we can delete that local table and use the SDK as the single source of truth.

## Version bump

`0.2.1 -> 0.3.0` (minor, new public API).

## Test plan

- [x] `cargo check --lib` in `sdks/py` — clean (only pre-existing dead-code warnings)
- [x] `cargo test --lib --no-run` in `sdks/rs` — compiles clean
- [x] `python -m pytest alkahest_py/test_alkahest_client_init.py` — 2 passed
- [x] Local smoke test:
  ```
  Supported chains: ['base_sepolia', 'ethereum_sepolia', 'ethereum_mainnet', 'filecoin_calibration', 'genlayer_bradbury']
  Sepolia EAS: 0xc2679fbd37d54388ce493f1db75320d236e1815e
  Sepolia recipient_arbiter: 0xf1c9e20078a13816acddf3153e2eaadd93fd6e57
  Mainnet EAS: 0xa1207f3bba224e2c9c3c6d5af63d0eb1582ce587
  Default (base_sepolia) EAS: 0x4200000000000000000000000000000000000021
  Rejection works: Unknown chain 'not_a_real_chain'. Supported: [...]
  ```
- [ ] CI to build wheels for all targets
- [ ] PyPI publish on merge to `main` (paths-filter on `sdks/py/**` is already in `.github/workflows/publish-sdks.yml`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)