### PR TITLE
chore(py): bump version 0.3.0 -> 0.4.0

### DIFF
--- a/sdks/py/Cargo.lock
+++ b/sdks/py/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "alkahest-py"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "alkahest-rs",
  "alloy",

--- a/sdks/py/Cargo.toml
+++ b/sdks/py/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alkahest-py"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/sdks/py/pyproject.toml
+++ b/sdks/py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "alkahest-py"
-version = "0.3.0"
+version = "0.4.0"
 requires-python = ">=3.8"
 classifiers = [
     "Programming Language :: Rust",


### PR DESCRIPTION
## Summary

Cuts a release for the two feature PRs that have landed since 0.3.0. The publish-sdks workflow runs on push-to-main with `sdks/**` changes and skips when the version is already published, so this commit alone re-arms PyPI publishing on merge.

## What's in 0.4.0

### #63 — `get_obligation` across every escrow client

Each of the 14 escrow clients (erc20 / erc721 / erc1155 / native_token / token_bundle / attestation v1 + v2, tierable + non_tierable each) now exposes `get_obligation(uid)` returning a typed `PyDecodedAttestation` carrying both the EAS envelope and the typed obligation payload.

Four new typed obligation-data classes shipped: `PyNativeTokenEscrowObligationData`, `PyTokenBundleEscrowObligationData`, `PyAttestationEscrowV1ObligationData`, `PyAttestationEscrowV2ObligationData` (alongside the pre-existing ERC20/721/1155 ones).

Strictly additive — no existing call sites change.

### #64 — http RPC URL support + transport-aware event waiters

`AlkahestClient` now accepts `http://` / `https://` URLs alongside `ws://` / `wss://`. Internal dispatch uses Alloy's `RpcClient.pubsub_frontend()` to pick subscribe-based vs poll-based event waiters; the public Python API stays uniform across transports.

New optional `poll_interval_seconds` constructor kwarg (default 7s, matching Alloy's `RpcClient` default) — only consumed by the polling path; ws transports ignore it.

The one small breaking change is on the rust side of `arbitrate_many*`: `subscription_id: Option<FixedBytes<32>>` (which leaked pubsub semantics into the public API) becomes `subscription: Option<SubscriptionHandle>` (opaque handle wrapping either a pubsub local_id or a cancellation token). The Python side is unaffected — the py-SDK's `OracleClient.unsubscribe(local_id: str)` is preserved for back-compat (no-ops on http transports).

## Why minor (not patch)

Both PRs added new public Python classes and constructor kwargs. Per semver, that's a minor bump from 0.3.0 → 0.4.0. Strict back-compat at the syntactic level — every existing 0.3.0 call site keeps working.

## Test plan

- [x] `cargo check` clean on the rust side after the version bump
- [x] `Cargo.lock` updated to reflect the new version

🤖 Generated with [Claude Code](https://claude.com/claude-code)