### PR TITLE
chore(rs): bump version 0.7.2 -> 0.8.0

### DIFF
--- a/sdks/py/Cargo.lock
+++ b/sdks/py/Cargo.lock
@@ -27,7 +27,7 @@ dependencies = [
 
 [[package]]
 name = "alkahest-rs"
-version = "0.7.2"
+version = "0.8.0"
 dependencies = [
  "alloy",
  "eyre",

--- a/sdks/rs/Cargo.lock
+++ b/sdks/rs/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "alkahest-rs"
-version = "0.7.2"
+version = "0.8.0"
 dependencies = [
  "alloy",
  "eyre",

--- a/sdks/rs/Cargo.toml
+++ b/sdks/rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alkahest-rs"
-version = "0.7.2"
+version = "0.8.0"
 edition = "2024"
 description = "Rust SDK to Alkahest contracts for decentralized escrow and exchange"
 license = "MIT"


### PR DESCRIPTION
## Summary
- Bumps `alkahest-rs` minor version (0.7.2 → 0.8.0) to reflect the new public API surface added in #64.
- Refreshes `sdks/rs/Cargo.lock` and `sdks/py/Cargo.lock` (alkahest-py depends on rs via local path).

## Why minor?
PR #64 added new public items, not just internal refactoring:
- `AlkahestClient::with_*_with_poll_interval` constructor variants
- `poll_interval: Duration` field on `ProviderContext`, `TrustedOracleModule`, `ArbitersModule`
- New `SubscriptionHandle` type wrapping pubsub local_id or `CancellationToken`
- Public `wait_for_first_log` helper and `BoxedLogStream` alias
- HTTP transport support across the client surface

These aren't breaking changes for existing ws/wss callers, but they extend the API enough that downstream consumers should be able to pin against the feature set explicitly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)