### PR TITLE
Protocol safety invariants

### DIFF
--- a/contracts/src/obligations/CommitRevealObligation.sol
+++ b/contracts/src/obligations/CommitRevealObligation.sol
@@ -28,6 +28,9 @@ contract CommitRevealObligation is BaseObligation, IArbiter, Ownable {
         uint64 commitBlock;
         uint64 commitTimestamp;
         address committer;
+        uint256 bondAmount;
+        uint256 commitDeadline;
+        address slashedBondRecipient;
     }
 
     /// @notice commitments[commitment] => commit information.
@@ -117,7 +120,10 @@ contract CommitRevealObligation is BaseObligation, IArbiter, Ownable {
         commitments[commitment] = CommitInfo({
             commitBlock: uint64(block.number),
             commitTimestamp: uint64(block.timestamp),
-            committer: msg.sender
+            committer: msg.sender,
+            bondAmount: bondAmount,
+            commitDeadline: commitDeadline,
+            slashedBondRecipient: slashedBondRecipient
         });
 
         emit Committed(commitment, msg.sender);
@@ -182,7 +188,7 @@ contract CommitRevealObligation is BaseObligation, IArbiter, Ownable {
         }
         if (commitmentClaimed[revealedCommitment]) revert BondAlreadyClaimed(revealedCommitment);
 
-        amount = bondAmount;
+        amount = info.bondAmount;
 
         commitmentClaimed[revealedCommitment] = true;
 
@@ -201,18 +207,18 @@ contract CommitRevealObligation is BaseObligation, IArbiter, Ownable {
     function slashBond(bytes32 commitment) external nonReentrant returns (uint256 amount) {
         CommitInfo memory info = commitments[commitment];
         if (info.committer == address(0)) revert CommitmentMissing(commitment, address(0));
-        if (block.timestamp <= info.commitTimestamp + commitDeadline) {
+        if (block.timestamp <= info.commitTimestamp + info.commitDeadline) {
             revert CommitDeadlineNotReached(commitment);
         }
         if (commitmentClaimed[commitment]) revert BondAlreadyClaimed(commitment);
 
-        amount = bondAmount;
+        amount = info.bondAmount;
         commitmentClaimed[commitment] = true;
 
-        (bool success,) = slashedBondRecipient.call{value: amount}("");
-        if (!success) revert SlashTransferFailed(slashedBondRecipient, amount);
+        (bool success,) = info.slashedBondRecipient.call{value: amount}("");
+        if (!success) revert SlashTransferFailed(info.slashedBondRecipient, amount);
 
-        emit BondSlashed(commitment, slashedBondRecipient, amount);
+        emit BondSlashed(commitment, info.slashedBondRecipient, amount);
     }
 
     // ---------------------------------------------------------------------

--- a/contracts/src/utils/barter/ERC1155BarterUtils.sol
+++ b/contracts/src/utils/barter/ERC1155BarterUtils.sol
@@ -31,6 +31,7 @@ contract ERC1155BarterUtils is IERC1155Receiver {
 
     error CouldntCollectEscrow();
     error AttestationNotFound(bytes32 attestationId);
+    error MsgValueMismatch();
 
     constructor(
         IEAS _eas,
@@ -501,6 +502,8 @@ contract ERC1155BarterUtils is IERC1155Receiver {
             escrowData.demand,
             (NativeTokenPaymentObligation.ObligationData)
         );
+
+        if (msg.value != demand.amount) revert MsgValueMismatch();
 
         bytes32 sellAttestation = nativePayment.doObligationFor{
             value: demand.amount

--- a/contracts/src/utils/barter/ERC721BarterUtils.sol
+++ b/contracts/src/utils/barter/ERC721BarterUtils.sol
@@ -30,6 +30,7 @@ contract ERC721BarterUtils {
 
     error CouldntCollectEscrow();
     error AttestationNotFound(bytes32 attestationId);
+    error MsgValueMismatch();
 
     constructor(
         IEAS _eas,
@@ -448,6 +449,8 @@ contract ERC721BarterUtils {
             escrowData.demand,
             (NativeTokenPaymentObligation.ObligationData)
         );
+
+        if (msg.value != demand.amount) revert MsgValueMismatch();
 
         bytes32 sellAttestation = nativePayment.doObligationFor{
             value: demand.amount

--- a/contracts/src/utils/barter/NativeTokenBarterUtils.sol
+++ b/contracts/src/utils/barter/NativeTokenBarterUtils.sol
@@ -85,6 +85,8 @@ contract NativeTokenBarterUtils {
         bytes32 buyAttestation,
         NativeTokenPaymentObligation.ObligationData memory demand
     ) internal returns (bytes32) {
+        if (msg.value != demand.amount) revert MsgValueMismatch();
+
         bytes32 sellAttestation = nativePayment.doObligationFor{
             value: demand.amount
         }(demand,
@@ -167,6 +169,8 @@ contract NativeTokenBarterUtils {
             (NativeTokenPaymentObligation.ObligationData)
         );
 
+        if (msg.value != demand.amount) revert MsgValueMismatch();
+
         bytes32 sellAttestation = nativePayment.doObligationFor{
             value: demand.amount
         }(demand,
@@ -223,6 +227,8 @@ contract NativeTokenBarterUtils {
             escrowData.demand,
             (NativeTokenPaymentObligation.ObligationData)
         );
+
+        if (msg.value != demand.amount) revert MsgValueMismatch();
 
         bytes32 sellAttestation = nativePayment.doObligationFor{
             value: demand.amount
@@ -283,6 +289,8 @@ contract NativeTokenBarterUtils {
             (NativeTokenPaymentObligation.ObligationData)
         );
 
+        if (msg.value != demand.amount) revert MsgValueMismatch();
+
         bytes32 sellAttestation = nativePayment.doObligationFor{
             value: demand.amount
         }(demand,
@@ -327,6 +335,8 @@ contract NativeTokenBarterUtils {
             escrowData.demand,
             (NativeTokenPaymentObligation.ObligationData)
         );
+
+        if (msg.value != demand.amount) revert MsgValueMismatch();
 
         bytes32 sellAttestation = nativePayment.doObligationFor{
             value: demand.amount

--- a/contracts/src/utils/barter/TokenBundleBarterUtils.sol
+++ b/contracts/src/utils/barter/TokenBundleBarterUtils.sol
@@ -18,6 +18,7 @@ contract TokenBundleBarterUtils is IERC1155Receiver {
 
     error CouldntCollectEscrow();
     error InvalidSignatureLength();
+    error MsgValueMismatch();
 
     struct ERC20PermitSignature {
         uint8 v;
@@ -41,6 +42,7 @@ contract TokenBundleBarterUtils is IERC1155Receiver {
         uint64 expiration,
         ERC20PermitSignature[] calldata permits
     ) external payable returns (bytes32) {
+        if (msg.value != data.nativeAmount) revert MsgValueMismatch();
         if (permits.length != data.erc20Tokens.length)
             revert InvalidSignatureLength();
 
@@ -76,6 +78,7 @@ contract TokenBundleBarterUtils is IERC1155Receiver {
         bytes32 refUID,
         ERC20PermitSignature[] calldata permits
     ) external payable returns (bytes32) {
+        if (msg.value != data.nativeAmount) revert MsgValueMismatch();
         if (permits.length != data.erc20Tokens.length)
             revert InvalidSignatureLength();
 
@@ -110,6 +113,8 @@ contract TokenBundleBarterUtils is IERC1155Receiver {
         TokenBundlePaymentObligation.ObligationData memory askBundle,
         uint64 expiration
     ) internal returns (bytes32) {
+        if (msg.value != bidBundle.nativeAmount) revert MsgValueMismatch();
+
         // Pull all tokens from user to BarterUtils
         _pullBundleTokens(bidBundle);
 
@@ -139,6 +144,8 @@ contract TokenBundleBarterUtils is IERC1155Receiver {
         bytes32 buyAttestation,
         TokenBundlePaymentObligation.ObligationData memory demand
     ) internal returns (bytes32) {
+        if (msg.value != demand.nativeAmount) revert MsgValueMismatch();
+
         // Pull all tokens from user to BarterUtils
         _pullPaymentBundleTokens(demand);
 
@@ -162,6 +169,7 @@ contract TokenBundleBarterUtils is IERC1155Receiver {
         uint64 expiration,
         ERC20PermitSignature[] calldata permits
     ) external payable returns (bytes32) {
+        if (msg.value != bidBundle.nativeAmount) revert MsgValueMismatch();
         if (permits.length != bidBundle.erc20Tokens.length)
             revert InvalidSignatureLength();
 
@@ -192,6 +200,8 @@ contract TokenBundleBarterUtils is IERC1155Receiver {
             escrowData.demand,
             (TokenBundlePaymentObligation.ObligationData)
         );
+
+        if (msg.value != demand.nativeAmount) revert MsgValueMismatch();
 
         if (permits.length != demand.erc20Tokens.length)
             revert InvalidSignatureLength();

--- a/contracts/src/utils/splitters/ERC1155Splitter.sol
+++ b/contracts/src/utils/splitters/ERC1155Splitter.sol
@@ -68,6 +68,9 @@ contract ERC1155Splitter is IArbiter, ReentrancyGuard, ERC1155Holder {
     error EmptySplits();
     error ZeroRecipient();
     error ExecuteFailed(address target, bytes data);
+    error EscrowCollectionFailed();
+    error InvalidEscrowContract(address expected, address provided);
+    error InvalidCollectionAmount(uint256 expected, uint256 received);
 
     IEAS public eas;
 
@@ -78,6 +81,8 @@ contract ERC1155Splitter is IArbiter, ReentrancyGuard, ERC1155Holder {
 
     /// @notice Transient storage for the current executor during execute/collectAndDistribute.
     address private _currentExecutor;
+    /// @notice Set only while collectAndDistribute is collecting escrow into this splitter.
+    bool private _collectingEscrow;
 
     constructor(IEAS _eas) {
         eas = _eas;
@@ -144,10 +149,14 @@ contract ERC1155Splitter is IArbiter, ReentrancyGuard, ERC1155Holder {
 
     /// @inheritdoc IArbiter
     function checkObligation(
-        Attestation memory,
+        Attestation memory obligation,
         bytes memory demand,
         bytes32 fulfilling
     ) public view override returns (bool) {
+        if (!_collectingEscrow || obligation.recipient != address(this)) {
+            return false;
+        }
+
         DemandData memory demandData = abi.decode(demand, (DemandData));
         bytes32 decisionKey = keccak256(
             abi.encodePacked(fulfilling, demand)
@@ -204,11 +213,34 @@ contract ERC1155Splitter is IArbiter, ReentrancyGuard, ERC1155Holder {
 
         Split[] memory splits = decisions[demandData.oracle][decisionKey];
 
+        if (escrowAttestation.attester != escrowContract) {
+            revert InvalidEscrowContract(
+                escrowAttestation.attester,
+                escrowContract
+            );
+        }
+
+        uint256 balanceBefore = IERC1155(escrowData.token).balanceOf(
+            address(this),
+            escrowData.tokenId
+        );
+
         // Collect escrow — tokens transfer to this contract
-        IERC1155EscrowObligation(escrowContract).collectEscrow(
+        _collectingEscrow = true;
+        bool collected = IERC1155EscrowObligation(escrowContract).collectEscrow(
             escrow,
             fulfillment
         );
+        _collectingEscrow = false;
+        if (!collected) revert EscrowCollectionFailed();
+
+        uint256 received = IERC1155(escrowData.token).balanceOf(
+            address(this),
+            escrowData.tokenId
+        ) - balanceBefore;
+        if (received != escrowData.amount) {
+            revert InvalidCollectionAmount(escrowData.amount, received);
+        }
 
         // Distribute tokens according to splits
         for (uint256 i; i < splits.length; ++i) {

--- a/contracts/src/utils/splitters/ERC20Splitter.sol
+++ b/contracts/src/utils/splitters/ERC20Splitter.sol
@@ -67,6 +67,9 @@ contract ERC20Splitter is IArbiter, ReentrancyGuard {
     error EmptySplits();
     error ZeroRecipient();
     error ExecuteFailed(address target, bytes data);
+    error EscrowCollectionFailed();
+    error InvalidEscrowContract(address expected, address provided);
+    error InvalidCollectionAmount(uint256 expected, uint256 received);
 
     IEAS public eas;
 
@@ -77,6 +80,8 @@ contract ERC20Splitter is IArbiter, ReentrancyGuard {
 
     /// @notice Transient storage for the current executor during execute/collectAndDistribute.
     address private _currentExecutor;
+    /// @notice Set only while collectAndDistribute is collecting escrow into this splitter.
+    bool private _collectingEscrow;
 
     constructor(IEAS _eas) {
         eas = _eas;
@@ -144,10 +149,14 @@ contract ERC20Splitter is IArbiter, ReentrancyGuard {
 
     /// @inheritdoc IArbiter
     function checkObligation(
-        Attestation memory,
+        Attestation memory obligation,
         bytes memory demand,
         bytes32 fulfilling
     ) public view override returns (bool) {
+        if (!_collectingEscrow || obligation.recipient != address(this)) {
+            return false;
+        }
+
         DemandData memory demandData = abi.decode(demand, (DemandData));
         bytes32 decisionKey = keccak256(
             abi.encodePacked(fulfilling, demand)
@@ -205,11 +214,31 @@ contract ERC20Splitter is IArbiter, ReentrancyGuard {
 
         Split[] memory splits = decisions[demandData.oracle][decisionKey];
 
+        if (escrowAttestation.attester != escrowContract) {
+            revert InvalidEscrowContract(
+                escrowAttestation.attester,
+                escrowContract
+            );
+        }
+
+        uint256 balanceBefore = IERC20(escrowData.token).balanceOf(
+            address(this)
+        );
+
         // Collect escrow — tokens transfer to this contract
-        IERC20EscrowObligation(escrowContract).collectEscrow(
+        _collectingEscrow = true;
+        bool collected = IERC20EscrowObligation(escrowContract).collectEscrow(
             escrow,
             fulfillment
         );
+        _collectingEscrow = false;
+        if (!collected) revert EscrowCollectionFailed();
+
+        uint256 received = IERC20(escrowData.token).balanceOf(address(this)) -
+            balanceBefore;
+        if (received != escrowData.amount) {
+            revert InvalidCollectionAmount(escrowData.amount, received);
+        }
 
         // Distribute tokens according to splits
         for (uint256 i; i < splits.length; ++i) {

--- a/contracts/src/utils/splitters/NativeTokenSplitter.sol
+++ b/contracts/src/utils/splitters/NativeTokenSplitter.sol
@@ -63,6 +63,9 @@ contract NativeTokenSplitter is IArbiter, ReentrancyGuard {
     error ZeroRecipient();
     error ExecuteFailed(address target, bytes data);
     error NativeTokenTransferFailed(address to, uint256 amount);
+    error EscrowCollectionFailed();
+    error InvalidEscrowContract(address expected, address provided);
+    error InvalidCollectionAmount(uint256 expected, uint256 received);
 
     IEAS public eas;
 
@@ -73,6 +76,8 @@ contract NativeTokenSplitter is IArbiter, ReentrancyGuard {
 
     /// @notice Transient storage for the current executor during execute/collectAndDistribute.
     address private _currentExecutor;
+    /// @notice Set only while collectAndDistribute is collecting escrow into this splitter.
+    bool private _collectingEscrow;
 
     constructor(IEAS _eas) {
         eas = _eas;
@@ -139,10 +144,14 @@ contract NativeTokenSplitter is IArbiter, ReentrancyGuard {
 
     /// @inheritdoc IArbiter
     function checkObligation(
-        Attestation memory,
+        Attestation memory obligation,
         bytes memory demand,
         bytes32 fulfilling
     ) public view override returns (bool) {
+        if (!_collectingEscrow || obligation.recipient != address(this)) {
+            return false;
+        }
+
         DemandData memory demandData = abi.decode(demand, (DemandData));
         bytes32 decisionKey = keccak256(
             abi.encodePacked(fulfilling, demand)
@@ -202,11 +211,28 @@ contract NativeTokenSplitter is IArbiter, ReentrancyGuard {
 
         Split[] memory splits = decisions[demandData.oracle][decisionKey];
 
+        if (escrowAttestation.attester != escrowContract) {
+            revert InvalidEscrowContract(
+                escrowAttestation.attester,
+                escrowContract
+            );
+        }
+
+        uint256 balanceBefore = address(this).balance;
+
         // Collect escrow — ETH transfers to this contract
-        INativeTokenEscrowObligation(escrowContract).collectEscrow(
+        _collectingEscrow = true;
+        bool collected = INativeTokenEscrowObligation(escrowContract).collectEscrow(
             escrow,
             fulfillment
         );
+        _collectingEscrow = false;
+        if (!collected) revert EscrowCollectionFailed();
+
+        uint256 received = address(this).balance - balanceBefore;
+        if (received != escrowData.amount) {
+            revert InvalidCollectionAmount(escrowData.amount, received);
+        }
 
         // Distribute ETH according to splits
         for (uint256 i; i < splits.length; ++i) {

--- a/contracts/src/utils/splitters/TokenBundleSplitterBase.sol
+++ b/contracts/src/utils/splitters/TokenBundleSplitterBase.sol
@@ -80,6 +80,23 @@ abstract contract TokenBundleSplitterBase is IArbiter, ReentrancyGuard, ERC1155H
     error ZeroRecipient();
     error ExecuteFailed(address target, bytes data);
     error NativeTokenTransferFailed(address to, uint256 amount);
+    error EscrowCollectionFailed();
+    error InvalidEscrowContract(address expected, address provided);
+    error InvalidNativeCollectionAmount(uint256 expected, uint256 received);
+    error InvalidERC20CollectionAmount(
+        uint256 tokenIndex,
+        address token,
+        uint256 expected,
+        uint256 received
+    );
+    error InvalidERC721Collection(address token, uint256 tokenId);
+    error InvalidERC1155CollectionAmount(
+        uint256 tokenIndex,
+        address token,
+        uint256 tokenId,
+        uint256 expected,
+        uint256 received
+    );
 
     IEAS public eas;
 
@@ -90,6 +107,8 @@ abstract contract TokenBundleSplitterBase is IArbiter, ReentrancyGuard, ERC1155H
 
     /// @notice Transient storage for the current executor during execute/collectAndDistribute.
     address private _currentExecutor;
+    /// @notice Set only while collectAndDistribute is collecting escrow into this splitter.
+    bool private _collectingEscrow;
 
     constructor(IEAS _eas) {
         eas = _eas;
@@ -157,10 +176,14 @@ abstract contract TokenBundleSplitterBase is IArbiter, ReentrancyGuard, ERC1155H
 
     /// @inheritdoc IArbiter
     function checkObligation(
-        Attestation memory,
+        Attestation memory obligation,
         bytes memory demand,
         bytes32 fulfilling
     ) public view override returns (bool) {
+        if (!_collectingEscrow || obligation.recipient != address(this)) {
+            return false;
+        }
+
         DemandData memory demandData = abi.decode(demand, (DemandData));
         bytes32 decisionKey = keccak256(
             abi.encodePacked(fulfilling, demand)
@@ -215,10 +238,33 @@ abstract contract TokenBundleSplitterBase is IArbiter, ReentrancyGuard, ERC1155H
 
         BundleSplit[] memory splits = decisions[demandData.oracle][decisionKey];
 
+        if (escrowAttestation.attester != escrowContract) {
+            revert InvalidEscrowContract(
+                escrowAttestation.attester,
+                escrowContract
+            );
+        }
+
+        uint256 nativeBalanceBefore = address(this).balance;
+        uint256[] memory erc20BalancesBefore = _erc20Balances(escrowData);
+        bool[] memory erc721HeldBefore = _erc721HeldBySplitter(escrowData);
+        uint256[] memory erc1155BalancesBefore = _erc1155Balances(escrowData);
+
         // Collect escrow — all assets transfer to this contract
-        ITokenBundleEscrowObligation(escrowContract).collectEscrow(
+        _collectingEscrow = true;
+        bool collected = ITokenBundleEscrowObligation(escrowContract).collectEscrow(
             escrow,
             fulfillment
+        );
+        _collectingEscrow = false;
+        if (!collected) revert EscrowCollectionFailed();
+
+        _validateCollectedBundle(
+            escrowData,
+            nativeBalanceBefore,
+            erc20BalancesBefore,
+            erc721HeldBefore,
+            erc1155BalancesBefore
         );
 
         // Distribute according to splits
@@ -302,6 +348,186 @@ abstract contract TokenBundleSplitterBase is IArbiter, ReentrancyGuard, ERC1155H
         bytes calldata data
     ) external pure returns (DemandData memory) {
         return abi.decode(data, (DemandData));
+    }
+
+    function _erc20Balances(
+        EscrowObligationData memory escrowData
+    ) internal view returns (uint256[] memory balances) {
+        balances = new uint256[](escrowData.erc20Tokens.length);
+        for (uint256 i; i < escrowData.erc20Tokens.length; ++i) {
+            balances[i] = IERC20(escrowData.erc20Tokens[i]).balanceOf(
+                address(this)
+            );
+        }
+    }
+
+    function _erc721HeldBySplitter(
+        EscrowObligationData memory escrowData
+    ) internal view returns (bool[] memory held) {
+        held = new bool[](escrowData.erc721Tokens.length);
+        for (uint256 i; i < escrowData.erc721Tokens.length; ++i) {
+            held[i] =
+                IERC721(escrowData.erc721Tokens[i]).ownerOf(
+                    escrowData.erc721TokenIds[i]
+                ) ==
+                address(this);
+        }
+    }
+
+    function _erc1155Balances(
+        EscrowObligationData memory escrowData
+    ) internal view returns (uint256[] memory balances) {
+        balances = new uint256[](escrowData.erc1155Tokens.length);
+        for (uint256 i; i < escrowData.erc1155Tokens.length; ++i) {
+            balances[i] = IERC1155(escrowData.erc1155Tokens[i]).balanceOf(
+                address(this),
+                escrowData.erc1155TokenIds[i]
+            );
+        }
+    }
+
+    function _validateCollectedBundle(
+        EscrowObligationData memory escrowData,
+        uint256 nativeBalanceBefore,
+        uint256[] memory erc20BalancesBefore,
+        bool[] memory erc721HeldBefore,
+        uint256[] memory erc1155BalancesBefore
+    ) internal view {
+        uint256 nativeReceived = address(this).balance - nativeBalanceBefore;
+        if (nativeReceived != escrowData.nativeAmount) {
+            revert InvalidNativeCollectionAmount(
+                escrowData.nativeAmount,
+                nativeReceived
+            );
+        }
+
+        _validateERC20Collection(escrowData, erc20BalancesBefore);
+        _validateERC721Collection(escrowData, erc721HeldBefore);
+        _validateERC1155Collection(escrowData, erc1155BalancesBefore);
+    }
+
+    function _validateERC20Collection(
+        EscrowObligationData memory escrowData,
+        uint256[] memory balancesBefore
+    ) internal view {
+        for (uint256 i; i < escrowData.erc20Tokens.length; ++i) {
+            if (!_isFirstERC20Token(escrowData, i)) continue;
+
+            uint256 expected = _expectedERC20Amount(escrowData, i);
+            uint256 received = IERC20(escrowData.erc20Tokens[i]).balanceOf(
+                address(this)
+            ) - balancesBefore[i];
+
+            if (received != expected) {
+                revert InvalidERC20CollectionAmount(
+                    i,
+                    escrowData.erc20Tokens[i],
+                    expected,
+                    received
+                );
+            }
+        }
+    }
+
+    function _validateERC721Collection(
+        EscrowObligationData memory escrowData,
+        bool[] memory heldBefore
+    ) internal view {
+        for (uint256 i; i < escrowData.erc721Tokens.length; ++i) {
+            if (
+                heldBefore[i] ||
+                IERC721(escrowData.erc721Tokens[i]).ownerOf(
+                    escrowData.erc721TokenIds[i]
+                ) !=
+                address(this)
+            ) {
+                revert InvalidERC721Collection(
+                    escrowData.erc721Tokens[i],
+                    escrowData.erc721TokenIds[i]
+                );
+            }
+        }
+    }
+
+    function _validateERC1155Collection(
+        EscrowObligationData memory escrowData,
+        uint256[] memory balancesBefore
+    ) internal view {
+        for (uint256 i; i < escrowData.erc1155Tokens.length; ++i) {
+            if (!_isFirstERC1155Token(escrowData, i)) continue;
+
+            uint256 expected = _expectedERC1155Amount(escrowData, i);
+            uint256 received = IERC1155(escrowData.erc1155Tokens[i]).balanceOf(
+                address(this),
+                escrowData.erc1155TokenIds[i]
+            ) - balancesBefore[i];
+
+            if (received != expected) {
+                revert InvalidERC1155CollectionAmount(
+                    i,
+                    escrowData.erc1155Tokens[i],
+                    escrowData.erc1155TokenIds[i],
+                    expected,
+                    received
+                );
+            }
+        }
+    }
+
+    function _isFirstERC20Token(
+        EscrowObligationData memory escrowData,
+        uint256 index
+    ) internal pure returns (bool) {
+        for (uint256 i; i < index; ++i) {
+            if (escrowData.erc20Tokens[i] == escrowData.erc20Tokens[index]) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    function _expectedERC20Amount(
+        EscrowObligationData memory escrowData,
+        uint256 index
+    ) internal pure returns (uint256 total) {
+        for (uint256 i; i < escrowData.erc20Tokens.length; ++i) {
+            if (escrowData.erc20Tokens[i] == escrowData.erc20Tokens[index]) {
+                total += escrowData.erc20Amounts[i];
+            }
+        }
+    }
+
+    function _isFirstERC1155Token(
+        EscrowObligationData memory escrowData,
+        uint256 index
+    ) internal pure returns (bool) {
+        for (uint256 i; i < index; ++i) {
+            if (
+                escrowData.erc1155Tokens[i] ==
+                escrowData.erc1155Tokens[index] &&
+                escrowData.erc1155TokenIds[i] ==
+                escrowData.erc1155TokenIds[index]
+            ) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    function _expectedERC1155Amount(
+        EscrowObligationData memory escrowData,
+        uint256 index
+    ) internal pure returns (uint256 total) {
+        for (uint256 i; i < escrowData.erc1155Tokens.length; ++i) {
+            if (
+                escrowData.erc1155Tokens[i] ==
+                escrowData.erc1155Tokens[index] &&
+                escrowData.erc1155TokenIds[i] ==
+                escrowData.erc1155TokenIds[index]
+            ) {
+                total += escrowData.erc1155Amounts[i];
+            }
+        }
     }
 
     /// @notice Allow contract to receive ETH from escrow collection.

--- a/contracts/test/unit/obligations/CommitRevealObligation.t.sol
+++ b/contracts/test/unit/obligations/CommitRevealObligation.t.sol
@@ -89,6 +89,55 @@ contract CommitRevealObligationTest is Test {
         obligation.reclaimBond(fulfillmentUid);
     }
 
+    function testReclaimUsesCommittedBondAmountAfterBondAmountChange() public {
+        bytes32 escrowUid = _makeEscrow();
+        CommitRevealObligation.ObligationData memory data = _obligationData();
+        bytes32 commitment = obligation.computeCommitment(escrowUid, claimer, data);
+
+        vm.deal(claimer, BOND);
+        vm.prank(claimer);
+        obligation.commit{value: BOND}(commitment);
+
+        uint256 updatedBond = 1 ether;
+        vm.deal(address(obligation), updatedBond);
+        obligation.setBondAmount(updatedBond);
+
+        vm.roll(block.number + 1);
+
+        vm.prank(claimer);
+        bytes32 fulfillmentUid = obligation.doObligation(data, escrowUid);
+
+        uint256 claimerBalanceBefore = claimer.balance;
+        uint256 returned = obligation.reclaimBond(fulfillmentUid);
+
+        assertEq(returned, BOND, "returns original committed bond");
+        assertEq(claimer.balance, claimerBalanceBefore + BOND, "claimer received original bond");
+    }
+
+    function testSlashUsesCommittedDeadlineAndRecipientAfterTermChanges() public {
+        bytes32 escrowUid = _makeEscrow();
+        CommitRevealObligation.ObligationData memory data = _obligationData();
+        bytes32 commitment = obligation.computeCommitment(escrowUid, claimer, data);
+
+        vm.deal(claimer, BOND);
+        vm.prank(claimer);
+        obligation.commit{value: BOND}(commitment);
+
+        address newTreasury = makeAddr("newTreasury");
+        obligation.setCommitDeadline(COMMIT_DEADLINE * 10);
+        obligation.setSlashedBondRecipient(newTreasury);
+
+        vm.warp(block.timestamp + COMMIT_DEADLINE + 1);
+
+        uint256 treasuryBefore = treasury.balance;
+        uint256 newTreasuryBefore = newTreasury.balance;
+        uint256 slashed = obligation.slashBond(commitment);
+
+        assertEq(slashed, BOND, "slashes original committed bond");
+        assertEq(treasury.balance, treasuryBefore + BOND, "uses original slash recipient");
+        assertEq(newTreasury.balance, newTreasuryBefore, "does not use updated recipient");
+    }
+
     function testCheckObligationRevertsWithoutCommit() public {
         bytes32 escrowUid = _makeEscrow();
         CommitRevealObligation.ObligationData memory data = _obligationData();

--- a/contracts/test/unit/utils/barter/NativeTokenBarterUtils.t.sol
+++ b/contracts/test/unit/utils/barter/NativeTokenBarterUtils.t.sol
@@ -239,6 +239,38 @@ contract NativeTokenBarterUtilsTest is Test {
         );
     }
 
+    function testRevert_PayEthForErc20RequiresCallerValue() public {
+        vm.startPrank(bob);
+        testERC20.approve(address(erc20Escrow), 100 * 10 ** 18);
+        bytes32 buyAttestation = erc20Escrow.doObligationFor(
+            ERC20EscrowObligation.ObligationData({
+                token: address(testERC20),
+                amount: 100 * 10 ** 18,
+                arbiter: address(nativePayment),
+                demand: abi.encode(
+                    NativeTokenPaymentObligation.ObligationData({
+                        amount: BID_AMOUNT,
+                        payee: bob
+                    })
+                )
+            }),
+            EXPIRATION,
+            bob
+        );
+        vm.stopPrank();
+
+        vm.deal(address(barterUtils), BID_AMOUNT);
+        uint256 helperBalanceBefore = address(barterUtils).balance;
+        uint256 bobBalanceBefore = bob.balance;
+
+        vm.prank(alice);
+        vm.expectRevert(NativeTokenBarterUtils.MsgValueMismatch.selector);
+        barterUtils.payEthForErc20(buyAttestation);
+
+        assertEq(address(barterUtils).balance, helperBalanceBefore);
+        assertEq(bob.balance, bobBalanceBefore);
+    }
+
     // ============ Native Token to ERC721 Tests ============
 
     function testBuyErc721WithEth() public {

--- a/contracts/test/unit/utils/barter/TokenBundleBarterUtils.t.sol
+++ b/contracts/test/unit/utils/barter/TokenBundleBarterUtils.t.sol
@@ -409,6 +409,29 @@ contract TokenBundleBarterUtilsUnitTest is Test {
         );
     }
 
+    function testRevert_BuyBundleForBundleRequiresCallerNativeValue() public {
+        uint64 expiration = uint64(block.timestamp + 1 days);
+
+        TokenBundleEscrowObligation.ObligationData memory aliceBundle = createAliceBundle();
+        TokenBundlePaymentObligation.ObligationData memory bobBundle = createBobBundle();
+        aliceBundle.nativeAmount = 1 ether;
+
+        vm.deal(address(barterUtils), 1 ether);
+        uint256 helperBalanceBefore = address(barterUtils).balance;
+
+        vm.prank(alice);
+        vm.expectRevert(TokenBundleBarterUtils.MsgValueMismatch.selector);
+        barterUtils.buyBundleForBundle(aliceBundle, bobBundle, expiration);
+
+        assertEq(address(barterUtils).balance, helperBalanceBefore);
+        assertEq(erc20TokenA.balanceOf(alice), erc20AmountA);
+        assertEq(erc721TokenA.ownerOf(aliceErc721Id), alice);
+        assertEq(
+            erc1155TokenA.balanceOf(alice, erc1155TokenIdA),
+            erc1155TokenAmountA
+        );
+    }
+
     function testPermitAndEscrowBundle() public {
         uint64 expiration = uint64(block.timestamp + 1 days);
         uint256 deadline = block.timestamp + 1 days;

--- a/contracts/test/unit/utils/splitters/ERC1155Splitter.t.sol
+++ b/contracts/test/unit/utils/splitters/ERC1155Splitter.t.sol
@@ -267,7 +267,7 @@ contract ERC1155SplitterTest is Test {
     // checkObligation
     // -----------------------------------------------------------------
 
-    function testCheckObligationReturnsTrueWhenDecisionExists() public {
+    function testCheckObligationReturnsFalseOutsideCollectionWhenDecisionExists() public {
         bytes32 escrowUid = _createEscrow(
             buyer,
             TOKEN_ID,
@@ -290,7 +290,7 @@ contract ERC1155SplitterTest is Test {
         );
 
         Attestation memory dummyAttestation;
-        assertTrue(
+        assertFalse(
             splitter.checkObligation(dummyAttestation, demand, escrowUid)
         );
     }

--- a/contracts/test/unit/utils/splitters/ERC20Splitter.t.sol
+++ b/contracts/test/unit/utils/splitters/ERC20Splitter.t.sol
@@ -238,7 +238,7 @@ contract ERC20SplitterTest is Test {
     // checkObligation
     // -----------------------------------------------------------------
 
-    function testCheckObligationReturnsTrueWhenDecisionExists() public {
+    function testCheckObligationReturnsFalseOutsideCollectionWhenDecisionExists() public {
         bytes32 escrowUid = _createEscrow(
             buyer,
             AMOUNT,
@@ -257,7 +257,7 @@ contract ERC20SplitterTest is Test {
         );
 
         Attestation memory dummyAttestation;
-        assertTrue(
+        assertFalse(
             splitter.checkObligation(dummyAttestation, demand, escrowUid)
         );
     }

--- a/contracts/test/unit/utils/splitters/NativeTokenSplitter.t.sol
+++ b/contracts/test/unit/utils/splitters/NativeTokenSplitter.t.sol
@@ -11,6 +11,12 @@ import {ISchemaRegistry} from "@eas/ISchemaRegistry.sol";
 
 import {EASDeployer} from "@test/utils/EASDeployer.sol";
 
+contract FakeNativeTokenEscrow {
+    function collectEscrow(bytes32, bytes32) external pure returns (bool) {
+        return true;
+    }
+}
+
 contract NativeTokenSplitterTest is Test {
     NativeTokenSplitter public splitter;
     NativeTokenEscrowObligation public escrowObligation;
@@ -257,7 +263,7 @@ contract NativeTokenSplitterTest is Test {
     // checkObligation
     // -----------------------------------------------------------------
 
-    function testCheckObligationReturnsTrueWhenDecisionExists() public {
+    function testCheckObligationReturnsFalseOutsideCollectionWhenDecisionExists() public {
         bytes32 escrowUid = _createEscrow(
             buyer,
             AMOUNT,
@@ -279,7 +285,7 @@ contract NativeTokenSplitterTest is Test {
         );
 
         Attestation memory dummyAttestation;
-        assertTrue(
+        assertFalse(
             splitter.checkObligation(dummyAttestation, demand, escrowUid)
         );
     }
@@ -424,6 +430,80 @@ contract NativeTokenSplitterTest is Test {
             0,
             "Escrow should have no remaining ETH"
         );
+    }
+
+    function testRevert_DirectEscrowCollectionCannotBypassSplitterDistribution() public {
+        bytes32 escrowUid = _createEscrow(
+            buyer,
+            AMOUNT,
+            uint64(block.timestamp + EXPIRATION)
+        );
+
+        bytes32 fulfillmentUid = _createFulfillmentViaSplitter(
+            executor,
+            escrowUid
+        );
+
+        NativeTokenSplitter.Split[]
+            memory splits = new NativeTokenSplitter.Split[](1);
+        splits[0] = NativeTokenSplitter.Split({
+            recipient: alice,
+            amount: AMOUNT
+        });
+
+        vm.prank(oracle);
+        splitter.arbitrate(escrowUid, splits);
+
+        vm.prank(executor);
+        vm.expectRevert(BaseEscrowObligation.InvalidFulfillment.selector);
+        escrowObligation.collectEscrow(escrowUid, fulfillmentUid);
+
+        assertEq(address(escrowObligation).balance, AMOUNT);
+        assertEq(address(splitter).balance, 0);
+        assertEq(alice.balance, 0);
+    }
+
+    function testRevert_CollectAndDistributeRejectsNonAttesterEscrowContract() public {
+        bytes32 escrowUid = _createEscrow(
+            buyer,
+            AMOUNT,
+            uint64(block.timestamp + EXPIRATION)
+        );
+
+        bytes32 fulfillmentUid = _createFulfillmentViaSplitter(
+            executor,
+            escrowUid
+        );
+
+        NativeTokenSplitter.Split[]
+            memory splits = new NativeTokenSplitter.Split[](1);
+        splits[0] = NativeTokenSplitter.Split({
+            recipient: alice,
+            amount: AMOUNT
+        });
+
+        vm.prank(oracle);
+        splitter.arbitrate(escrowUid, splits);
+
+        FakeNativeTokenEscrow fakeEscrow = new FakeNativeTokenEscrow();
+
+        vm.prank(executor);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                NativeTokenSplitter.InvalidEscrowContract.selector,
+                address(escrowObligation),
+                address(fakeEscrow)
+            )
+        );
+        splitter.collectAndDistribute(
+            address(fakeEscrow),
+            escrowUid,
+            fulfillmentUid
+        );
+
+        assertEq(address(escrowObligation).balance, AMOUNT);
+        assertEq(address(splitter).balance, 0);
+        assertEq(alice.balance, 0);
     }
 
     function testCollectAndDistributeWithSentinel() public {

--- a/contracts/test/unit/utils/splitters/TokenBundleSplitter.t.sol
+++ b/contracts/test/unit/utils/splitters/TokenBundleSplitter.t.sol
@@ -490,7 +490,7 @@ contract TokenBundleSplitterTest is Test {
     // checkObligation
     // -----------------------------------------------------------------
 
-    function testCheckObligationReturnsTrueWhenDecisionExists() public {
+    function testCheckObligationReturnsFalseOutsideCollectionWhenDecisionExists() public {
         bytes32 escrowUid = _createEscrow();
 
         vm.prank(oracle);
@@ -504,7 +504,7 @@ contract TokenBundleSplitterTest is Test {
         );
 
         Attestation memory dummyAttestation;
-        assertTrue(
+        assertFalse(
             splitter.checkObligation(dummyAttestation, demand, escrowUid)
         );
     }

--- a/contracts/test/unit/utils/splitters/TokenBundleSplitterUnvalidated.t.sol
+++ b/contracts/test/unit/utils/splitters/TokenBundleSplitterUnvalidated.t.sol
@@ -340,7 +340,7 @@ contract TokenBundleSplitterUnvalidatedTest is Test {
     // checkObligation
     // -----------------------------------------------------------------
 
-    function testCheckObligationReturnsTrueWhenDecisionExists() public {
+    function testCheckObligationReturnsFalseOutsideCollectionWhenDecisionExists() public {
         bytes32 escrowUid = _createEscrow();
 
         vm.prank(oracle);
@@ -354,7 +354,7 @@ contract TokenBundleSplitterUnvalidatedTest is Test {
         );
 
         Attestation memory dummyAttestation;
-        assertTrue(
+        assertFalse(
             splitter.checkObligation(dummyAttestation, demand, escrowUid)
         );
     }


### PR DESCRIPTION
## Summary

  This PR strengthens several protocol flows where mutable parameters, caller-supplied ETH values, or indirect escrow
  collection paths could produce unintended asset movement.

  The changes are grouped into three areas:

  1. Snapshot commit-reveal economic terms at commit time
  2. Require exact native token value in barter helper flows
  3. Constrain splitter escrow collection and validate received assets before distribution

  ## Motivation

  The affected flows relied on assumptions that were not fully enforced at the contract boundary:

  - Commit-reveal commitments used the current global bond/slashing settings during reclaim/slash, even for
  commitments created under earlier terms.
  - Barter helper flows accepted calls where `msg.value` did not exactly match the demanded native amount.
  - Splitter arbiters could approve an escrow collection outside the intended splitter collection path, and splitter
  distribution assumed that the escrow collection call actually delivered the expected assets.

  These changes make those assumptions explicit and enforce them in the contracts.

  ## Changes

  ### Commit-reveal term snapshotting

  `CommitRevealObligation` now stores the active economic terms inside each `CommitInfo` when a commitment is created:

  - `bondAmount`
  - `commitDeadline`
  - `slashedBondRecipient`

  `reclaimBond` and `slashBond` now use the commitment’s stored terms instead of the current global configuration.

  This prevents later owner parameter updates from retroactively changing the economics of already-open commitments.

  ### Exact native value checks in barter helpers

  Barter helper functions that require ETH payment now enforce that `msg.value` exactly equals the demanded native
  amount.

  This avoids underpayment, accidental overpayment, and mismatches between the encoded demand and the actual ETH
  supplied by the caller.

  ### Splitter collection constraints

  Splitter arbiters now only approve obligations during their own `collectAndDistribute` flow and only when the
  fulfillment recipient is the splitter contract itself.

  The splitter collection path also now validates:

  - the escrow attestation was created by the escrow contract being called
  - the expected assets were actually received by the splitter
  - received asset deltas match the escrowed amount before distribution

  This prevents direct escrow collection from bypassing configured split recipients and prevents distribution using
  pre-existing splitter balances.

  ## Tests

  Added and updated unit coverage for:

  - commit-reveal reclaim/slash behavior after parameter changes
  - native value mismatch rejection in barter helpers
  - splitter direct-collection bypass prevention
  - splitter rejection of non-attester escrow contracts
  - splitter `checkObligation` behavior outside the intended collection path

  Targeted test suites run:

  ```bash
  forge test --match-path test/unit/utils/barter/TokenBundleBarterUtils.t.sol -vv
  forge test --match-path test/unit/utils/barter/ERC721BarterUtils.t.sol -vv
  forge test --match-path test/unit/utils/barter/ERC1155BarterUtils.t.sol -vv
  forge test --match-path test/unit/utils/splitters/NativeTokenSplitter.t.sol -vv
  forge test --match-path test/unit/utils/splitters/ERC20Splitter.t.sol -vv
  forge test --match-path test/unit/utils/splitters/ERC1155Splitter.t.sol -vv
  forge test --match-path test/unit/utils/splitters/TokenBundleSplitter.t.sol -vv
  forge test --match-path test/unit/utils/splitters/TokenBundleSplitterUnvalidated.t.sol -vv